### PR TITLE
IR-365: Show prisoners' names

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,6 +4,7 @@ import auth from './integration_tests/mockApis/auth'
 import incidentReportingApi from './integration_tests/mockApis/incidentReportingApi'
 import frontendComponents from './integration_tests/mockApis/frontendComponents'
 import manageUsersApi from './integration_tests/mockApis/manageUsersApi'
+import offenderSearchApi from './integration_tests/mockApis/offenderSearchApi'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 
 export default defineConfig({
@@ -26,6 +27,7 @@ export default defineConfig({
         ...incidentReportingApi,
         ...auth,
         ...manageUsersApi,
+        ...offenderSearchApi,
         ...tokenVerification,
         ...frontendComponents,
       })

--- a/integration_tests/e2e/health.cy.ts
+++ b/integration_tests/e2e/health.cy.ts
@@ -5,6 +5,7 @@ context('Healthcheck', () => {
       cy.task('stubIncidentReportingApiPing')
       cy.task('stubAuthPing')
       cy.task('stubManageUsersPing')
+      cy.task('stubOffenderSearchApiPing')
       cy.task('stubTokenVerificationPing')
     })
 
@@ -27,6 +28,7 @@ context('Healthcheck', () => {
       cy.task('stubIncidentReportingApiPing')
       cy.task('stubAuthPing')
       cy.task('stubManageUsersPing')
+      cy.task('stubOffenderSearchApiPing')
       cy.task('stubTokenVerificationPing', 500)
     })
 
@@ -35,6 +37,7 @@ context('Healthcheck', () => {
         expect(response.body.components.incidentReportingApi.status).to.equal('UP')
         expect(response.body.components.hmppsAuth.status).to.equal('UP')
         expect(response.body.components.manageUsersApi.status).to.equal('UP')
+        expect(response.body.components.offenderSearchApi.status).to.equal('UP')
         expect(response.body.components.tokenVerification.status).to.equal('DOWN')
         expect(response.body.components.tokenVerification.details).to.contain({ status: 500, retries: 2 })
       })

--- a/integration_tests/mockApis/offenderSearchApi.ts
+++ b/integration_tests/mockApis/offenderSearchApi.ts
@@ -1,0 +1,16 @@
+import type { SuperAgentRequest } from 'superagent'
+
+import { stubFor } from './wiremock'
+
+export default {
+  stubOffenderSearchApiPing: (): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: '/offenderSearchApi/health/ping',
+      },
+      response: {
+        status: 200,
+      },
+    }),
+}

--- a/server/config.ts
+++ b/server/config.ts
@@ -102,6 +102,15 @@ export default {
       },
       agent: new AgentConfig(Number(get('MANAGE_USERS_API_TIMEOUT_RESPONSE', 10000))),
     },
