### PR TITLE
IR-421: Send alerts to our dev channel

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -26,5 +26,5 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-incident-reporting-dev
   businessHoursOnly: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,5 +24,5 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-incident-reporting-preprod
   businessHoursOnly: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -19,4 +19,4 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service
+  alertSeverity: hmpps-incident-reporting-prod


### PR DESCRIPTION
Use alertSeverity provided by CP team.
These would send alerts to the
`#incident-reporting-service-dev` Slack channel.