### PR TITLE
Add (disabled) audit client (hmpps-template-typescript#327)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,8 @@
         "plugin:prettier/recommended"
       ],
       "rules": {
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": ["error"],
         "@typescript-eslint/no-use-before-define": 0,
         "class-methods-use-this": 0,
         "no-useless-constructor": 0,

--- a/helm_deploy/hmpps-incident-reporting/values.yaml
+++ b/helm_deploy/hmpps-incident-reporting/values.yaml
@@ -2,6 +2,8 @@ generic-service:
   nameOverride: hmpps-incident-reporting
   productId: DPS021
 
+  # serviceAccountName: "hmpps-incident-reporting"
+
   replicaCount: 4
 
   image:
@@ -35,6 +37,9 @@ generic-service:
     REDIS_TLS_ENABLED: "true"
     TOKEN_VERIFICATION_ENABLED: "true"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
+    AUDIT_ENABLED: "false"
+    AUDIT_SQS_REGION: "eu-west-2"
+    AUDIT_SERVICE_NAME: "UNASSIGNED"
 
   envFrom:
     - secretRef:
@@ -44,6 +49,9 @@ generic-service:
     elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"
+    # sqs-hmpps-audit-secret:
+    #   AUDIT_SQS_QUEUE_URL: "sqs_queue_url"
+    #   AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 
   allowlist:
     groups:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/frontend": "^2.1.2",
+        "@aws-sdk/client-sqs": "^3.540.0",
+        "@ministryofjustice/frontend": "^2.1.1",
         "agentkeepalive": "^4.5.0",
         "applicationinsights": "^2.9.5",
         "body-parser": "^1.20.2",
@@ -58,6 +59,7 @@
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
         "audit-ci": "^6.6.1",
+        "aws-sdk-client-mock": "^4.0.0",
         "concurrently": "^8.2.2",
         "cookie-session": "^2.1.0",
         "cypress": "^13.7.1",
@@ -111,6 +113,622 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.540.0.tgz",
+      "integrity": "sha512-PYyFIUZwN1LcrUtHQ/KJqNUgPgY3bNGjVp/SbwJ8cKGALBUvUNN6E7VpEDYglY1X/CuMolxK00TFZOSR9O056Q==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.540.0",
+        "@aws-sdk/core": "3.535.0",
+        "@aws-sdk/credential-provider-node": "3.540.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/md5-js": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.2.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.540.0.tgz",
+      "integrity": "sha512-rrQZMuw4sxIo3eyAUUzPQRA336mPRnrAeSlSdVHBKZD8Fjvoy0lYry2vNhkPLpFZLso1J66KRyuIv4LzRR3v1Q==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.535.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.2.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.540.0.tgz",
+      "integrity": "sha512-LZYK0lBRQK8D8M3Sqc96XiXkAV2v70zhTtF6weyzEpgwxZMfSuFJjs0jFyhaeZBZbZv7BBghIdhJ5TPavNxGMQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.540.0",
+        "@aws-sdk/core": "3.535.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.2.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.540.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.540.0.tgz",
+      "integrity": "sha512-ITHUQxvpqfQX6obfpIi3KYGzZYfe/I5Ixjfxoi5lB7ISCtmxqObKB1fzD93wonkMJytJ7LUO8panZl/ojiJ1uw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.535.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.2.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.540.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.535.0.tgz",
+      "integrity": "sha512-+Yusa9HziuaEDta1UaLEtMAtmgvxdxhPn7jgfRY6PplqAqgsfa5FR83sxy5qr2q7xjQTwHtV4MjQVuOjG9JsLw==",
+      "dependencies": {
+        "@smithy/core": "^1.4.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.535.0.tgz",
+      "integrity": "sha512-XppwO8c0GCGSAvdzyJOhbtktSEaShg14VJKg8mpMa1XcgqzmcqqHQjtDWbx5rZheY1VdpXZhpEzJkB6LpQejpA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.535.0.tgz",
+      "integrity": "sha512-kdj1wCmOMZ29jSlUskRqN04S6fJ4dvt0Nq9Z32SA6wO7UG8ht6Ot9h/au/eTWJM3E1somZ7D771oK7dQt9b8yw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.540.0.tgz",
+      "integrity": "sha512-igN/RbsnulIBwqXbwsWmR3srqmtbPF1dm+JteGvUY31FW65fTVvWvSr945Y/cf1UbhPmIQXntlsqESqpkhTHwg==",
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.540.0",
+        "@aws-sdk/credential-provider-env": "3.535.0",
+        "@aws-sdk/credential-provider-process": "3.535.0",
+        "@aws-sdk/credential-provider-sso": "3.540.0",
+        "@aws-sdk/credential-provider-web-identity": "3.540.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.540.0.tgz",
+      "integrity": "sha512-HKQZJbLHlrHX9A0B1poiYNXIIQfy8whTjuosTCYKPDBhhUyVAQfxy/KG726j0v43IhaNPLgTGZCJve4hAsazSw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.535.0",
+        "@aws-sdk/credential-provider-http": "3.535.0",
+        "@aws-sdk/credential-provider-ini": "3.540.0",
+        "@aws-sdk/credential-provider-process": "3.535.0",
+        "@aws-sdk/credential-provider-sso": "3.540.0",
+        "@aws-sdk/credential-provider-web-identity": "3.540.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.535.0.tgz",
+      "integrity": "sha512-9O1OaprGCnlb/kYl8RwmH7Mlg8JREZctB8r9sa1KhSsWFq/SWO0AuJTyowxD7zL5PkeS4eTvzFFHWCa3OO5epA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.540.0.tgz",
+      "integrity": "sha512-tKkFqK227LF5ajc5EL6asXS32p3nkofpP8G7NRpU7zOEOQCg01KUc4JRX+ItI0T007CiN1J19yNoFqHLT/SqHg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.540.0",
+        "@aws-sdk/token-providers": "3.540.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.540.0.tgz",
+      "integrity": "sha512-OpDm9w3A168B44hSjpnvECP4rvnFzD86rN4VYdGADuCvEa5uEcdA/JuT5WclFPDqdWEmFBqS1pxBIJBf0g2Q9Q==",
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.540.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.535.0.tgz",
+      "integrity": "sha512-0h6TWjBWtDaYwHMQJI9ulafeS4lLaw1vIxRjbpH0svFRt6Eve+Sy8NlVhECfTU2hNz/fLubvrUxsXoThaLBIew==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.535.0.tgz",
+      "integrity": "sha512-huNHpONOrEDrdRTvSQr1cJiRMNf0S52NDXtaPzdxiubTkP+vni2MohmZANMOai/qT0olmEVX01LhZ0ZAOgmg6A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.535.0.tgz",
+      "integrity": "sha512-am2qgGs+gwqmR4wHLWpzlZ8PWhm4ktj5bYSgDrsOfjhdBlWNxvPoID9/pDAz5RWL48+oH7I6SQzMqxXsFDikrw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.535.0.tgz",
+      "integrity": "sha512-E6En+QI7AFp5DsUhhA+DexMRjrJmYYte/wkArY47+6gw8VO6z7WYW6KtrhUP2OyJRYMil7o/1z76+j69vc2PBQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.540.0.tgz",
+      "integrity": "sha512-8Rd6wPeXDnOYzWj1XCmOKcx/Q87L0K1/EHqOBocGjLVbN3gmRxBvpmR1pRTjf7IsWfnnzN5btqtcAkfDPYQUMQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.535.0.tgz",
+      "integrity": "sha512-IXOznDiaItBjsQy4Fil0kzX/J3HxIOknEphqHbOfUf+LpA5ugcsxuQQONrbEQusCBnfJyymrldBvBhFmtlU9Wg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.540.0.tgz",
+      "integrity": "sha512-9BvtiVEZe5Ev88Wa4ZIUbtT6BVcPwhxmVInQ6c12MYNb0WNL54BN6wLy/eknAfF05gpX2/NDU2pUDOyMPdm/+g==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.540.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.540.0.tgz",
+      "integrity": "sha512-1kMyQFAWx6f8alaI6UT65/5YW/7pDWAKAdNwL6vuJLea03KrZRX3PMoONOSJpAS5m3Ot7HlWZvf3wZDNTLELZw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.535.0.tgz",
+      "integrity": "sha512-PHJ3SL6d2jpcgbqdgiPxkXpu7Drc2PYViwxSIqvvMKhDwzSB1W3mMvtpzwKM4IE7zLFodZo0GKjJ9AsoXndXhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.535.0.tgz",
+      "integrity": "sha512-RWMcF/xV5n+nhaA/Ff5P3yNP3Kur/I+VNZngog4TEs92oB/nwOdAg/2JL8bVAhUbMrjTjpwm7PItziYFQoqyig==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.535.0.tgz",
+      "integrity": "sha512-dRek0zUuIT25wOWJlsRm97nTkUlh1NDcLsQZIN2Y8KxhwoXXWtJs5vaDPT+qAg+OpcNj80i1zLR/CirqlFg/TQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -1723,6 +2341,573 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+      "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-uu9ZDI95Uij4qk+L6kyFjdk11zqBkcJ3Lv0sc6jZrqHvLyr0+oeekD3CnqMafBn/5PRI6uv6ulW3kNLRBUHeVw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.2.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+      "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+      "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+      "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.2.0.tgz",
+      "integrity": "sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+      "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.0.tgz",
+      "integrity": "sha512-OBhI9ZEAG8Xen0xsFJwwNOt44WE2CWkfYIxTognC8x42Lfsdf0VN/wCMqpdkySMDio/vts10BiovAxQp0T0faA==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.2.0.tgz",
+      "integrity": "sha512-PsjDOLpbevgn37yJbawmfVoanru40qVA8UEf2+YA1lvOefmhuhL6ZbKtGsLAWDRnE1OlAmedsbA/htH6iSZjNA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "tslib": "^2.6.2",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+      "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.2.0.tgz",
+      "integrity": "sha512-+B5TNzj/fRZzVW3z8UUJOkNx15+4E0CLuvJmJUA1JUIZFp3rdJ/M2H5r2SqltaVPXL0oIxv/6YK92T9TsFGbFg==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.0.tgz",
+      "integrity": "sha512-DDXWHWdimtS3y/Kw1Jo46KQ0ZYsDKcldFynQERUGBPDpkW1lXOTHy491ALHjwfiBQvzsVKVxl5+ocXNIgJuX4g==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+      "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+      "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.0.tgz",
+      "integrity": "sha512-2okTdZaCBvOJszAPU/KSvlimMe35zLOKbQpHhamFJmR7t95HSe0K3C92jQPjKY3PmDBD+7iMkOnuW05F5OlF4g==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.0.tgz",
+      "integrity": "sha512-hfKXnNLmsW9cmLb/JXKIvtuO6Cf4SuqN5PN1C2Ru/TBIws+m1wSgb+A53vo0r66xzB6E82inKG2J7qtwdi+Kkw==",
+      "dependencies": {
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.2.0.tgz",
+      "integrity": "sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+      "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2055,6 +3240,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.5.tgz",
       "integrity": "sha512-9Hp0ObzwwO57DpLFF0InUjUm/II8GmKAvzbefxQTihCb7KI6yc9yzf0nLc4mVdby5N4DRCgQM2wCup9KTieeww=="
+    },
+    "node_modules/@types/sinon": {
+      "version": "10.0.20",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
+      "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -2827,6 +4021,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.0.0.tgz",
+      "integrity": "sha512-/rxo+pzCFaUozK7TyCqo3GYwzdBGn9Ai6EsT8ytXDoUXlD/Q5hw9hj2lOkCAyubECzGJFHMmQg9GZ1GOGlN/qQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinon": "^10.0.10",
+        "sinon": "^16.1.3",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -3062,6 +4267,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -5224,6 +6434,27 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -7355,6 +8586,12 @@
         "verror": "1.10.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
+    },
     "node_modules/jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -7968,6 +9205,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -8554,6 +9797,34 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/nise": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
+      "integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
     },
     "node_modules/nocache": {
       "version": "4.0.0",
@@ -9966,6 +11237,45 @@
         "node": ">=10"
       }
     },