+    offenderSearchApi: {
+      url: get('OFFENDER_SEARCH_API_URL', 'http://localhost:8082', requiredInProduction),
+      externalUrl: get('OFFENDER_SEARCH_API_EXTERNAL_URL', get('OFFENDER_SEARCH_API_URL', 'http://localhost:8082')),
+      timeout: {
+        response: Number(get('OFFENDER_SEARCH_API_TIMEOUT_RESPONSE', 8000)),
+        deadline: Number(get('OFFENDER_SEARCH_API_TIMEOUT_DEADLINE', 8000)),
+      },
+      agent: new AgentConfig(Number(get('OFFENDER_SEARCH_API_TIMEOUT_RESPONSE', 8000))),
+    },
     tokenVerification: {
       url: get('TOKEN_VERIFICATION_API_URL', 'http://localhost:8100', requiredInProduction),
       timeout: {

--- a/server/data/offenderSearchApi.ts
+++ b/server/data/offenderSearchApi.ts
@@ -1,0 +1,30 @@
+import config from '../config'
+import RestClient from './restClient'
+
+export type OffenderSearchPrisoner = {
+  prisonerNumber: string
+  firstName: string
+  lastName: string
+}
+
+export class OffenderSearchApi extends RestClient {
+  constructor(systemToken: string) {
+    super('HMPPS Offender Search API', config.apis.offenderSearchApi, systemToken)
+  }
+
+  async getPrisoners(prisonerNumbers: string[]): Promise<Record<string, OffenderSearchPrisoner>> {
+    if (prisonerNumbers.length === 0) {
+      return {}
+    }
+
+    const prisoners = await this.post<OffenderSearchPrisoner[]>({
+      path: '/prisoner-search/prisoner-numbers',
+      data: {
+        prisonerNumbers,
+      },
+    })
+
+    // Returns the prisoners in an object for easy access
+    return prisoners.reduce((prev, prisonerInfo) => ({ ...prev, [prisonerInfo.prisonerNumber]: prisonerInfo }), {})
+  }
+}

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -49,6 +49,7 @@ const apiChecks = [
   ),
   service('hmppsAuth', `${config.apis.hmppsAuth.url}/health/ping`, config.apis.hmppsAuth.agent),
   service('manageUsersApi', `${config.apis.manageUsersApi.url}/health/ping`, config.apis.manageUsersApi.agent),
+  service('offenderSearchApi', `${config.apis.offenderSearchApi.url}/health/ping`, config.apis.offenderSearchApi.agent),
   ...(config.apis.tokenVerification.enabled
     ? [
         service(

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -7,7 +7,7 @@ import nunjucks from 'nunjucks'
 
 import logger from '../../logger'
 import config from '../config'
-import { initialiseName } from './utils'
+import { convertToTitleCase, initialiseName, nameOfPerson, reversedNameOfPerson } from './utils'
 import format from './format'
 
 export default function nunjucksSetup(app: express.Express): void {
@@ -44,8 +44,13 @@ export default function nunjucksSetup(app: express.Express): void {
     },
   )
 
-  njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addFilter('assetMap', (url: string) => assetManifest[url] || url)
+
+  // name formatting
+  njkEnv.addFilter('convertToTitleCase', convertToTitleCase)
+  njkEnv.addFilter('initialiseName', initialiseName)
+  njkEnv.addFilter('nameOfPerson', nameOfPerson)
+  njkEnv.addFilter('reversedNameOfPerson', reversedNameOfPerson)
 
   // date/datetime formatting
   njkEnv.addFilter('dateAndTime', format.dateAndTime)

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { convertToTitleCase, initialiseName, toDateString } from './utils'
+import { convertToTitleCase, initialiseName, nameOfPerson, reversedNameOfPerson, toDateString } from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -13,6 +13,36 @@ describe('convert to title case', () => {
     ['Hyphenated', 'Robert-John SmiTH-jONes-WILSON', 'Robert-John Smith-Jones-Wilson'],
   ])('%s convertToTitleCase(%s, %s)', (_: string, a: string, expected: string) => {
     expect(convertToTitleCase(a)).toEqual(expected)
+  })
+})
+
+describe('display of prisoner names', () => {
+  const prisoner = {
+    firstName: 'DAVID',
+    lastName: 'JONES',
+  }
+
+  it('normal', () => {
+    expect(nameOfPerson(prisoner)).toEqual('David Jones')
+  })
+
+  it('reversed', () => {
+    expect(reversedNameOfPerson(prisoner)).toEqual('Jones, David')
+  })
+
+  describe.each([
+    { scenario: 'only first name', firstName: 'DAVID', expected: 'David' },
+    { scenario: 'only surname', lastName: 'JONES', expected: 'Jones' },
+  ])('trimming whitespace if $scenario is present', person => {
+    it('normal', () => {
+      expect(nameOfPerson(person as unknown as { firstName: string; lastName: string })).toEqual(person.expected)
+    })
+
+    it('reversed', () => {
+      expect(reversedNameOfPerson(person as unknown as { firstName: string; lastName: string })).toEqual(
+        person.expected,
+      )
+    })
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -14,6 +14,27 @@ const properCaseName = (name: string): string => (isBlank(name) ? '' : name.spli
 export const convertToTitleCase = (sentence: string): string =>
   isBlank(sentence) ? '' : sentence.split(' ').map(properCaseName).join(' ')
 
+/**
+ * Normal display form of a person’s name (often a prisoner)
+ * { "firstName": "DAVID", "lastName": "JONES", … } → "David Jones"
+ */
+export const nameOfPerson = (prisoner: { firstName: string; lastName: string }): string =>
+  `${convertToTitleCase(prisoner.firstName)} ${convertToTitleCase(prisoner.lastName)}`.trim()
+
+/**
+ * Display form of a person’s name (often a prisoner) for lists and tables
+ * { "firstName": "DAVID", "lastName": "JONES", … } → "Jones, David"
+ */
+export const reversedNameOfPerson = (prisoner: { firstName: string; lastName: string }): string => {
+  if (!prisoner.lastName) {
+    return convertToTitleCase(prisoner.firstName)
+  }
+  if (!prisoner.firstName) {
+    return convertToTitleCase(prisoner.lastName)
+  }
+  return `${convertToTitleCase(prisoner.lastName)}, ${convertToTitleCase(prisoner.firstName)}`
+}
+
 export const initialiseName = (fullName?: string): string | null => {
   // this check is for the authError page
   if (!fullName) return null

--- a/server/views/pages/report.njk
+++ b/server/views/pages/report.njk
@@ -75,7 +75,11 @@
       {%- for prisonerInvolved in report.prisonersInvolved -%}
         <li>
           <a href="{{ dpsUrl }}/prisoner/{{ prisonerInvolved.prisonerNumber }}">
-            {{ prisonerInvolved.prisonerNumber }}
+            {% if prisonersLookup[prisonerInvolved.prisonerNumber] %}
+              {{ prisonersLookup[prisonerInvolved.prisonerNumber] | nameOfPerson }}
+            {% else %}
+              {{ prisonerInvolved.prisonerNumber }}
+            {% endif %}
           </a>
           ({{ prisonerInvolved.prisonerRole }}) -
           {% if prisonerInvolved.outcome %}


### PR DESCRIPTION
Use Prisoner Search API's `POST /prisoner-search/prisoner-numbers` endpoint to get the names of the prisoners involved in a report.

Prisoner full names are displayed using the `nameOfPerson` nunjucks filter.
This was copied over from Non-associations with a bunch of related filters.