### PR TITLE
IR-68: Run type-checking in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,15 +52,27 @@ jobs:
       - run:
           name: Build application
           command: npm run build
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
-          name: Linter check
-          command: npm run lint
       - persist_to_workspace:
           root: .
           paths:
             - node_modules
             - build
             - dist
+
+  lint_and_typecheck:
+    executor:
+      name: hmpps/node
+      tag: << pipeline.parameters.node-version >>
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+      - run:
+          name: Run linter
+          command: npm run lint
+      - run:
+          name: Check types
+          command: npm run typecheck
 
   unit_test:
     executor:
@@ -126,6 +138,9 @@ workflows:
           filters:
             tags:
               ignore: /.*/
+      - lint_and_typecheck:
+          requires:
+            - build
       - unit_test:
           requires:
             - build

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -2,9 +2,10 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
+    "module": "commonjs",
+    "target": "es2018",
     "noEmit": true,
-    "lib": ["es5", "dom", "es2015.promise"],
+    "lib": ["dom", "es2018"],
     "types": ["cypress", "express", "express-session"],
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
• `eslint` already ran in CircleCI build job but for some reason `tsc` did not
• integration tests now compile to a more-modern version of javascript