### PR TITLE
IR-431: Add variable to allow removing the TLS requirement in “production” mode

### DIFF
--- a/local.env
+++ b/local.env
@@ -2,6 +2,7 @@ PRODUCT_ID=DPS021
 ENVIRONMENT=local
 
 INGRESS_URL=http://localhost:3000
+NO_HTTPS=true
 REDIS_HOST=localhost
 REDIS_ENABLED=true
 SESSION_SECRET=somesecretvalue

--- a/server/config.ts
+++ b/server/config.ts
@@ -54,8 +54,8 @@ export default {
   gitRef: get('GIT_REF', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),
   branchName: get('GIT_BRANCH', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),
   environment: process.env.ENVIRONMENT || 'local',
-  production, // NB: this is true in _all_ deployed environments
-  https: production,
+  production, // NB: this is true in _all_ deployed environments and when running locally in docker
+  https: process.env.NO_HTTPS === 'true' ? false : production,
   staticResourceCacheDuration: '1h',
   redis: {
     enabled: get('REDIS_ENABLED', 'false', requiredInProduction) === 'true',


### PR DESCRIPTION
The “production” flag does not have a clear meaning, but enforced TLS. When the app is run fully in docker locally, it meant that TLS was required and therefore authentication could not function.