+    "node_modules/sinon": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
+      "integrity": "sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.3.0",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -10238,6 +11548,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/superagent": {
       "version": "8.1.2",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     ]
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "^2.1.2",
+    "@aws-sdk/client-sqs": "^3.540.0",
+    "@ministryofjustice/frontend": "^2.1.1",
     "agentkeepalive": "^4.5.0",
     "applicationinsights": "^2.9.5",
     "body-parser": "^1.20.2",
@@ -147,6 +148,7 @@
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
     "audit-ci": "^6.6.1",
+    "aws-sdk-client-mock": "^4.0.0",
     "concurrently": "^8.2.2",
     "cookie-session": "^2.1.0",
     "cypress": "^13.7.1",

--- a/server/config.ts
+++ b/server/config.ts
@@ -34,6 +34,20 @@ export interface ApiConfig {
   agent: AgentConfig
 }
 
+const auditConfig = () => {
+  const auditEnabled = get('AUDIT_ENABLED', 'false') === 'true'
+  return {
+    enabled: auditEnabled,
+    queueUrl: get(
+      'AUDIT_SQS_QUEUE_URL',
+      'http://localhost:4566/000000000000/mainQueue',
+      auditEnabled && requiredInProduction,
+    ),
+    serviceName: get('AUDIT_SERVICE_NAME', 'UNASSIGNED', auditEnabled && requiredInProduction),
+    region: get('AUDIT_SQS_REGION', 'eu-west-2'),
+  }
+}
+
 export default {
   productId: get('PRODUCT_ID', 'UNASSIGNED', requiredInProduction),
   buildNumber: get('BUILD_NUMBER', '1_0_0', requiredInProduction),
@@ -93,6 +107,9 @@ export default {
       },
       agent: new AgentConfig(Number(get('COMPONENT_API_TIMEOUT_SECONDS', 5000))),
     },
