### PR TITLE
IR-396: Add basic client to talk with API (part 1)

### DIFF
--- a/server/@types/index.d.ts
+++ b/server/@types/index.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Replaces all Date types with string.
+ * Needed because api responses over-the-wire are JSON and therefore encode dates as plain strings.
+ */
+type DatesAsStrings<T> = {
+  [k in keyof T]: T[k] extends Array<infer U>
+    ? Array<DatesAsStrings<U>>
+    : T[k] extends Date
+      ? string
+      : T[k] extends object
+        ? DatesAsStrings<T[k]>
+        : T[k]
+}

--- a/server/config.ts
+++ b/server/config.ts
@@ -69,6 +69,18 @@ export default {
     expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)),
   },
   apis: {
+    hmppsIncidentReportingApi: {
+      url: get('HMPPS_INCIDENT_REPORTING_API_URL', 'http://localhost:2999', requiredInProduction),
+      externalUrl: get(
+        'HMPPS_INCIDENT_REPORTING_API_EXTERNAL_URL',
+        get('HMPPS_INCIDENT_REPORTING_API_URL', 'http://localhost:2999'),
+      ),
+      timeout: {
+        response: Number(get('HMPPS_INCIDENT_REPORTING_API_TIMEOUT_RESPONSE', 60000)),
+        deadline: Number(get('HMPPS_INCIDENT_REPORTING_API_TIMEOUT_DEADLINE', 60000)),
+      },
+      agent: new AgentConfig(Number(get('HMPPS_INCIDENT_REPORTING_API_TIMEOUT_RESPONSE', 60000))),
+    },
     hmppsAuth: {
       url: get('HMPPS_AUTH_URL', 'http://localhost:9090/auth', requiredInProduction),
       externalUrl: get('HMPPS_AUTH_EXTERNAL_URL', get('HMPPS_AUTH_URL', 'http://localhost:9090/auth')),

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -113,8 +113,6 @@ export class IncidentReportingApi extends RestClient {
       query.eventDateUntil = toDateString(eventDateUntil)
     }
 
-    console.debug(query)
-
     return this.get<DatesAsStrings<PaginatedEventsWithBasicReports>>({
       path: '/incident-events',
       query,
@@ -124,5 +122,17 @@ export class IncidentReportingApi extends RestClient {
         content: response.content.map(convertEventWithBasicReportsDates),
       }
     })
+  }
+
+  getEventById(id: string): Promise<EventWithBasicReports> {
+    return this.get<DatesAsStrings<EventWithBasicReports>>({
+      path: `/incident-events/${id}`,
+    }).then(convertEventWithBasicReportsDates)
+  }
+
+  getEventByReference(reference: string): Promise<EventWithBasicReports> {
+    return this.get<DatesAsStrings<EventWithBasicReports>>({
+      path: `/incident-events/reference/${reference}`,
+    }).then(convertEventWithBasicReportsDates)
   }
 }

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
 import config from '../config'
+import { convertEventWithBasicReportsDates } from './incidentReportingApiUtils'
 import RestClient from './restClient'
 
 /**
@@ -22,12 +23,61 @@ export class ErrorResponse {
   }
 }
 
+export type Paginated<T> = {
+  content: T[]
+  number: number
+  size: number
+  numberOfElements: number
+  totalPages: number
+  sort: string[]
+}
+
+export type PaginatedEventsWithBasicReports = Paginated<EventWithBasicReports>
+
+export type EventWithBasicReports = {
+  id: string
+  eventReference: string
+  eventDateAndTime: Date
+  prisonId: string
+  title: string
+  description: string
+  createdAt: Date
+  modifiedAt: Date
+  modifiedBy: string
+  reports: ReportBasic[]
+}
+
+export type ReportBasic = {
+  id: string
+  reportReference: string
+  // TODO: Add enums?
+  type: string
+  incidentDateAndTime: Date
+  prisonId: string
+  title: string
+  description: string
+  reportedBy: string
+  reportedAt: Date
+  // TODO: Add enums?
+  status: string
+  assignedTo: string
+  createdAt: Date
+  modifiedAt: Date
+  modifiedBy: string
+  createdInNomis: boolean
+}
+
 export class IncidentReportingApi extends RestClient {
   constructor(systemToken: string) {
     super('HMPPS Incident Reporting API', config.apis.hmppsIncidentReportingApi, systemToken)
   }
 
-  getEvents(): Promise<object> {
-    return this.get({ path: '/incident-events' })
+  getEvents(): Promise<PaginatedEventsWithBasicReports> {
+    return this.get<DatesAsStrings<PaginatedEventsWithBasicReports>>({ path: '/incident-events' }).then(response => {
+      return {
+        ...response,
+        content: response.content.map(convertEventWithBasicReportsDates),
+      }
+    })
   }
 }

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -1,0 +1,33 @@
+// eslint-disable-next-line max-classes-per-file
+import config from '../config'
+import RestClient from './restClient'
+
+/**
+ * Structure representing an error response from the incentives api
+ */
+export class ErrorResponse {
+  status: number
+
+  errorCode?: number
+
+  userMessage?: string
+
+  developerMessage?: string
+
+  moreInfo?: string
+
+  static isErrorResponse(obj: object): obj is ErrorResponse {
+    // TODO: would be nice to make userMessage & developerMessage non-nullable in the api
+    return obj && 'status' in obj && typeof obj.status === 'number'
+  }
+}
+
+export class IncidentReportingApi extends RestClient {
+  constructor(systemToken: string) {
+    super('HMPPS Incident Reporting API', config.apis.hmppsIncidentReportingApi, systemToken)
+  }
+
+  getEvents(): Promise<object> {
+    return this.get({ path: '/incident-events' })
+  }
+}

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line max-classes-per-file
 import config from '../config'
