### PR TITLE
IR-68: Silence asset manifest file error during tests

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -26,7 +26,9 @@ export default function nunjucksSetup(app: express.Express): void {
     const assetMetadataPath = path.resolve(__dirname, '../../assets/manifest.json')
     assetManifest = JSON.parse(fs.readFileSync(assetMetadataPath, 'utf8'))
   } catch (e) {
-    logger.error('Could not read asset manifest file')
+    if (process.env.NODE_ENV !== 'test') {
+      logger.error('Could not read asset manifest file')
+    }
   }
 
   const njkEnv = nunjucks.configure(


### PR DESCRIPTION
The app runs from within the `/dist` folder into which assets are built along with the *manifest* file. This manifest file is used from within nunjucks templates to map local paths to versioned assets.

However, tests run from the actual sources and cannot find the manifest file, leading to a wall of inconsequential error messages.

For now it’s easiest to silence this error in test mode. `jest` tests don’t actually even try to load any assets; there is no server running.

Once the template project decides on a better workaround, we can cherry-pick it and remove this solution.