### PR TITLE
IR-68: Improve integration tests

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -10,6 +10,7 @@ TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 NOMIS_USER_ROLES_API_URL=http://localhost:9091/nomisUserRolesApi
 HMPPS_PRISON_API_URL=http://localhost:9091/prisonApi
 OFFENDER_SEARCH_API_URL=http://localhost:9091/offenderSearchApi
+COMPONENT_API_URL=http://localhost:9091/frontendComponents
 
 DPS_URL=http://localhost:3000
 

--- a/integration_tests/e2e/signIn.cy.ts
+++ b/integration_tests/e2e/signIn.cy.ts
@@ -7,8 +7,8 @@ context('Sign In', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
+    cy.task('stubFallbackHeaderAndFooter')
     cy.task('stubManageUser')
-    cy.task('stubFrontendComponentsFail')
   })
 
   it('Unauthenticated user directed to auth', () => {
@@ -21,13 +21,13 @@ context('Sign In', () => {
     Page.verifyOnPage(AuthSignInPage)
   })
 
-  it('User name visible in header', () => {
+  it('User name visible in fallback header', () => {
     cy.signIn()
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.headerUserName.should('contain.text', 'J. Smith')
   })
 
-  it('Environment tag visible in header', () => {
+  it('Environment tag visible in fallback header', () => {
     cy.signIn()
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.headerEnvironmentTag.should('contain.text', 'Local')
@@ -48,6 +48,23 @@ context('Sign In', () => {
     indexPage.manageDetails.get('a').invoke('removeAttr', 'target')
     indexPage.manageDetails.click()
     Page.verifyOnPage(AuthManageDetailsPage)
+  })
+
+  it('Official sensitive shows in fallback footer', () => {
+    cy.signIn()
+    const indexPage = Page.verifyOnPage(IndexPage)
+    indexPage.footer.should('include.text', 'Official sensitive')
+  })
+
+  it('Frontend components load', () => {
+    cy.signIn()
+    cy.task('stubFrontendComponentsHeaderAndFooter')
+    cy.visit('/')
+    Page.verifyOnPage(IndexPage)
+    cy.get('header').should('have.css', 'background-color', 'rgb(255, 0, 0)')
+    cy.get('footer').should('have.css', 'background-color', 'rgb(255, 255, 0)')
+    cy.window().its('FrontendComponentsHeaderDidLoad').should('be.true')
+    cy.window().its('FrontendComponentsFooterDidLoad').should('be.true')
   })
 
   it('Token verification failure takes user to sign in page', () => {

--- a/integration_tests/mockApis/frontendComponents.ts
+++ b/integration_tests/mockApis/frontendComponents.ts
@@ -1,35 +1,76 @@
 import type { Response } from 'superagent'
 
 import { stubFor } from './wiremock'
+import type { Component, AvailableComponent } from '../../server/data/frontendComponentsClient'
 
-const stubHeaderFail = () =>
+const stubComponent = (name: AvailableComponent, component: Component): Promise<Response> =>
   stubFor({
     request: {
       method: 'GET',
-      urlPath: '/components/header',
+      urlPath: `/frontendComponents/${name}`,
     },
     response: {
-      status: 500,
-      headers: {
-        'Content-Type': 'text/html;charset=UTF-8',
-      },
+      headers: { 'Content-Type': 'application/json' },
+      jsonBody: component,
     },
   })
 
-const stubFooterFail = () =>
+const stubCSS = (name: AvailableComponent, css: string): Promise<Response> =>
   stubFor({
     request: {
       method: 'GET',
-      urlPath: '/components/footer',
+      urlPath: `/frontendComponents/${name}.css`,
     },
     response: {
-      status: 500,
       headers: {
-        'Content-Type': 'text/html;charset=UTF-8',
+        'Content-Type': 'text/css',
+        'Cross-Origin-Resource-Policy': 'cross-origin',
       },
+      body: css,
+    },
+  })
+
+const stubJavascript = (name: AvailableComponent, js: string): Promise<Response> =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPath: `/frontendComponents/${name}.js`,
+    },
+    response: {
+      headers: {
+        'Content-Type': 'text/javascript',
+        'Access-Control-Allow-Origin': '*',
+        'Cross-Origin-Resource-Policy': 'cross-origin',
+      },
+      body: js,
     },
   })
 
 export default {
-  stubFrontendComponentsFail: (): Promise<[Response, Response]> => Promise.all([stubHeaderFail(), stubFooterFail()]),
+  stubFallbackHeaderAndFooter(): Promise<Response[]> {
+    const empty: Component = {
+      html: '',
+      css: [],
+      javascript: [],
+    }
+    return Promise.all([stubComponent('header', empty), stubComponent('footer', empty)])
+  },
+  stubFrontendComponentsHeaderAndFooter(): Promise<Response[]> {
+    return Promise.all([
+      stubCSS('header', 'header { background: red }'),
+      stubCSS('footer', 'footer { background: yellow }'),
+      stubJavascript('header', 'window.FrontendComponentsHeaderDidLoad = true;'),
+      stubJavascript('footer', 'window.FrontendComponentsFooterDidLoad = true;'),
+      stubComponent('header', {
+        html: '<header>HEADER</header>',
+        css: ['http://localhost:9091/frontendComponents/header.css'],
+        javascript: ['http://localhost:9091/frontendComponents/header.js'],
+      }),
+      stubComponent('footer', {
+        html: '<footer>FOOTER</footer>',
+        css: ['http://localhost:9091/frontendComponents/footer.css'],
+        javascript: ['http://localhost:9091/frontendComponents/footer.js'],
+      }),
+    ])
+  },
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -24,4 +24,8 @@ export default abstract class Page {
   get manageDetails(): PageElement<HTMLAnchorElement> {
     return cy.get('[data-qa=manageDetails]')
   }
+
+  get footer(): PageElement {
+    return cy.get('.govuk-footer')
+  }
 }

--- a/server/data/frontendComponentsClient.ts
+++ b/server/data/frontendComponentsClient.ts
@@ -17,9 +17,9 @@ export default class FrontendComponentsClient {
 
   getComponent(component: AvailableComponent, userToken: string): Promise<Component> {
     logger.info(`Getting frontend component ${component}`)
-    return FrontendComponentsClient.restClient(userToken).get({
+    return FrontendComponentsClient.restClient(userToken).get<Component>({
       path: `/${component}`,
       headers: { 'x-user-token': userToken },
-    }) as Promise<Component>
+    })
   }
 }

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -10,12 +10,13 @@ const applicationInfo = applicationInfoSupplier()
 initialiseAppInsights()
 buildAppInsightsClient(applicationInfo)
 
-import HmppsAuthClient from './hmppsAuthClient'
-import ManageUsersApiClient from './manageUsersApiClient'
+import config from '../config'
 import { createRedisClient } from './redisClient'
 import RedisTokenStore from './tokenStore/redisTokenStore'
 import InMemoryTokenStore from './tokenStore/inMemoryTokenStore'
-import config from '../config'
+import HmppsAuthClient from './hmppsAuthClient'
+import ManageUsersApiClient from './manageUsersApiClient'
+import FrontendComponentsClient from './frontendComponentsClient'
 
 export type RestClientBuilder<T> = (token: string) => T
 
@@ -25,6 +26,7 @@ export const dataAccess = () => ({
     config.redis.enabled ? new RedisTokenStore(createRedisClient()) : new InMemoryTokenStore(),
   ),
   manageUsersApiClient: new ManageUsersApiClient(),
+  frontendComponentsClient: new FrontendComponentsClient(),
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto'
+import crypto from 'node:crypto'
 
 import express, { Router, Request, Response, NextFunction } from 'express'
 import helmet from 'helmet'

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,12 +1,10 @@
 import { dataAccess } from '../data'
 import UserService from './userService'
-import FrontendComponentsClient from '../data/frontendComponentsClient'
 
 export const services = () => {
-  const { applicationInfo, manageUsersApiClient } = dataAccess()
+  const { applicationInfo, manageUsersApiClient, frontendComponentsClient } = dataAccess()
 
   const userService = new UserService(manageUsersApiClient)
-  const frontendComponentsClient = new FrontendComponentsClient()
 
   return {
     applicationInfo,

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -1,11 +1,12 @@
 /* eslint-disable no-param-reassign */
 import path from 'node:path'
 
-import nunjucks from 'nunjucks'
 import express from 'express'
-import { initialiseName } from './utils'
-import { ApplicationInfo } from '../applicationInfo'
+import nunjucks from 'nunjucks'
+
 import config from '../config'
+import { ApplicationInfo } from '../applicationInfo'
+import { initialiseName } from './utils'
 
 export default function nunjucksSetup(app: express.Express, applicationInfo: ApplicationInfo): void {
   app.set('view engine', 'njk')


### PR DESCRIPTION
Previously, stubbing did not work for DPS’ frontend components api as the url was never set to point to wiremock.

Now, in most tests the fallback header and footer is used (to make signing in possible) but a new test exists to ensure html, css and javascript is correctly loaded.