-import { convertBasicReportDates, convertEventWithBasicReportsDates, toDateString } from './incidentReportingApiUtils'
+import { toDateString } from '../utils/utils'
+import { convertBasicReportDates, convertEventWithBasicReportsDates } from './incidentReportingApiUtils'
 import RestClient from './restClient'
 
 /**

--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -1,0 +1,21 @@
+import type { EventWithBasicReports, ReportBasic } from './incidentReportingApi'
+
+export function convertBasicReportDates(report: DatesAsStrings<ReportBasic>): ReportBasic {
+  return {
+    ...report,
+    incidentDateAndTime: new Date(report.incidentDateAndTime),
+    reportedAt: new Date(report.reportedAt),
+    createdAt: new Date(report.createdAt),
+    modifiedAt: new Date(report.modifiedAt),
+  }
+}
+
+export function convertEventWithBasicReportsDates(event: DatesAsStrings<EventWithBasicReports>): EventWithBasicReports {
+  return {
+    ...event,
+    eventDateAndTime: new Date(event.eventDateAndTime),
+    createdAt: new Date(event.createdAt),
+    modifiedAt: new Date(event.modifiedAt),
+    reports: event.reports.map(convertBasicReportDates),
+  }
+}

--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -19,7 +19,3 @@ export function convertEventWithBasicReportsDates(event: DatesAsStrings<EventWit
     reports: event.reports.map(convertBasicReportDates),
   }
 }
-
-export function toDateString(date: Date): string {
-  return date.toISOString().split('T')[0]
-}

--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -19,3 +19,7 @@ export function convertEventWithBasicReportsDates(event: DatesAsStrings<EventWit
     reports: event.reports.map(convertBasicReportDates),
   }
 }
+
+export function toDateString(date: Date): string {
+  return date.toISOString().split('T')[0]
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -2,6 +2,12 @@ import { type RequestHandler, Router } from 'express'
 
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import type { Services } from '../services'
+import HmppsAuthClient from '../data/hmppsAuthClient'
+import RedisTokenStore from '../data/tokenStore/redisTokenStore'
+import { createRedisClient } from '../data/redisClient'
+import { IncidentReportingApi } from '../data/incidentReportingApi'
+
+const hmppsAuthClient = new HmppsAuthClient(new RedisTokenStore(createRedisClient()))
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes(service: Services): Router {
@@ -10,6 +16,16 @@ export default function routes(service: Services): Router {
 
   get('/', (req, res, next) => {
     res.render('pages/index')
+  })
+
+  get('/events', async (req, res, next) => {
+    const { user } = res.locals
+    const systemToken = await hmppsAuthClient.getSystemClientToken(user.username)
+    const incidentReportingApi = new IncidentReportingApi(systemToken)
+
+    const response = await incidentReportingApi.getEvents()
+
+    res.render('pages/events', { response })
   })
 
   return router

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -23,7 +23,12 @@ export default function routes(service: Services): Router {
     const systemToken = await hmppsAuthClient.getSystemClientToken(user.username)
     const incidentReportingApi = new IncidentReportingApi(systemToken)
 
-    const response = await incidentReportingApi.getEvents()
+    const response = await incidentReportingApi.getEvents({
+      prisonId: user.activeCaseLoadId,
+      // eventDateFrom: new Date('2024-07-30'),
+      // eventDateUntil: new Date('2024-07-30'),
+      // sort: ['eventDateAndTime,ASC'],
+    })
 
     res.render('pages/events', { response })
   })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { convertToTitleCase, initialiseName } from './utils'
+import { convertToTitleCase, initialiseName, toDateString } from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -26,5 +26,12 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
+  })
+})
+
+describe('toDateString()', () => {
+  it('returns a string representing the date component of the Date', () => {
+    const datetime = new Date('2024-07-30T12:34:56')
+    expect(toDateString(datetime)).toEqual('2024-07-30')
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -21,3 +21,7 @@ export const initialiseName = (fullName?: string): string | null => {
   const array = fullName.split(' ')
   return `${array[0][0]}. ${array.reverse()[0]}`
 }
+
+export function toDateString(date: Date): string {
+  return date.toISOString().split('T')[0]
+}

--- a/server/views/pages/events.njk
+++ b/server/views/pages/events.njk
@@ -1,0 +1,11 @@
+{% extends "../partials/layout.njk" %}
+{% set pageTitle = applicationName + " - Home" %}
+{% set mainClasses = "app-container govuk-body" %}
+{% block content %}
+  <h1>Incident events</h1>
+  <p>API Response for <pre>GET /incident-events/</pre>
+    endpoint</p>
+  <pre>
+    {{ response | dump(2) }}
+  </pre>
+{% endblock %}


### PR DESCRIPTION
Added a basic client to talk with the [Incident Reporting API](https://incident-reporting-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html#/).

- wiring to read client settings (URL, etc...)
- TS types
- methods to get list of incidents "events" and reports
  - with filtering/pagination/sorting
- methods to get single incident "event" and single basic report, by ID or reference 
- conversion of JSON datetimes from strings to JS `Date`

#### NOTES
The API has many more endpoints that are currently not exposed in this client.
However this is a minimal set of features that can be merged and potentially used by others in the team to start to build some basic pages to display lists events/reports or single events/reports without additional details.

I plan to add at least more methods for the reading some of the additional details and the related TS types. But this can be done on top of this PR and/or lazily as the pages are built. But at least there is a skeleton of the client.

There are some TODOs comments, especially regarding enums. This could be done later on. For things like a Report's status the values will likely change as design thinks about the reports workflows.