### PR TITLE
IR-68: Fix date parsing for BST time

### DIFF
--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -159,10 +159,12 @@ describe('parseDateInput', () => {
   it.each([
     ['25/02/2024', [25, 2, 2024]],
     ['01/01/2024 ', [1, 1, 2024]],
+    ['03/10/2024', [3, 10, 2024]], // BST
     ['1/1/2024', [1, 1, 2024]],
   ])('should work on valid date %s', (input, [day, month, year]) => {
     const date = parseDateInput(input)
     expect(date.getDate()).toEqual(day)
+    expect(date.getUTCDate()).toEqual(day)
     expect(date.getMonth()).toEqual(month - 1)
     expect(date.getFullYear()).toEqual(year)
   })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -69,7 +69,7 @@ export const initialiseName = (fullName?: string): string | null => {
   return `${array[0][0]}. ${array.reverse()[0]}`
 }
 
-/** Parse date in the form DD/MM/YYYY. Throws an error when invalid */
+/** Parse date in the form DD/MM/YYYY; the returned time part should be ignored. Throws an error when invalid */
 export const parseDateInput = (input: string): Date => {
   const match = input && /^(?<day>\d{1,2})\/(?<month>\d{1,2})\/(?<year>\d{4})$/.exec(input.trim())
   if (!match) throw new Error('Invalid date')
@@ -78,7 +78,7 @@ export const parseDateInput = (input: string): Date => {
   const m = parseInt(month, 10)
   const d = parseInt(day, 10)
   if (Number.isSafeInteger(y) && m >= 1 && m <= 12 && d >= 1 && d <= 31) {
-    const date = new Date(y, m - 1, d)
+    const date = new Date(y, m - 1, d, 12)
     if (date) return date
   }
   throw new Error('Invalid date')


### PR DESCRIPTION
Internally, the date is converted into UTC so effectively 1 day was subtracted when using the returned value with `format.isoDate(…)`:

`03/10/2024` is parsed into `2024-10-02T23:00:00.000Z` (in Europe/London) and truncation results in `"2024-10-02"`