### PR TITLE
IR-396: Incident Reporting client methods to get reports with details

### DIFF
--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -79,8 +79,8 @@ export type ReportWithDetails = ReportBasic & {
   // TODO: questions
   // TODO: history
   historyOfStatuses: HistoricStatus[]
-  // TODO: staffInvolved
-  // TODO: prisonersInvolved
+  staffInvolved: StaffInvolvement[]
+  prisonersInvolved: PrisonerInvolvement[]
   // TODO: correctionRequests
 }
 
@@ -89,6 +89,12 @@ export type ReportType = string
 // TODO: Add enums?
 export type ReportStatus = string
 export type ReportSource = 'DPS' | 'NOMIS'
+// TODO: Add enums?
+export type StaffRole = string
+// TODO: Add enums?
+export type PrisonerRole = string
+// TODO: Add enums?
+export type PrisonerInvolvementOutcome = string
 
 export type GetEventsParams = {
   prisonId: string
@@ -118,6 +124,19 @@ export type HistoricStatus = {
   status: ReportStatus
   changedAt: Date
   changedBy: string
+}
+
+export type StaffInvolvement = {
+  staffUsername: string
+  staffRole: StaffRole
+  comment: string | null
+}
+
+export type PrisonerInvolvement = {
+  prisonerNumber: string
+  prisonerRole: PrisonerRole
+  outcome: PrisonerInvolvementOutcome | null
+  comment: string | null
 }
 
 export class IncidentReportingApi extends RestClient {

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -78,7 +78,7 @@ export type ReportWithDetails = ReportBasic & {
   event: Event
   // TODO: questions
   // TODO: history
-  // TODO: historyOfStatuses
+  historyOfStatuses: HistoricStatus[]
   // TODO: staffInvolved
   // TODO: prisonersInvolved
   // TODO: correctionRequests
@@ -112,6 +112,12 @@ export type PaginationSortingParams = {
   size: number
   // TODO: Add enums?
   sort: string[]
+}
+
+export type HistoricStatus = {
+  status: ReportStatus
+  changedAt: Date
+  changedBy: string
 }
 
 export class IncidentReportingApi extends RestClient {

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -212,13 +212,13 @@ export class IncidentReportingApi extends RestClient {
 
   getEventById(id: string): Promise<EventWithBasicReports> {
     return this.get<DatesAsStrings<EventWithBasicReports>>({
-      path: `/incident-events/${id}`,
+      path: `/incident-events/${encodeURIComponent(id)}`,
     }).then(convertEventWithBasicReportsDates)
   }
 
   getEventByReference(reference: string): Promise<EventWithBasicReports> {
     return this.get<DatesAsStrings<EventWithBasicReports>>({
-      path: `/incident-events/reference/${reference}`,
+      path: `/incident-events/reference/${encodeURIComponent(reference)}`,
     }).then(convertEventWithBasicReportsDates)
   }
 
@@ -292,25 +292,25 @@ export class IncidentReportingApi extends RestClient {
 
   getReportById(id: string): Promise<ReportBasic> {
     return this.get<DatesAsStrings<ReportBasic>>({
-      path: `/incident-reports/${id}`,
+      path: `/incident-reports/${encodeURIComponent(id)}`,
     }).then(convertBasicReportDates)
   }
 
   getReportByReference(reference: string): Promise<ReportBasic> {
     return this.get<DatesAsStrings<ReportBasic>>({
-      path: `/incident-reports/reference/${reference}`,
+      path: `/incident-reports/reference/${encodeURIComponent(reference)}`,
     }).then(convertBasicReportDates)
   }
 
   getReportWithDetailsById(id: string): Promise<ReportWithDetails> {
     return this.get<DatesAsStrings<ReportWithDetails>>({
-      path: `/incident-reports/${id}/with-details`,
+      path: `/incident-reports/${encodeURIComponent(id)}/with-details`,
     }).then(convertReportWithDetailsDates)
   }
 
   getReportWithDetailsByReference(reference: string): Promise<ReportWithDetails> {
     return this.get<DatesAsStrings<ReportWithDetails>>({
-      path: `/incident-reports/reference/${reference}/with-details`,
+      path: `/incident-reports/reference/${encodeURIComponent(reference)}/with-details`,
     }).then(convertReportWithDetailsDates)
   }
 }

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -76,7 +76,7 @@ export type ReportBasic = {
 
 export type ReportWithDetails = ReportBasic & {
   event: Event
-  // TODO: questions
+  questions: Question[]
   // TODO: history
   historyOfStatuses: HistoricStatus[]
   staffInvolved: StaffInvolvement[]
@@ -120,6 +120,20 @@ export type PaginationSortingParams = {
   size: number
   // TODO: Add enums?
   sort: string[]
+}
+
+export type Question = {
+  code: string
+  question: string
+  responses: Response[]
+  additionalInformation: string | null
+}
+
+export type Response = {
+  response: string
+  recordedBy: string
+  recordedAt: Date
+  additionalInformation: string | null
 }
 
 export type HistoricStatus = {

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line max-classes-per-file
 import config from '../config'
 import { toDateString } from '../utils/utils'
-import { convertBasicReportDates, convertEventWithBasicReportsDates } from './incidentReportingApiUtils'
+import {
+  convertBasicReportDates,
+  convertEventWithBasicReportsDates,
+  convertReportWithDetailsDates,
+} from './incidentReportingApiUtils'
 import RestClient from './restClient'
 
 /**
@@ -36,7 +40,7 @@ export type Paginated<T> = {
 export type PaginatedEventsWithBasicReports = Paginated<EventWithBasicReports>
 export type PaginatedBasicReports = Paginated<ReportBasic>
 
-export type EventWithBasicReports = {
+export type Event = {
   id: string
   eventReference: string
   eventDateAndTime: Date
@@ -46,6 +50,9 @@ export type EventWithBasicReports = {
   createdAt: Date
   modifiedAt: Date
   modifiedBy: string
+}
+
+export type EventWithBasicReports = Event & {
   reports: ReportBasic[]
 }
 
@@ -65,6 +72,16 @@ export type ReportBasic = {
   modifiedAt: Date
   modifiedBy: string
   createdInNomis: boolean
+}
+
+export type ReportWithDetails = ReportBasic & {
+  event: Event
+  // TODO: questions
+  // TODO: history
+  // TODO: historyOfStatuses
+  // TODO: staffInvolved
+  // TODO: prisonersInvolved
+  // TODO: correctionRequests
 }
 
 // TODO: Add enums?
@@ -228,5 +245,17 @@ export class IncidentReportingApi extends RestClient {
     return this.get<DatesAsStrings<ReportBasic>>({
       path: `/incident-reports/reference/${reference}`,
     }).then(convertBasicReportDates)
+  }
+
+  getReportWithDetailsById(id: string): Promise<ReportWithDetails> {
+    return this.get<DatesAsStrings<ReportWithDetails>>({
+      path: `/incident-reports/${id}/with-details`,
+    }).then(convertReportWithDetailsDates)
+  }
+
+  getReportWithDetailsByReference(reference: string): Promise<ReportWithDetails> {
+    return this.get<DatesAsStrings<ReportWithDetails>>({
+      path: `/incident-reports/reference/${reference}/with-details`,
+    }).then(convertReportWithDetailsDates)
   }
 }

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -77,7 +77,7 @@ export type ReportBasic = {
 export type ReportWithDetails = ReportBasic & {
   event: Event
   questions: Question[]
-  // TODO: history
+  history: HistoricReport[]
   historyOfStatuses: HistoricStatus[]
   staffInvolved: StaffInvolvement[]
   prisonersInvolved: PrisonerInvolvement[]
@@ -134,6 +134,13 @@ export type Response = {
   recordedBy: string
   recordedAt: Date
   additionalInformation: string | null
+}
+
+export type HistoricReport = {
+  type: ReportType
+  changedAt: Date
+  changedBy: string
+  questions: Question[]
 }
 
 export type HistoricStatus = {

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -81,7 +81,7 @@ export type ReportWithDetails = ReportBasic & {
   historyOfStatuses: HistoricStatus[]
   staffInvolved: StaffInvolvement[]
   prisonersInvolved: PrisonerInvolvement[]
-  // TODO: correctionRequests
+  correctionRequests: CorrectionRequest[]
 }
 
 // TODO: Add enums?
@@ -95,6 +95,8 @@ export type StaffRole = string
 export type PrisonerRole = string
 // TODO: Add enums?
 export type PrisonerInvolvementOutcome = string
+// TODO: Add enums?
+export type CorrectionRequestReason = string
 
 export type GetEventsParams = {
   prisonId: string
@@ -137,6 +139,13 @@ export type PrisonerInvolvement = {
   prisonerRole: PrisonerRole
   outcome: PrisonerInvolvementOutcome | null
   comment: string | null
+}
+
+export type CorrectionRequest = {
+  reason: CorrectionRequestReason
+  descriptionOfChange: string
+  correctionRequestedBy: string
+  correctionRequestedAt: Date
 }
 
 export class IncidentReportingApi extends RestClient {

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -67,7 +67,7 @@ export type ReportBasic = {
   reportedBy: string
   reportedAt: Date
   status: ReportStatus
-  assignedTo: string
+  assignedTo: string | null
   createdAt: Date
   modifiedAt: Date
   modifiedBy: string

--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -1,4 +1,10 @@
-import type { Event, EventWithBasicReports, ReportBasic, ReportWithDetails } from './incidentReportingApi'
+import type {
+  Event,
+  EventWithBasicReports,
+  HistoricStatus,
+  ReportBasic,
+  ReportWithDetails,
+} from './incidentReportingApi'
 
 export function convertBasicReportDates(report: DatesAsStrings<ReportBasic>): ReportBasic {
   return {
@@ -15,6 +21,7 @@ export function convertReportWithDetailsDates(report: DatesAsStrings<ReportWithD
     ...report,
     ...convertBasicReportDates(report),
     event: convertEventDates(report.event),
+    historyOfStatuses: report.historyOfStatuses.map(convertHistoricStatusDates),
   }
 }
 
@@ -32,5 +39,12 @@ export function convertEventWithBasicReportsDates(event: DatesAsStrings<EventWit
     ...event,
     ...convertEventDates(event),
     reports: event.reports.map(convertBasicReportDates),
+  }
+}
+
+export function convertHistoricStatusDates(historicStatus: DatesAsStrings<HistoricStatus>): HistoricStatus {
+  return {
+    ...historicStatus,
+    changedAt: new Date(historicStatus.changedAt),
   }
 }

--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -2,6 +2,7 @@ import type {
   CorrectionRequest,
   Event,
   EventWithBasicReports,
+  HistoricReport,
   HistoricStatus,
   Question,
   ReportBasic,
@@ -25,6 +26,7 @@ export function convertReportWithDetailsDates(report: DatesAsStrings<ReportWithD
     ...convertBasicReportDates(report),
     event: convertEventDates(report.event),
     questions: report.questions.map(convertQuestionDates),
+    history: report.history.map(convertHistoricReportDates),
     historyOfStatuses: report.historyOfStatuses.map(convertHistoricStatusDates),
     correctionRequests: report.correctionRequests.map(convertCorrectionRequestDates),
   }
@@ -41,7 +43,6 @@ export function convertEventDates(event: DatesAsStrings<Event>): Event {
 
 export function convertEventWithBasicReportsDates(event: DatesAsStrings<EventWithBasicReports>): EventWithBasicReports {
   return {
-    ...event,
     ...convertEventDates(event),
     reports: event.reports.map(convertBasicReportDates),
   }
@@ -58,6 +59,14 @@ export function convertResponseDates(response: DatesAsStrings<Response>): Respon
   return {
     ...response,
     recordedAt: new Date(response.recordedAt),
+  }
+}
+
+export function convertHistoricReportDates(historicReport: DatesAsStrings<HistoricReport>): HistoricReport {
+  return {
+    ...historicReport,
+    changedAt: new Date(historicReport.changedAt),
+    questions: historicReport.questions.map(convertQuestionDates),
   }
 }
 

--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -1,4 +1,5 @@
 import type {
+  CorrectionRequest,
   Event,
   EventWithBasicReports,
   HistoricStatus,
@@ -22,6 +23,7 @@ export function convertReportWithDetailsDates(report: DatesAsStrings<ReportWithD
     ...convertBasicReportDates(report),
     event: convertEventDates(report.event),
     historyOfStatuses: report.historyOfStatuses.map(convertHistoricStatusDates),
+    correctionRequests: report.correctionRequests.map(convertCorrectionRequestDates),
   }
 }
 
@@ -46,5 +48,12 @@ export function convertHistoricStatusDates(historicStatus: DatesAsStrings<Histor
   return {
     ...historicStatus,
     changedAt: new Date(historicStatus.changedAt),
+  }
+}
+
+export function convertCorrectionRequestDates(correctionRequest: DatesAsStrings<CorrectionRequest>): CorrectionRequest {
+  return {
+    ...correctionRequest,
+    correctionRequestedAt: new Date(correctionRequest.correctionRequestedAt),
   }
 }

--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -3,8 +3,10 @@ import type {
   Event,
   EventWithBasicReports,
   HistoricStatus,
+  Question,
   ReportBasic,
   ReportWithDetails,
+  Response,
 } from './incidentReportingApi'
 
 export function convertBasicReportDates(report: DatesAsStrings<ReportBasic>): ReportBasic {
@@ -22,6 +24,7 @@ export function convertReportWithDetailsDates(report: DatesAsStrings<ReportWithD
     ...report,
     ...convertBasicReportDates(report),
     event: convertEventDates(report.event),
+    questions: report.questions.map(convertQuestionDates),
     historyOfStatuses: report.historyOfStatuses.map(convertHistoricStatusDates),
     correctionRequests: report.correctionRequests.map(convertCorrectionRequestDates),
   }
@@ -41,6 +44,20 @@ export function convertEventWithBasicReportsDates(event: DatesAsStrings<EventWit
     ...event,
     ...convertEventDates(event),
     reports: event.reports.map(convertBasicReportDates),
+  }
+}
+
+export function convertQuestionDates(question: DatesAsStrings<Question>): Question {
+  return {
+    ...question,
+    responses: question.responses.map(convertResponseDates),
+  }
+}
+
+export function convertResponseDates(response: DatesAsStrings<Response>): Response {
+  return {
+    ...response,
+    recordedAt: new Date(response.recordedAt),
   }
 }
 

--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -1,4 +1,4 @@
-import type { EventWithBasicReports, ReportBasic } from './incidentReportingApi'
+import type { Event, EventWithBasicReports, ReportBasic, ReportWithDetails } from './incidentReportingApi'
 
 export function convertBasicReportDates(report: DatesAsStrings<ReportBasic>): ReportBasic {
   return {
@@ -10,12 +10,27 @@ export function convertBasicReportDates(report: DatesAsStrings<ReportBasic>): Re
   }
 }
 
-export function convertEventWithBasicReportsDates(event: DatesAsStrings<EventWithBasicReports>): EventWithBasicReports {
+export function convertReportWithDetailsDates(report: DatesAsStrings<ReportWithDetails>): ReportWithDetails {
+  return {
+    ...report,
+    ...convertBasicReportDates(report),
+    event: convertEventDates(report.event),
+  }
+}
+
+export function convertEventDates(event: DatesAsStrings<Event>): Event {
   return {
     ...event,
     eventDateAndTime: new Date(event.eventDateAndTime),
     createdAt: new Date(event.createdAt),
     modifiedAt: new Date(event.modifiedAt),
+  }
+}
+
+export function convertEventWithBasicReportsDates(event: DatesAsStrings<EventWithBasicReports>): EventWithBasicReports {
+  return {
+    ...event,
+    ...convertEventDates(event),
     reports: event.reports.map(convertBasicReportDates),
   }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -6,6 +6,7 @@ import HmppsAuthClient from '../data/hmppsAuthClient'
 import RedisTokenStore from '../data/tokenStore/redisTokenStore'
 import { createRedisClient } from '../data/redisClient'
 import { IncidentReportingApi } from '../data/incidentReportingApi'
+import config from '../config'
 
 const hmppsAuthClient = new HmppsAuthClient(new RedisTokenStore(createRedisClient()))
 
@@ -29,6 +30,11 @@ export default function routes(service: Services): Router {
       // eventDateUntil: new Date('2024-07-30'),
       // sort: ['eventDateAndTime,ASC'],
     })
+
+    // No authorisation at this point, no data shown in production
+    if (config.environment === 'prod') {
+      response.content = []
+    }
 
     res.render('pages/events', { response })
   })


### PR DESCRIPTION
Added methods and types to get reports with details (e.g. staff/prisoners involvement, questions, etc...)

**NOTE**: the API has distinct "types" for Questions/Responses and historical ones - possibly because they're baked by different DB tables on the JPA side of things - but their format is the same so the UI types are the same.
This is simpler. We can always introduce more types when/if these will ever diverge.

Types for "enums" values like staff/prisoner roles, prisoner involvement outcome or correction request reasons are still defined as string (although we have a type alias) as they will likely change - we may also _possibly_/maybe move these into the UI from the API. But for now aliases to string will do.