+  },
+  sqs: {
+    audit: auditConfig(),
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   dpsUrl: get('DPS_URL', 'http://dps.local', requiredInProduction),

--- a/server/data/hmppsAuditClient.test.ts
+++ b/server/data/hmppsAuditClient.test.ts
@@ -1,0 +1,110 @@
+import { mockClient } from 'aws-sdk-client-mock'
+import { SendMessageCommand, type SendMessageCommandInput, SQSClient } from '@aws-sdk/client-sqs'
+
+import HmppsAuditClient, { SqsMessage } from './hmppsAuditClient'
+
+describe('hmppsAuditClient', () => {
+  const sqsMock = mockClient(SQSClient)
+  let hmppsAuditClient: HmppsAuditClient
+
+  const auditClientConfig = {
+    queueUrl: 'http://localhost:4566/000000000000/mainQueue',
+    region: 'eu-west-2',
+    serviceName: 'hmpps-service',
+    enabled: true,
+  }
+
+  afterEach(() => {
+    sqsMock.reset()
+    jest.resetAllMocks()
+  })
+
+  describe('sendMessage', () => {
+    it('should send sqs message to audit queue', async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: '123' })
+      hmppsAuditClient = new HmppsAuditClient({
+        ...auditClientConfig,
+        queueUrl: 'http://localhost:4566/000000000000/mainQueue',
+      })
+
+      const actualResponse = await hmppsAuditClient.sendMessage({
+        what: 'EXAMPLE_EVENT',
+        who: 'user1',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+
+      const expectedSqsMessageBody: SqsMessage = {
+        what: 'EXAMPLE_EVENT',
+        who: 'user1',
+        when: expect.any(String),
+        service: 'hmpps-service',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      }
+
+      expect(actualResponse).toEqual({ MessageId: '123' })
+
+      const actualMessageInput = sqsMock.call(0).args[0].input as SendMessageCommandInput
+
+      expect(actualMessageInput.QueueUrl).toEqual('http://localhost:4566/000000000000/mainQueue')
+
+      const actualMessageBody = JSON.parse(actualMessageInput.MessageBody)
+      expect(actualMessageBody).toEqual(expectedSqsMessageBody)
+
+      const eventTime = Date.parse(actualMessageBody.when)
+      expect(Date.now() - eventTime).toBeLessThan(10)
+
+      expect(sqsMock.calls().length).toEqual(1)
+    })
+
+    it("shouldn't send sqs message to audit queue if client disabled", async () => {
+      sqsMock.on(SendMessageCommand).resolves({ MessageId: '123' })
+      hmppsAuditClient = new HmppsAuditClient({ ...auditClientConfig, enabled: false })
+
+      await hmppsAuditClient.sendMessage({
+        what: 'EXAMPLE_EVENT',
+        who: 'user1',
+      })
+
+      expect(sqsMock.calls().length).toEqual(0)
+    })
+
+    it("shouldn't throw an error if sqs message cannot be sent", async () => {
+      sqsMock.on(SendMessageCommand).rejects(new Error('Error sending sqs message'))
+      hmppsAuditClient = new HmppsAuditClient({ ...auditClientConfig })
+
+      const trySendMessage = async () => {
+        await hmppsAuditClient.sendMessage(
+          {
+            what: 'EXAMPLE_EVENT',
+            who: 'user1',
+          },
+          false,
+        )
+      }
+
+      await expect(trySendMessage()).resolves.not.toThrow()
+      expect(sqsMock.calls().length).toEqual(1)
+    })
+
+    it('should throw an error if sqs message cannot be sent', async () => {
+      sqsMock.on(SendMessageCommand).rejects(new Error('Error sending sqs message'))
+      hmppsAuditClient = new HmppsAuditClient({ ...auditClientConfig })
+
+      const trySendMessage = async () => {
+        await hmppsAuditClient.sendMessage({
+          what: 'EXAMPLE_EVENT',
+          who: 'user1',
+        })
+      }
+
+      await expect(trySendMessage()).rejects.toThrow('Error sending sqs message')
+      expect(sqsMock.calls().length).toEqual(1)
+    })
+  })
+})

