### PR TITLE
IR-404: Test API clients

### DIFF
--- a/server/@types/index.d.ts
+++ b/server/@types/index.d.ts
@@ -1,13 +1,16 @@
 /**
- * Replaces all Date types with string.
+ * Replaces nested Date types with string (preserving nullability).
  * Needed because api responses over-the-wire are JSON and therefore encode dates as plain strings.
+ * NB: arrays of Date are not supported
  */
 type DatesAsStrings<T> = {
   [k in keyof T]: T[k] extends Array<infer U>
     ? Array<DatesAsStrings<U>>
-    : T[k] extends Date
-      ? string
-      : T[k] extends object
-        ? DatesAsStrings<T[k]>
-        : T[k]
+    : T[k] extends Date | null
+      ? string | null
+      : T[k] extends Date
+        ? string
+        : T[k] extends object
+          ? DatesAsStrings<T[k]>
+          : T[k]
 }

--- a/server/data/incidentReportingApi.test.ts
+++ b/server/data/incidentReportingApi.test.ts
@@ -1,0 +1,136 @@
+import nock from 'nock'
+
+import config from '../config'
+import { IncidentReportingApi } from './incidentReportingApi'
+import { mockEvent, mockReport } from './testData/incidentReporting'
+import { unsortedPageOf } from './testData/paginatedResponses'
+
+jest.mock('./tokenStore/redisTokenStore')
+
+describe('Incident reporting API client', () => {
+  // 2023-12-05T12:34:56.000Z
+  const now = new Date(2023, 11, 5, 12, 34, 56)
+
+  const eventWith1Report = mockEvent({ eventReference: '54322', reportDateAndTime: now, includeReports: 1 })
+  const basicReport = mockReport({ reportReference: '6543', reportDateAndTime: now })
+  const reportWithDetails = mockReport({ reportReference: '6544', reportDateAndTime: now, withDetails: true })
+
+  let fakeApiClient: nock.Scope
+  let apiClient: IncidentReportingApi
+
+  beforeEach(() => {
+    fakeApiClient = nock(config.apis.hmppsIncidentReportingApi.url)
+    apiClient = new IncidentReportingApi('token')
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    nock.cleanAll()
+  })
+
+  describe('conversion of date fields', () => {
+    it('should work for getEvents returning a list of events with reports', async () => {
+      fakeApiClient
+        .get('/incident-events')
+        .query(true)
+        .reply(200, unsortedPageOf([eventWith1Report]))
+      const response = await apiClient.getEvents()
+      const shouldBeDates = response.content.flatMap(item => [
+        item.eventDateAndTime,
+        item.createdAt,
+        item.modifiedAt,
+        item.reports[0].incidentDateAndTime,
+        item.reports[0].reportedAt,
+        item.reports[0].createdAt,
+        item.reports[0].modifiedAt,
+      ])
+      shouldBeDates.forEach(value => expect(value).toBeInstanceOf(Date))
+    })
+
+    it.each([
+      {
+        method: 'getEventById',
+        url: `/incident-events/${eventWith1Report.id}`,
+        testCase: () => apiClient.getEventById(eventWith1Report.id),
+      },
+      {
+        method: 'getEventByReference',
+        url: `/incident-events/reference/${eventWith1Report.eventReference}`,
+        testCase: () => apiClient.getEventByReference(eventWith1Report.eventReference),
+      },
+    ])('should work for $method returning an event with reports', async ({ testCase, url }) => {
+      fakeApiClient.get(url).reply(200, eventWith1Report)
+      const response = await testCase()
+      const shouldBeDates = [
+        response.eventDateAndTime,
+        response.createdAt,
+        response.modifiedAt,
+        response.reports[0].incidentDateAndTime,
+        response.reports[0].reportedAt,
+        response.reports[0].createdAt,
+        response.reports[0].modifiedAt,
+      ]
+      shouldBeDates.forEach(value => expect(value).toBeInstanceOf(Date))
+    })
+
+    it('should work for getReports returning a list of basic reports', async () => {
+      fakeApiClient
+        .get('/incident-reports')
+        .query(true)
+        .reply(200, unsortedPageOf([basicReport]))
+      const response = await apiClient.getReports()
+      const shouldBeDates = response.content.flatMap(item => [
+        item.incidentDateAndTime,
+        item.reportedAt,
+        item.createdAt,
+        item.modifiedAt,
+      ])
+      shouldBeDates.forEach(value => expect(value).toBeInstanceOf(Date))
+    })
+
+    it.each([
+      {
+        method: 'getReportById',
+        url: `/incident-reports/${basicReport.id}`,
+        testCase: () => apiClient.getReportById(basicReport.id),
+      },
+      {
+        method: 'getReportByReference',
+        url: `/incident-reports/reference/${basicReport.reportReference}`,
+        testCase: () => apiClient.getReportByReference(basicReport.reportReference),
+      },
+    ])('should work for $method returning a basic report', async ({ testCase, url }) => {
+      fakeApiClient.get(url).reply(200, basicReport)
+      const response = await testCase()
+      const shouldBeDates = [response.incidentDateAndTime, response.reportedAt, response.createdAt, response.modifiedAt]
+      shouldBeDates.forEach(value => expect(value).toBeInstanceOf(Date))
+    })
+
+    it.each([
+      {
+        method: 'getReportWithDetailsById',
+        url: `/incident-reports/${reportWithDetails.id}/with-details`,
+        testCase: () => apiClient.getReportWithDetailsById(reportWithDetails.id),
+      },
+      {
+        method: 'getReportWithDetailsByReference',
+        url: `/incident-reports/reference/${reportWithDetails.reportReference}/with-details`,
+        testCase: () => apiClient.getReportWithDetailsByReference(reportWithDetails.reportReference),
+      },
+    ])('should work for $method returning a basic report', async ({ testCase, url }) => {
+      fakeApiClient.get(url).reply(200, reportWithDetails)
+      const response = await testCase()
+      const shouldBeDates = [
+        response.incidentDateAndTime,
+        response.reportedAt,
+        response.createdAt,
+        response.modifiedAt,
+        response.event.eventDateAndTime,
+        response.event.createdAt,
+        response.event.modifiedAt,
+        // NB: other children are checked in incidentReportingApiUtils.test.ts
+      ]
+      shouldBeDates.forEach(value => expect(value).toBeInstanceOf(Date))
+    })
+  })
+})

