### PR TITLE
IR-527: Use non-deprecated endpoint to load DPS micro-frontend components

### DIFF
--- a/integration_tests/mockApis/frontendComponents.ts
+++ b/integration_tests/mockApis/frontendComponents.ts
@@ -1,17 +1,21 @@
 import type { Response } from 'superagent'
 
 import { stubFor } from './wiremock'
-import type { Component, AvailableComponent } from '../../server/data/frontendComponentsClient'
+import type { AvailableComponent, Component } from '../../server/data/frontendComponentsClient'
+import { mockFrontendComponentResponse } from '../../server/data/testData/frontendComponents'
 
-const stubComponent = (name: AvailableComponent, component: Component): Promise<Response> =>
+const stubComponents = (components: Partial<Record<AvailableComponent, Component>> = {}): Promise<Response> =>
   stubFor({
     request: {
       method: 'GET',
-      urlPath: `/frontendComponents/${name}`,
+      urlPath: '/frontendComponents/components',
+      queryParameters: {
+        component: { includes: Object.keys(components).map(component => ({ equalTo: component })) },
+      },
     },
     response: {
       headers: { 'Content-Type': 'application/json' },
-      jsonBody: component,
+      jsonBody: mockFrontendComponentResponse(components),
     },
   })
 
@@ -47,13 +51,8 @@ const stubJavascript = (name: AvailableComponent, js: string): Promise<Response>
   })
 
 export default {
-  stubFallbackHeaderAndFooter(): Promise<Response[]> {
-    const empty: Component = {
-      html: '',
-      css: [],
-      javascript: [],
-    }
-    return Promise.all([stubComponent('header', empty), stubComponent('footer', empty)])
+  stubFallbackHeaderAndFooter(): Promise<Response> {
+    return stubComponents()
   },
   stubFrontendComponentsHeaderAndFooter(): Promise<Response[]> {
     return Promise.all([
@@ -61,15 +60,17 @@ export default {
       stubCSS('footer', 'footer { background: yellow }'),
       stubJavascript('header', 'window.FrontendComponentsHeaderDidLoad = true;'),
       stubJavascript('footer', 'window.FrontendComponentsFooterDidLoad = true;'),
-      stubComponent('header', {
-        html: '<header>HEADER</header>',
-        css: ['http://localhost:9091/frontendComponents/header.css'],
-        javascript: ['http://localhost:9091/frontendComponents/header.js'],
-      }),
-      stubComponent('footer', {
-        html: '<footer>FOOTER</footer>',
-        css: ['http://localhost:9091/frontendComponents/footer.css'],
-        javascript: ['http://localhost:9091/frontendComponents/footer.js'],
+      stubComponents({
+        header: {
+          html: '<header>HEADER</header>',
+          css: ['http://localhost:9091/frontendComponents/header.css'],
+          javascript: ['http://localhost:9091/frontendComponents/header.js'],
+        },
+        footer: {
+          html: '<footer>FOOTER</footer>',
+          css: ['http://localhost:9091/frontendComponents/footer.css'],
+          javascript: ['http://localhost:9091/frontendComponents/footer.js'],
+        },
       }),
     ])
   },

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -8,7 +8,7 @@ const wiremockAdminUrl = 'http://localhost:9091/__admin'
  */
 export interface Mapping {
   request?: Partial<
-    { method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE' } & (
+    { method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'; queryParameters: object } & (
       | { url: string }
       | { urlPath: string }
       | { urlPathPattern: string }

--- a/server/data/frontendComponentsClient.ts
+++ b/server/data/frontendComponentsClient.ts
@@ -1,4 +1,3 @@
-import logger from '../../logger'
 import config from '../config'
 import RestClient from './restClient'
 
@@ -10,7 +9,7 @@ export interface Component {
 
 export type AvailableComponent = 'header' | 'footer'
 
-type CaseLoad = {
+export interface CaseLoad {
   caseLoadId: string
   description: string
   type: string
@@ -18,23 +17,20 @@ type CaseLoad = {
   currentlyActive: boolean
 }
 
-type Service = {
-  description: string
-  heading: string
-  href: string
+export interface Service {
   id: string
+  heading: string
+  description: string
+  href: string
+  navEnabled: boolean
 }
 
-export interface FrontendComponentsMeta {
-  activeCaseLoad: CaseLoad
-  caseLoads: CaseLoad[]
-  services: Service[]
-}
-
-export interface FrontendComponentsResponse {
-  header?: Component
-  footer?: Component
-  meta: FrontendComponentsMeta
+export interface ComponentsResponse extends Record<AvailableComponent, Component> {
+  meta: {
+    activeCaseLoad: CaseLoad
+    caseLoads: CaseLoad[]
+    services: Service[]
+  }
 }
 
 export default class FrontendComponentsClient {
@@ -42,18 +38,13 @@ export default class FrontendComponentsClient {
     return new RestClient('HMPPS Components Client', config.apis.frontendComponents, token)
   }
 
-  getComponent(component: AvailableComponent, userToken: string): Promise<Component> {
-    logger.info(`Getting frontend component ${component}`)
-    return FrontendComponentsClient.restClient(userToken).get<Component>({
-      path: `/${component}`,
-      headers: { 'x-user-token': userToken },
-    })
-  }
-
-  getComponents<T extends AvailableComponent[]>(components: T, userToken: string): Promise<FrontendComponentsResponse> {
-    return FrontendComponentsClient.restClient(userToken).get<FrontendComponentsResponse>({
+  getComponents<T extends AvailableComponent[]>(
+    components: T,
+    userToken: string,
+  ): Promise<Pick<ComponentsResponse, 'meta' | T[number]>> {
+    return FrontendComponentsClient.restClient(userToken).get({
       path: '/components',
-      query: `component=${components.join('&component=')}`,
+      query: { component: components },
       headers: { 'x-user-token': userToken },
     })
   }

--- a/server/data/testData/frontendComponents.ts
+++ b/server/data/testData/frontendComponents.ts
@@ -1,0 +1,32 @@
+import type { AvailableComponent, CaseLoad, Component, ComponentsResponse } from '../frontendComponentsClient'
+import { moorland } from './prisonApi'
+
+const emptyComponent: Component = {
+  html: '',
+  css: [],
+  javascript: [],
+}
+
+const caseload: CaseLoad = {
+  caseLoadId: moorland.agencyId,
+  description: moorland.description,
+  type: moorland.agencyType,
+  caseloadFunction: 'GENERAL',
+  currentlyActive: true,
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export function mockFrontendComponentResponse(
+  components: Partial<Record<AvailableComponent, Component>> = {},
+): ComponentsResponse {
+  return {
+    header: emptyComponent,
+    footer: emptyComponent,
+    ...components,
+    meta: {
+      activeCaseLoad: caseload,
+      caseLoads: [caseload],
+      services: [],
+    },
+  }
+}

--- a/server/middleware/frontendComponents.test.ts
+++ b/server/middleware/frontendComponents.test.ts
@@ -1,0 +1,71 @@
+import type { NextFunction, Request, Response } from 'express'
+import nock from 'nock'
+
+import config from '../config'
+import type { Services } from '../services'
+import FrontendComponentsClient from '../data/frontendComponentsClient'
+import { mockFrontendComponentResponse } from '../data/testData/frontendComponents'
+import frontendComponents from './frontendComponents'
+
+describe('Frontend components middleware', () => {
+  const fakeApiClient = nock(config.apis.frontendComponents.url)
+  const frontendComponentsMiddleware = frontendComponents({
+    frontendComponentsClient: new FrontendComponentsClient(),
+  } as Services)
+  const userToken = 'user-token'
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should load frontend components', async () => {
+    fakeApiClient
+      .get('/components')
+      .query({ component: ['header', 'footer'] })
+      .matchHeader('authorization', `Bearer ${userToken}`)
+      .reply(
+        200,
+        mockFrontendComponentResponse({
+          header: {
+            html: 'header html',
+            css: ['/header.css'],
+            javascript: ['/header.js'],
+          },
+          footer: {
+            html: 'footer html',
+            css: ['/footer.css', '/footer-2.css'],
+            javascript: ['/footer.js'],
+          },
+        }),
+      )
+
+    const req = {} as Request
+    const res = { locals: { user: { token: userToken } } } as Response
+    const next: NextFunction = jest.fn()
+    await frontendComponentsMiddleware(req, res, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(res.locals.feComponents).toEqual({
+      header: 'header html',
+      footer: 'footer html',
+      cssIncludes: ['/header.css', '/footer.css', '/footer-2.css'],
+      jsIncludes: ['/header.js', '/footer.js'],
+    })
+  })
+
+  it('should call next request handler even if frontend components failed to load', async () => {
+    fakeApiClient
+      .get('/components')
+      .query({ component: ['header', 'footer'] })
+      .matchHeader('authorization', `Bearer ${userToken}`)
+      .reply(401, { status: 401, userMessage: 'Unauthorized', developerMessage: 'Unauthorized' })
+
+    const req = {} as Request
+    const res = { locals: { user: { token: userToken } } } as Response
+    const next: NextFunction = jest.fn()
+    await frontendComponentsMiddleware(req, res, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(res.locals.feComponents).toBeUndefined()
+  })
+})

--- a/server/middleware/frontendComponents.ts
+++ b/server/middleware/frontendComponents.ts
@@ -1,16 +1,16 @@
-import type { RequestHandler } from 'express'
+import type { NextFunction, Request, Response } from 'express'
 
 import logger from '../../logger'
 import type { Services } from '../services'
 
-export default function frontendComponents(services: Services): RequestHandler {
-  const { frontendComponentsClient } = services
-  return async (req, res, next) => {
+export default function frontendComponents({ frontendComponentsClient }: Services) {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const [header, footer] = await Promise.all([
-        frontendComponentsClient.getComponent('header', res.locals.user.token),
-        frontendComponentsClient.getComponent('footer', res.locals.user.token),
-      ])
+      const { header, footer } = await frontendComponentsClient.getComponents(
+        ['header', 'footer'],
+        res.locals.user.token,
+      )
+      // TODO: meta information from frontend components can be used to read active and available caseloads
       res.locals.feComponents = {
         header: header.html,
         footer: footer.html,

--- a/server/middleware/populatePrisoner.test.ts
+++ b/server/middleware/populatePrisoner.test.ts
@@ -9,8 +9,6 @@ import { OffenderSearchApi } from '../data/offenderSearchApi'
 describe('prisoner-loading middleware', () => {
   let fakeApi: nock.Scope
 
-  const next: NextFunction = jest.fn()
-
   beforeEach(() => {
     fakeApi = nock(config.apis.offenderSearchApi.url)
   })
@@ -25,6 +23,7 @@ describe('prisoner-loading middleware', () => {
 
     const req = { params: { prisonerNumber: 'A1234BC' } } as unknown as Request
     const res = { locals: { apis: { offenderSearchApi: new OffenderSearchApi('token') } } } as Response
+    const next: NextFunction = jest.fn()
     await populatePrisoner()(req, res, next)
 
     expect(next).toHaveBeenCalledWith()
@@ -36,6 +35,7 @@ describe('prisoner-loading middleware', () => {
 
     const req = { params: { prisonerNumber: 'A1234BC' } } as unknown as Request
     const res = { locals: { apis: { offenderSearchApi: new OffenderSearchApi('token') } } } as Response
+    const next: NextFunction = jest.fn()
     await populatePrisoner()(req, res, next)
 
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'Not Found', status: 404 }))

--- a/server/middleware/populateReport.test.ts
+++ b/server/middleware/populateReport.test.ts
@@ -13,8 +13,6 @@ describe('report-loading middleware', () => {
 
   let fakeApi: nock.Scope
 
-  const next: NextFunction = jest.fn()
-
   beforeEach(() => {
     fakeApi = nock(config.apis.hmppsIncidentReportingApi.url)
   })
@@ -29,6 +27,7 @@ describe('report-loading middleware', () => {
 
     const req = { params: { id: basicReport.id } } as unknown as Request
     const res = { locals: { apis: { incidentReportingApi: new IncidentReportingApi('token') } } } as Response
+    const next: NextFunction = jest.fn()
     await populateReport()(req, res, next)
 
     expect(next).toHaveBeenCalledWith()
@@ -40,6 +39,7 @@ describe('report-loading middleware', () => {
 
     const req = { params: { id: basicReport.id } } as unknown as Request
     const res = { locals: { apis: { incidentReportingApi: new IncidentReportingApi('token') } } } as Response
+    const next: NextFunction = jest.fn()
     await populateReport()(req, res, next)
 
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'Not Found', status: 404 }))


### PR DESCRIPTION
`/header` & `/footer` endpoints are deprecated and [`/components`](https://frontend-components.hmpps.service.justice.gov.uk/api-docs/#/default/get_components) should be used instead