--- a/server/data/hmppsAuditClient.ts
+++ b/server/data/hmppsAuditClient.ts
@@ -1,0 +1,71 @@
+import { SendMessageCommand, type SendMessageCommandOutput, SQSClient } from '@aws-sdk/client-sqs'
+
+import logger from '../../logger'
+
+export interface AuditEvent {
+  what: string
+  who: string
+  subjectId?: string
+  subjectType?: string
+  correlationId?: string
+  details?: object
+}
+
+export interface SqsMessage {
+  what: string
+  who: string
+  when: string
+  service: string
+  subjectId?: string
+  subjectType?: string
+  correlationId?: string
+  details?: object
+}
+
+export interface AuditClientConfig {
+  queueUrl: string
+  region: string
+  serviceName: string
+  enabled: boolean
+}
+
+export default class HmppsAuditClient {
+  private sqsClient: SQSClient
+
+  private readonly queueUrl: string
+
+  private readonly serviceName: string
+
+  private readonly enabled: boolean
+
+  constructor(config: AuditClientConfig) {
+    this.enabled = config.enabled
+    this.queueUrl = config.queueUrl
+    this.serviceName = config.serviceName
+    this.sqsClient = new SQSClient({ region: config.region })
+  }
+
+  async sendMessage(event: AuditEvent, throwOnError: boolean = true): Promise<SendMessageCommandOutput | null> {
+    if (!this.enabled) return null
+
+    const sqsMessage: SqsMessage = {
+      ...event,
+      service: this.serviceName,
+      when: new Date().toISOString(),
+    }
+
+    try {
+      const messageResponse = await this.sqsClient.send(
+        new SendMessageCommand({ MessageBody: JSON.stringify(sqsMessage), QueueUrl: this.queueUrl }),
+      )
+
+      logger.info(`HMPPS Audit SQS message sent (${messageResponse.MessageId})`)
+
+      return messageResponse
+    } catch (error) {
+      logger.error('Error sending HMPPS Audit SQS message, ', error)
+      if (throwOnError) throw error
+    }
+    return null
+  }
+}

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -1,0 +1,57 @@
+import HmppsAuditClient from '../data/hmppsAuditClient'
+import AuditService, { Page } from './auditService'
+
+jest.mock('../data/hmppsAuditClient')
+
+describe('Audit service', () => {
+  let hmppsAuditClient: jest.Mocked<HmppsAuditClient>
+  let auditService: AuditService
+
+  beforeEach(() => {
+    hmppsAuditClient = new HmppsAuditClient(null) as jest.Mocked<HmppsAuditClient>
+    auditService = new AuditService(hmppsAuditClient)
+  })
+
+  describe('logAuditEvent', () => {
+    it('sends audit message using audit client', async () => {
+      await auditService.logAuditEvent({
+        what: 'AUDIT_EVENT',
+        who: 'user1',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
+        what: 'AUDIT_EVENT',
+        who: 'user1',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+    })
+  })
+
+  describe('logPageView', () => {
+    it('sends page view event audit message using audit client', async () => {
+      await auditService.logPageView(Page.HOME_PAGE, {
+        who: 'user1',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
+        what: 'PAGE_VIEW_HOME_PAGE',
+        who: 'user1',
+        subjectId: 'subject123',
+        subjectType: 'exampleType',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+    })
+  })
+})

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -1,0 +1,29 @@
+import HmppsAuditClient, { type AuditEvent } from '../data/hmppsAuditClient'
+
+export enum Page {
+  HOME_PAGE = 'HOME_PAGE',
+}
+
+export interface PageViewEventDetails {
+  who: string
+  subjectId?: string
+  subjectType?: string
+  correlationId?: string
+  details?: object
+}
+
+export default class AuditService {
+  constructor(private readonly hmppsAuditClient: HmppsAuditClient) {}
+
+  async logAuditEvent(event: AuditEvent): Promise<void> {
+    await this.hmppsAuditClient.sendMessage(event)
+  }
+
+  async logPageView(page: Page, eventDetails: PageViewEventDetails): Promise<void> {
+    const event: AuditEvent = {
+      ...eventDetails,
+      what: `PAGE_VIEW_${page}`,
+    }
+    await this.hmppsAuditClient.sendMessage(event)
+  }
+}


### PR DESCRIPTION
Copied from [upstream template](https://github.com/ministryofjustice/hmpps-template-typescript/pull/327) but the audit client is _not_ provided to the app’s “services”