--- a/server/data/incidentReportingApi.test.ts
+++ b/server/data/incidentReportingApi.test.ts
@@ -1,8 +1,8 @@
 import nock from 'nock'
 
 import config from '../config'
-import { IncidentReportingApi } from './incidentReportingApi'
-import { mockEvent, mockReport } from './testData/incidentReporting'
+import { ErrorCode, IncidentReportingApi, isErrorResponse } from './incidentReportingApi'
+import { mockErrorResponse, mockEvent, mockReport } from './testData/incidentReporting'
 import { unsortedPageOf } from './testData/paginatedResponses'
 
 jest.mock('./tokenStore/redisTokenStore')
@@ -26,6 +26,16 @@ describe('Incident reporting API client', () => {
   afterEach(() => {
     jest.resetAllMocks()
     nock.cleanAll()
+  })
+
+  describe('error handling', () => {
+    it('should recognise error responses from the api', async () => {
+      const badRequest = mockErrorResponse({
+        message: 'Inactive incident type OLD_FINDS4',
+        errorCode: ErrorCode.ValidationFailure,
+      })
+      expect(isErrorResponse(badRequest)).toBe(true)
+    })
   })
 
   describe('conversion of date fields', () => {

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -139,9 +139,10 @@ export type Question = {
 
 export type Response = {
   response: string
+  // recordedDate: Date | null // TODO: DatesAsStrings does not work on optional dates
+  additionalInformation: string | null
   recordedBy: string
   recordedAt: Date
-  additionalInformation: string | null
 }
 
 export type HistoricReport = {

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -139,7 +139,7 @@ export type Question = {
 
 export type Response = {
   response: string
-  // recordedDate: Date | null // TODO: DatesAsStrings does not work on optional dates
+  responseDate: Date | null
   additionalInformation: string | null
   recordedBy: string
   recordedAt: Date

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line max-classes-per-file
 import config from '../config'
 import format from '../utils/format'
 import {
@@ -9,23 +8,35 @@ import {
 import RestClient from './restClient'
 
 /**
- * Structure representing an error response from the incentives api
+ * Structure representing an error response from the incident reporting api
+ *
+ * Defined in uk.gov.justice.digital.hmpps.incidentreporting.resource.ErrorResponse class
+ * see https://github.com/ministryofjustice/hmpps-incident-reporting-api
  */
-export class ErrorResponse {
+export interface ErrorResponse {
   status: number
-
-  errorCode?: number
-
-  userMessage?: string
-
-  developerMessage?: string
-
+  errorCode?: ErrorCode
+  userMessage: string
+  developerMessage: string
   moreInfo?: string
+}
 
-  static isErrorResponse(obj: object): obj is ErrorResponse {
-    // TODO: would be nice to make userMessage & developerMessage non-nullable in the api
-    return obj && 'status' in obj && typeof obj.status === 'number'
-  }
+export function isErrorResponse(obj: unknown): obj is ErrorResponse {
+  // TODO: would be nice to make userMessage & developerMessage non-nullable in the api
+  return typeof obj === 'object' && 'status' in obj && typeof obj.status === 'number' && 'userMessage' in obj
+}
+
+/**
+ * Unique codes to discriminate errors returned from the incident reporting api
+ *
+ * Defined in uuk.gov.justice.digital.hmpps.incidentreporting.resource.ErrorCode enumeration
+ * see https://github.com/ministryofjustice/hmpps-incident-reporting-api
+ */
+export enum ErrorCode {
+  ValidationFailure = 100,
+  EventNotFound = 201,
+  ReportNotFound = 301,
+  ReportAlreadyExists = 302,
 }
 
 export const defaultPageSize = 20

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -28,7 +28,9 @@ export class ErrorResponse {
   }
 }
 
-export type Paginated<T> = {
+export const defaultPageSize = 20
+
+export interface Page<T> {
   /** Elements in this pages */
   content: T[]
   /** Page number (0-based) */
@@ -45,8 +47,8 @@ export type Paginated<T> = {
   sort: string[]
 }
 
-export type PaginatedEventsWithBasicReports = Paginated<EventWithBasicReports>
-export type PaginatedBasicReports = Paginated<ReportBasic>
+export type PaginatedEventsWithBasicReports = Page<EventWithBasicReports>
+export type PaginatedBasicReports = Page<ReportBasic>
 
 export type Event = {
   id: string
@@ -189,7 +191,7 @@ export class IncidentReportingApi extends RestClient {
       eventDateFrom: null,
       eventDateUntil: null,
       page: 0,
-      size: 20,
+      size: defaultPageSize,
       sort: ['eventDateAndTime,DESC'],
     },
   ): Promise<PaginatedEventsWithBasicReports> {
@@ -254,7 +256,7 @@ export class IncidentReportingApi extends RestClient {
       reportedDateFrom: null,
       reportedDateUntil: null,
       page: 0,
-      size: 20,
+      size: defaultPageSize,
       sort: ['incidentDateAndTime,DESC'],
     },
   ): Promise<PaginatedBasicReports> {

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
 import config from '../config'
-import { toDateString } from '../utils/utils'
+import format from '../utils/format'
 import {
   convertBasicReportDates,
   convertEventWithBasicReportsDates,
@@ -202,10 +202,10 @@ export class IncidentReportingApi extends RestClient {
       query.prisonId = prisonId
     }
     if (eventDateFrom) {
-      query.eventDateFrom = toDateString(eventDateFrom)
+      query.eventDateFrom = format.isoDate(eventDateFrom)
     }
     if (eventDateUntil) {
-      query.eventDateUntil = toDateString(eventDateUntil)
+      query.eventDateUntil = format.isoDate(eventDateUntil)
     }
 
     return this.get<DatesAsStrings<PaginatedEventsWithBasicReports>>({
@@ -276,16 +276,16 @@ export class IncidentReportingApi extends RestClient {
       query.type = type
     }
     if (incidentDateFrom) {
-      query.incidentDateFrom = toDateString(incidentDateFrom)
+      query.incidentDateFrom = format.isoDate(incidentDateFrom)
     }
     if (incidentDateUntil) {
-      query.incidentDateUntil = toDateString(incidentDateUntil)
+      query.incidentDateUntil = format.isoDate(incidentDateUntil)
     }
     if (reportedDateFrom) {
-      query.reportedDateFrom = toDateString(reportedDateFrom)
+      query.reportedDateFrom = format.isoDate(reportedDateFrom)
     }
     if (reportedDateUntil) {
-      query.reportedDateUntil = toDateString(reportedDateUntil)
+      query.reportedDateUntil = format.isoDate(reportedDateUntil)
     }
 
     return this.get<DatesAsStrings<PaginatedBasicReports>>({

--- a/server/data/incidentReportingApiUtils.test.ts
+++ b/server/data/incidentReportingApiUtils.test.ts
@@ -40,6 +40,7 @@ describe('Parsing dates in incident-reporting API responses', () => {
   }
 
   function expectCorrectDatesInResponse(response: Response) {
+    expect(response.responseDate).toEqual(reportDateAndTime)
     expect(response.recordedAt).toEqual(reportDateAndTime)
   }
 

--- a/server/data/incidentReportingApiUtils.test.ts
+++ b/server/data/incidentReportingApiUtils.test.ts
@@ -1,22 +1,46 @@
+import type { Event, ReportBasic } from './incidentReportingApi'
 import { mockEvent, mockBasicReport } from './testData/incidentReporting'
-import { convertEventDates, convertBasicReportDates } from './incidentReportingApiUtils'
+import {
+  convertEventDates,
+  convertEventWithBasicReportsDates,
+  convertBasicReportDates,
+} from './incidentReportingApiUtils'
 
 describe('Parsing dates in incident-reporting API responses', () => {
-  const reportDateAndTime = new Date(2023, 11, 5, 12, 34, 56) // 2023-12-05T12:34:56.000Z
-  const eventDateAndTime = new Date(2023, 11, 5, 11, 34, 56) // 2023-12-05T11:34:56.000Z
+  // now, when incident was reported: 2023-12-05T12:34:56.000Z
+  const reportDateAndTime = new Date(2023, 11, 5, 12, 34, 56)
+  // actual incident happened 1 hour before: 2023-12-05T11:34:56.000Z
+  const incidentDateAndTime = new Date(2023, 11, 5, 11, 34, 56)
+
+  function expectCorrectDatesInEvent(event: Event) {
+    expect(event.eventDateAndTime).toEqual(incidentDateAndTime)
+    expect(event.createdAt).toEqual(reportDateAndTime)
+    expect(event.modifiedAt).toEqual(reportDateAndTime)
+  }
+
+  function expectCorrectDatesInBasicReport(basicReport: ReportBasic) {
+    expect(basicReport.incidentDateAndTime).toEqual(incidentDateAndTime)
+    expect(basicReport.reportedAt).toEqual(reportDateAndTime)
+    expect(basicReport.createdAt).toEqual(reportDateAndTime)
+    expect(basicReport.modifiedAt).toEqual(reportDateAndTime)
+  }
 
   it('should work for an event', () => {
-    const event = convertEventDates(mockEvent({ eventReference: '12345', eventDateAndTime }))
-    expect(event.eventDateAndTime).toEqual(eventDateAndTime)
-    expect(event.createdAt).toEqual(eventDateAndTime)
-    expect(event.modifiedAt).toEqual(eventDateAndTime)
+    const event = convertEventDates(mockEvent({ eventReference: '12345', reportDateAndTime }))
+    expectCorrectDatesInEvent(event)
+  })
+
+  it('should work for an event containing reports with basic details', () => {
+    const eventWithDetails = convertEventWithBasicReportsDates(
+      mockEvent({ eventReference: '12345', reportDateAndTime, includeReports: 2 }),
+    )
+    expectCorrectDatesInEvent(eventWithDetails)
+    expect(eventWithDetails.reports).toHaveLength(2)
+    eventWithDetails.reports.forEach(expectCorrectDatesInBasicReport)
   })
 
   it('should work for a report with basic details', () => {
     const basicReport = convertBasicReportDates(mockBasicReport({ reportReference: '4321', reportDateAndTime }))
-    expect(basicReport.incidentDateAndTime).toEqual(eventDateAndTime)
-    expect(basicReport.reportedAt).toEqual(reportDateAndTime)
-    expect(basicReport.createdAt).toEqual(reportDateAndTime)
-    expect(basicReport.modifiedAt).toEqual(reportDateAndTime)
+    expectCorrectDatesInBasicReport(basicReport)
   })
 })

--- a/server/data/incidentReportingApiUtils.test.ts
+++ b/server/data/incidentReportingApiUtils.test.ts
@@ -40,7 +40,12 @@ describe('Parsing dates in incident-reporting API responses', () => {
   }
 
   function expectCorrectDatesInResponse(response: Response) {
-    expect(response.responseDate).toEqual(reportDateAndTime)
+    expect(response).toHaveProperty('responseDate')
+    if (response.responseDate) {
+      expect(response.responseDate).toEqual(reportDateAndTime)
+    } else {
+      expect(response.responseDate).toBeNull()
+    }
     expect(response.recordedAt).toEqual(reportDateAndTime)
   }
 

--- a/server/data/incidentReportingApiUtils.test.ts
+++ b/server/data/incidentReportingApiUtils.test.ts
@@ -1,0 +1,22 @@
+import { mockEvent, mockBasicReport } from './testData/incidentReporting'
+import { convertEventDates, convertBasicReportDates } from './incidentReportingApiUtils'
+
+describe('Parsing dates in incident-reporting API responses', () => {
+  const reportDateAndTime = new Date(2023, 11, 5, 12, 34, 56) // 2023-12-05T12:34:56.000Z
+  const eventDateAndTime = new Date(2023, 11, 5, 11, 34, 56) // 2023-12-05T11:34:56.000Z
+
+  it('should work for an event', () => {
+    const event = convertEventDates(mockEvent({ eventReference: '12345', eventDateAndTime }))
+    expect(event.eventDateAndTime).toEqual(eventDateAndTime)
+    expect(event.createdAt).toEqual(eventDateAndTime)
+    expect(event.modifiedAt).toEqual(eventDateAndTime)
+  })
+
+  it('should work for a report with basic details', () => {
+    const basicReport = convertBasicReportDates(mockBasicReport({ reportReference: '4321', reportDateAndTime }))
+    expect(basicReport.incidentDateAndTime).toEqual(eventDateAndTime)
+    expect(basicReport.reportedAt).toEqual(reportDateAndTime)
+    expect(basicReport.createdAt).toEqual(reportDateAndTime)
+    expect(basicReport.modifiedAt).toEqual(reportDateAndTime)
+  })
+})

--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -48,21 +48,21 @@ export function convertEventWithBasicReportsDates(event: DatesAsStrings<EventWit
   }
 }
 
-export function convertQuestionDates(question: DatesAsStrings<Question>): Question {
+function convertQuestionDates(question: DatesAsStrings<Question>): Question {
   return {
     ...question,
     responses: question.responses.map(convertResponseDates),
   }
 }
 
-export function convertResponseDates(response: DatesAsStrings<Response>): Response {
+function convertResponseDates(response: DatesAsStrings<Response>): Response {
   return {
     ...response,
     recordedAt: new Date(response.recordedAt),
   }
 }
 
-export function convertHistoricReportDates(historicReport: DatesAsStrings<HistoricReport>): HistoricReport {
+function convertHistoricReportDates(historicReport: DatesAsStrings<HistoricReport>): HistoricReport {
   return {
     ...historicReport,
     changedAt: new Date(historicReport.changedAt),
@@ -70,14 +70,14 @@ export function convertHistoricReportDates(historicReport: DatesAsStrings<Histor
   }
 }
 
-export function convertHistoricStatusDates(historicStatus: DatesAsStrings<HistoricStatus>): HistoricStatus {
+function convertHistoricStatusDates(historicStatus: DatesAsStrings<HistoricStatus>): HistoricStatus {
   return {
     ...historicStatus,
     changedAt: new Date(historicStatus.changedAt),
   }
 }
 
-export function convertCorrectionRequestDates(correctionRequest: DatesAsStrings<CorrectionRequest>): CorrectionRequest {
+function convertCorrectionRequestDates(correctionRequest: DatesAsStrings<CorrectionRequest>): CorrectionRequest {
   return {
     ...correctionRequest,
     correctionRequestedAt: new Date(correctionRequest.correctionRequestedAt),

--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -58,6 +58,7 @@ function convertQuestionDates(question: DatesAsStrings<Question>): Question {
 function convertResponseDates(response: DatesAsStrings<Response>): Response {
   return {
     ...response,
+    responseDate: response.responseDate && new Date(response.responseDate),
     recordedAt: new Date(response.recordedAt),
   }
 }

--- a/server/data/offenderSearchApi.test.ts
+++ b/server/data/offenderSearchApi.test.ts
@@ -1,0 +1,67 @@
+import nock from 'nock'
+
+import config from '../config'
+import { OffenderSearchApi, type OffenderSearchPrisoner } from './offenderSearchApi'
+
+jest.mock('./tokenStore/redisTokenStore')
+
+describe('offenderSearchApi', () => {
+  let fakeApiClient: nock.Scope
+  let apiClient: OffenderSearchApi
+
+  beforeEach(() => {
+    fakeApiClient = nock(config.apis.offenderSearchApi.url)
+    apiClient = new OffenderSearchApi('token')
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    nock.cleanAll()
+  })
+
+  describe('getPrisoners', () => {
+    it('should de-duplicate prisoner numbers', () => {
+      fakeApiClient.post('/prisoner-search/prisoner-numbers').reply(200, (_uri, requestBody) => {
+        const request = requestBody as { prisonerNumbers: string[] }
+        expect(request.prisonerNumbers).toHaveLength(3)
+        const response: OffenderSearchPrisoner[] = [
+          {
+            prisonerNumber: 'A3333CC',
+            firstName: 'DAVID',
+            lastName: 'JONES',
+          },
+          {
+            prisonerNumber: 'A2222BB',
+            firstName: 'FRED',
+            lastName: 'MILLS',
+          },
+          {
+            prisonerNumber: 'A1111AA',
+            firstName: 'ANDREW',
+            lastName: 'BROWN',
+          },
+        ]
+        return response
+      })
+
+      const responseFuture = apiClient.getPrisoners(['A1111AA', 'A2222BB', 'A1111AA', 'A3333CC'])
+      expect(responseFuture).resolves.toEqual({
+        A1111AA: {
+          prisonerNumber: 'A1111AA',
+          firstName: 'ANDREW',
+          lastName: 'BROWN',
+        },
+        A2222BB: {
+          prisonerNumber: 'A2222BB',
+          firstName: 'FRED',
+          lastName: 'MILLS',
+        },
+        A3333CC: {
+          prisonerNumber: 'A3333CC',
+          firstName: 'DAVID',
+          lastName: 'JONES',
+        },
+      })
+    })
+  })
+})

--- a/server/data/offenderSearchApi.test.ts
+++ b/server/data/offenderSearchApi.test.ts
@@ -1,7 +1,8 @@
 import nock from 'nock'
 
 import config from '../config'
-import { OffenderSearchApi, type OffenderSearchPrisoner } from './offenderSearchApi'
+import { OffenderSearchApi } from './offenderSearchApi'
+import { andrew, barry, chris } from './testData/offenderSearch'
 
 jest.mock('./tokenStore/redisTokenStore')
 
@@ -20,47 +21,18 @@ describe('offenderSearchApi', () => {
   })
 
   describe('getPrisoners', () => {
-    it('should de-duplicate prisoner numbers', () => {
+    it('should de-duplicate input prisoner numbers', () => {
       fakeApiClient.post('/prisoner-search/prisoner-numbers').reply(200, (_uri, requestBody) => {
         const request = requestBody as { prisonerNumbers: string[] }
         expect(request.prisonerNumbers).toHaveLength(3)
-        const response: OffenderSearchPrisoner[] = [
-          {
-            prisonerNumber: 'A3333CC',
-            firstName: 'DAVID',
-            lastName: 'JONES',
-          },
-          {
-            prisonerNumber: 'A2222BB',
-            firstName: 'FRED',
-            lastName: 'MILLS',
-          },
-          {
-            prisonerNumber: 'A1111AA',
-            firstName: 'ANDREW',
-            lastName: 'BROWN',
-          },
-        ]
-        return response
+        return [chris, barry, andrew]
       })
 
       const responseFuture = apiClient.getPrisoners(['A1111AA', 'A2222BB', 'A1111AA', 'A3333CC'])
       expect(responseFuture).resolves.toEqual({
-        A1111AA: {
-          prisonerNumber: 'A1111AA',
-          firstName: 'ANDREW',
-          lastName: 'BROWN',
-        },
-        A2222BB: {
-          prisonerNumber: 'A2222BB',
-          firstName: 'FRED',
-          lastName: 'MILLS',
-        },
-        A3333CC: {
-          prisonerNumber: 'A3333CC',
-          firstName: 'DAVID',
-          lastName: 'JONES',
-        },
+        A1111AA: andrew,
+        A2222BB: barry,
+        A3333CC: chris,
       })
     })
   })

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -1,7 +1,14 @@
 import { v7 as uuidFromDate } from 'uuid'
 
 import { buildArray } from '../../utils/utils'
-import type { Event, EventWithBasicReports, ReportBasic, ReportWithDetails } from '../incidentReportingApi'
+import {
+  ErrorCode,
+  ErrorResponse,
+  Event,
+  EventWithBasicReports,
+  ReportBasic,
+  ReportWithDetails,
+} from '../incidentReportingApi'
 
 interface MockEventConfig {
   eventReference: string
@@ -167,4 +174,25 @@ export function mockReport({
   }
 
   return basicReport
+}
+
+/**
+ * Build an object that is returned by the api (as JSON) in case of errors.
+ * Used only in testing.
+ */
+export function mockErrorResponse({
+  message,
+  status = 400,
+  errorCode,
+}: {
+  message: string
+  status?: number
+  errorCode?: ErrorCode
+}): ErrorResponse {
+  return {
+    status,
+    developerMessage: message,
+    userMessage: message, // in practice, the messages differ but are not shown directly to users anyway
+    errorCode,
+  }
 }

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -1,0 +1,65 @@
+import { v7 as uuidFromDate } from 'uuid'
+
+import type { Event, ReportBasic } from '../incidentReportingApi'
+
+export function mockEvent({
+  eventReference,
+  eventDateAndTime,
+  prisonId = 'MDI',
+  reportingUsername = 'USER1',
+}: {
+  eventReference: string
+  eventDateAndTime: Date
+  prisonId?: string
+  reportingUsername?: string
+}): DatesAsStrings<Event> {
+  return {
+    id: uuidFromDate({ msecs: eventDateAndTime }),
+    eventReference,
+    eventDateAndTime: eventDateAndTime.toISOString(),
+    prisonId,
+    title: 'An event occurred',
+    description: 'Details of the event',
+    createdAt: eventDateAndTime.toISOString(),
+    modifiedAt: eventDateAndTime.toISOString(),
+    modifiedBy: reportingUsername,
+  }
+}
+
+export function mockBasicReport({
+  reportReference,
+  reportDateAndTime,
+  prisonId = 'MDI',
+  createdInNomis = false,
+  status = 'DRAFT',
+  type = 'FINDS',
+  reportingUsername = 'USER1',
+}: {
+  reportReference: string
+  reportDateAndTime: Date
+  prisonId?: string
+  createdInNomis?: boolean
+  status?: string
+  type?: string
+  reportingUsername?: string
+}): DatesAsStrings<ReportBasic> {
+  const incidentDateAndTime = new Date(reportDateAndTime)
+  incidentDateAndTime.setHours(incidentDateAndTime.getHours() - 1)
+  return {
+    id: uuidFromDate({ msecs: reportDateAndTime }),
+    reportReference,
+    type,
+    incidentDateAndTime: incidentDateAndTime.toISOString(),
+    prisonId,
+    title: `Incident Report ${reportReference}`,
+    description: `A new incident created in the new service of type ${type}`,
+    reportedBy: reportingUsername,
+    reportedAt: reportDateAndTime.toISOString(),
+    status,
+    assignedTo: reportingUsername,
+    createdAt: reportDateAndTime.toISOString(),
+    modifiedAt: reportDateAndTime.toISOString(),
+    modifiedBy: reportingUsername,
+    createdInNomis,
+  }
+}

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -1,5 +1,6 @@
 import { v7 as uuidFromDate } from 'uuid'
 
+import { buildArray } from '../../utils/utils'
 import type { Event, EventWithBasicReports, ReportBasic, ReportWithDetails } from '../incidentReportingApi'
 
 interface MockEventConfig {
@@ -36,7 +37,7 @@ export function mockEvent({
   if (includeReports > 0) {
     return {
       ...event,
-      reports: Array(includeReports).map((_, i) =>
+      reports: buildArray(includeReports, i =>
         mockReport({ reportReference: (10000 + i).toString(), reportDateAndTime }),
       ),
     } satisfies DatesAsStrings<EventWithBasicReports>
@@ -133,11 +134,11 @@ export function mockReport({
           correctionRequestedAt: reportDateAndTime.toISOString(),
         },
       ],
-      questions: Array(2).map((_q, questionIndex) => ({
+      questions: buildArray(2, questionIndex => ({
         code: `QID-${(questionIndex + 1).toString().padStart(12, '0')}`,
         question: `Question #${questionIndex + 1}`,
         additionalInformation: `Explanation #${questionIndex + 1}`,
-        responses: Array(2).map((_r, responseIndex) => ({
+        responses: buildArray(2, responseIndex => ({
           response: `Response #${responseIndex + 1}`,
           responseDate: reportDateAndTime.toISOString(),
           recordedBy: 'some-user',
@@ -145,15 +146,15 @@ export function mockReport({
           additionalInformation: `comment #${responseIndex + 1}`,
         })),
       })),
-      history: Array(2).map(() => ({
+      history: buildArray(2, () => ({
         type: 'MISCELLANEOUS',
         changedAt: reportDateAndTime.toISOString(),
         changedBy: 'some-user-2',
-        questions: Array(2).map((_q, questionIndex) => ({
+        questions: buildArray(2, questionIndex => ({
           code: `QID-${(questionIndex + 1).toString().padStart(12, '0')}`,
           question: `Historic question #${questionIndex + 1}`,
           additionalInformation: '',
-          responses: Array(2).map((_r, responseIndex) => ({
+          responses: buildArray(2, responseIndex => ({
             response: `Historic response #${responseIndex + 1}`,
             responseDate: reportDateAndTime.toISOString(),
             additionalInformation: `Historic comment #${responseIndex + 1}`,

--- a/server/data/testData/offenderSearch.ts
+++ b/server/data/testData/offenderSearch.ts
@@ -1,0 +1,19 @@
+import { type OffenderSearchPrisoner } from '../offenderSearchApi'
+
+export const andrew: OffenderSearchPrisoner = {
+  prisonerNumber: 'A1111AA',
+  firstName: 'ANDREW',
+  lastName: 'ARNOLD',
+}
+
+export const barry: OffenderSearchPrisoner = {
+  prisonerNumber: 'A2222BB',
+  firstName: 'BARRY',
+  lastName: 'BENJAMIN',
+}
+
+export const chris: OffenderSearchPrisoner = {
+  prisonerNumber: 'A3333CC',
+  firstName: 'CHRIS',
+  lastName: 'COOPER',
+}

--- a/server/data/testData/paginatedResponses.ts
+++ b/server/data/testData/paginatedResponses.ts
@@ -1,0 +1,18 @@
+import { defaultPageSize, type Page } from '../incidentReportingApi'
+
+/**
+ * Build a 1-page response of unsorted items.
+ * Used only in testing
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function unsortedPageOf<T>(content: T[]): Page<T> {
+  return {
+    content,
+    number: 0,
+    size: defaultPageSize,
+    numberOfElements: content.length,
+    totalElements: content.length,
+    totalPages: 1,
+    sort: [],
+  }
+}

--- a/server/data/testData/paginatedResponses.ts
+++ b/server/data/testData/paginatedResponses.ts
@@ -2,7 +2,7 @@ import { defaultPageSize, type Page } from '../incidentReportingApi'
 
 /**
  * Build a 1-page response of unsorted items.
- * Used only in testing
+ * Used only in testing.
  */
 // eslint-disable-next-line import/prefer-default-export
 export function unsortedPageOf<T>(content: T[]): Page<T> {

--- a/server/data/testData/thrownErrors.ts
+++ b/server/data/testData/thrownErrors.ts
@@ -1,0 +1,17 @@
+import type { SanitisedError } from '../../sanitisedError'
+
+/**
+ * Build an object mimicking a sanitised Error thrown by an api client in case of unsuccessful response.
+ * Used only in mocks.
+ *
+ * NB: some fields are omitted, in reality these are built out of superagent.ResponseError
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function mockThrownError<T>(responseBody: T, status: number = 400): SanitisedError<T> {
+  const error = new Error(`Error ${status}`) as SanitisedError<T>
+  error.status = status
+  error.headers = {}
+  error.data = responseBody
+  error.text = responseBody.toString()
+  return error
+}

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -1,5 +1,8 @@
 import type { ResponseError } from 'superagent'
 
+/**
+ * An error that may be safe to log as it omits sensitive request headers
+ */
 export interface SanitisedError<Data = unknown> extends Error {
   text?: string
   status?: number
@@ -9,8 +12,15 @@ export interface SanitisedError<Data = unknown> extends Error {
   message: string
 }
 
+/**
+ * An error as returned by superagemt, contains sensitive request headers
+ */
 export type UnsanitisedError = ResponseError
 
+/**
+ * Converts an UnsanitisedError (superagent.ResponseError) into a simpler Error object,
+ * omitting request inforation (e.g. sensitive request headers)
+ */
 export default function sanitise(error: UnsanitisedError): SanitisedError {
   const e = new Error() as SanitisedError
   e.message = error.message

--- a/server/utils/format.test.ts
+++ b/server/utils/format.test.ts
@@ -95,3 +95,17 @@ describe('shortDate(): Format shorts dates as Europe/London ignoring time-of-day
     expect(format.shortDate(undefined)).toEqual('')
   })
 })
+
+describe('isoDate(): Formats dates in ISO style, used when calling APIs', () => {
+  it.each([
+    ['2024-07-30T12:34:56', '2024-07-30'],
+    ['2024-07-30T12:34:56Z', '2024-07-30'],
+    ['2024-07-30T12:34:56+01:00', '2024-07-30'],
+  ])('new Date(%s) formats as %s in ISO date style', (date, expected) => {
+    expect(format.isoDate(new Date(date))).toEqual(expected)
+  })
+
+  it.each([null, undefined])('preserves %s', input => {
+    expect(format.isoDate(input)).toEqual(input)
+  })
+})

--- a/server/utils/format.ts
+++ b/server/utils/format.ts
@@ -1,4 +1,9 @@
 export default {
+  /**
+   * Format Date as Europe/London including time of day
+   *
+   * Example: `22 February 2022, 11:00`
+   */
   dateAndTime(date: Date): string {
     if (typeof date === 'undefined' || date === null) {
       return ''
@@ -15,6 +20,11 @@ export default {
     return formatted.replace(' at ', ', ')
   },
 
+  /**
+   * Format Date as Europe/London ignoring time-of-day
+   *
+   * Example: `22 February 2022`
+   */
   date(date: Date): string {
     if (typeof date === 'undefined' || date === null) {
       return ''
@@ -27,6 +37,11 @@ export default {
     })
   },
 
+  /**
+   * Format Date as Europe/London ignoring time-of-day
+   *
+   * Example: `22/02/2022`
+   */
   shortDate(date: Date): string {
     if (typeof date === 'undefined' || date === null) {
       return ''
@@ -37,5 +52,14 @@ export default {
       year: 'numeric',
       timeZone: 'Europe/London',
     })
+  },
+
+  /**
+   * Formats dates in ISO style, used when calling APIs
+   *
+   * Example: `2024-07-30`
+   */
+  isoDate(date: Date): string {
+    return date && date.toISOString().split('T')[0]
   },
 }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,11 @@
-import { convertToTitleCase, initialiseName, nameOfPerson, reversedNameOfPerson, toDateString } from './utils'
+import {
+  buildArray,
+  convertToTitleCase,
+  initialiseName,
+  nameOfPerson,
+  reversedNameOfPerson,
+  toDateString,
+} from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -63,5 +70,23 @@ describe('toDateString()', () => {
   it('returns a string representing the date component of the Date', () => {
     const datetime = new Date('2024-07-30T12:34:56')
     expect(toDateString(datetime)).toEqual('2024-07-30')
+  })
+})
+
+describe('buildArray()', () => {
+  type Scenario = {
+    scenario: string
+    input: { length: number; builder: (index: number) => unknown }
+    expected: unknown[]
+  }
+  const scenarios: Scenario[] = [
+    { scenario: 'empty', input: { length: 0, builder: () => 0 }, expected: [] },
+    { scenario: 'empty', input: { length: 1, builder: (index: number) => index }, expected: [0] },
+    { scenario: 'empty', input: { length: 3, builder: (index: number) => `${index}` }, expected: ['0', '1', '2'] },
+  ]
+  it.each(scenarios)('should work with $scenario', ({ input: { length, builder }, expected }) => {
+    const result = buildArray(length, builder)
+    expect(result).toHaveLength(expected.length)
+    expect(result).toEqual(expected)
   })
 })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,11 +1,4 @@
-import {
-  buildArray,
-  convertToTitleCase,
-  initialiseName,
-  nameOfPerson,
-  reversedNameOfPerson,
-  toDateString,
-} from './utils'
+import { buildArray, convertToTitleCase, initialiseName, nameOfPerson, reversedNameOfPerson } from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -63,13 +56,6 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
-  })
-})
-
-describe('toDateString()', () => {
-  it('returns a string representing the date component of the Date', () => {
-    const datetime = new Date('2024-07-30T12:34:56')
-    expect(toDateString(datetime)).toEqual('2024-07-30')
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -43,10 +43,6 @@ export const initialiseName = (fullName?: string): string | null => {
   return `${array[0][0]}. ${array.reverse()[0]}`
 }
 
-export function toDateString(date: Date): string {
-  return date.toISOString().split('T')[0]
-}
-
 export function buildArray<T>(length: number, builder: (index: number) => T): T[] {
   const array = Array(length)
   for (let index = 0; index < length; index += 1) {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -46,3 +46,11 @@ export const initialiseName = (fullName?: string): string | null => {
 export function toDateString(date: Date): string {
   return date.toISOString().split('T')[0]
 }
+
+export function buildArray<T>(length: number, builder: (index: number) => T): T[] {
+  const array = Array(length)
+  for (let index = 0; index < length; index += 1) {
+    array[index] = builder(index)
+  }
+  return array
+}


### PR DESCRIPTION
We only have debugging routes/views at present and little of their code is likely to remain in future.

The incident-reporting API client, however, will still be around so ought to have some tests!
As part of this, there is some test event and report generation being added – these will prove necessary for mocking out the API.