### PR TITLE
IR-534: Recreate HMPO form wizard types afresh

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -27,6 +27,7 @@ export declare global {
       logout(done: (err: unknown) => void): void
     }
 
+    // NB: FormWizard.Locals will not be available for all routes so should not be merged in
     interface Locals {
       user: Express.User
       systemToken: string

--- a/server/@types/hmpo-form-wizard/application-extensions.d.ts
+++ b/server/@types/hmpo-form-wizard/application-extensions.d.ts
@@ -1,0 +1,71 @@
+/**
+ * Application-specific overrides for HMPO Form Wizard types
+ */
+declare module 'hmpo-form-wizard' {
+  import type { ErrorSummaryItem } from '../../utils/utils'
+
+  namespace FormWizard {
+    interface Field {
+      // TODO: custom properties need major cleanup: we should group them into very few nested objects
+
+      id?: string
+      name?: string
+      text?: string
+      nameForErrors?: string
+      errorMessage?: ErrorSummaryItem
+      errorMessages?: Record<string, string>
+      value?: unknown // TODO: value should be removed: it is already provided elsewhere
+      component?: string
+      classes?: string
+      labelClasses?: string
+      prefix?: string
+      leadingZeros?: string
+      autocomplete?: 'off'
+      rows?: string | number
+      attributes?: Record<string, unknown>
+      label?: {
+        text: string
+        classes?: string
+      }
+      hint?: {
+        text: string
+        classes?: string
+      }
+      fieldset?: {
+        legend?: {
+          text: string
+          classes?: string
+        }
+      }
+    }
+
+    interface FieldItem {
+      // TODO: custom properties need major cleanup
+
+      text?: string
+      label?: string
+      hint?: {
+        text: string
+        classes?: string
+      }
+      divider?: string
+      behaviour?: 'exclusive'
+      conditional?: ConditionalFieldItem | ConditionalFieldItem[]
+    }
+
+    type ConditionalFieldItem =
+      | string
+      | {
+          id?: string
+          name?: string
+          html?: string
+        }
+
+    interface Locals {
+      // TODO: custom properties need major cleanup
+
+      fields: FormWizard.Fields // TODO: fields should be removed as they appear inside options already
+      validationErrors: ErrorSummaryItem[]
+    }
+  }
+}

--- a/server/@types/hmpo-form-wizard/index.d.ts
+++ b/server/@types/hmpo-form-wizard/index.d.ts
@@ -1,336 +1,609 @@
-// Copied from https://github.com/ministryofjustice/hmpps-locations-inside-prison/blob/5fe32c3024f248cd038b752c2f8ef612a77ef322/server/%40types/hmpo-form-wizard/index.d.ts
-
-/* eslint-disable max-classes-per-file */
-import { NextFunction, Response } from 'express'
+// eslint-disable-next-line max-classes-per-file
+import type Express from 'express'
 
 declare module 'hmpo-form-wizard' {
-  import Express from 'express'
+  import type { DefaultFormatter } from 'hmpo-form-wizard/lib/formatting'
+  import type { DefaultValidator } from 'hmpo-form-wizard/lib/validation'
+  import type { Local as LocalModel, LocalModelOptions } from 'hmpo-model'
 
-  // These enums have to live here because of TS/Jest and Enums work..  ¯\_(ツ)_/¯
-  // Also this ESLint override because of how TS/Eslint works.
-  export const enum FieldType {
-    Text = 'TEXT',
-    Radio = 'RADIO',
-    CheckBox = 'CHECKBOX',
-    TextArea = 'TEXT_AREA',
-    Date = 'DATE',
-    Dropdown = 'DROPDOWN',
-  }
+  export function FormWizard(
+    steps: FormWizard.Steps,
+    fields: FormWizard.Fields,
+    config: FormWizard.Config,
+  ): Express.Router
 
-  export const enum ValidationType {
-    String = 'string',
-    Regex = 'regex',
-    Required = 'required',
-    Email = 'email',
-    MinLength = 'minlength',
-    MaxLength = 'maxlength',
-    ExactLength = 'exactlength',
-    Alpha = 'alpha',
-    AlphaEx = 'alphaex',
-    AlphaEx1 = 'alphaex1',
-    Alphanumeric = 'alphanum',
-    AlphanumericEx = 'alphanumex',
-    AlphanumericEx1 = 'alphanumex1',
-    Numeric = 'numeric',
-    Equal = 'equal',
-    PhoneNumber = 'phonenumber',
-    UKMobileNumber = 'ukmobilephone',
-    Date = 'date',
-    DateYear = 'date-year',
-    DateMonth = 'date-month',
-    DateDay = 'date-day',
-    BeforeDate = 'before',
-    AfterDate = 'after',
-    Postcode = 'postcode',
-    Match = 'match',
-    BeforeDateField = 'beforeField',
-    AfterDateField = 'afterField',
-  }
-
-  export const enum FormatterType {
-    Trim = 'trim',
-    Boolean = 'boolean',
-    Uppercase = 'uppercase',
-    Lowercase = 'lowercase',
-    RemoveSpaces = 'removespaces',
-    SingleSpaces = 'singlespaces',
-    Hyphens = 'hyphens',
-    Apostrophes = 'apostrophes',
-    Quotes = 'quotes',
-    RemoveRoundBrackets = 'removeroundbrackets',
-    RemoveHyphens = 'removehyphens',
-    RemoveSlashes = 'removeslashes',
-    UKPhonePrefix = 'ukphoneprefix',
-    Base64Decode = 'base64decode',
-  }
-
-  export const enum Gender {
-    NotKnown = 0,
-    Male = 1,
-    Female = 2,
-    NotSpecified = 9,
-  }
-
-  function FormWizard(steps: FormWizard.Steps, fields: FormWizard.Fields, config: FormWizardConfig)
-
-  namespace FormWizard {
-    type Conditional = string | string[] | { html?: string; name?: string; id?: string }
-    type ConditionFn = (isValidated: boolean, values: Record<string, string | Array<string>>) => boolean
-    type SectionProgressRule = { fieldCode: string; conditionFn: ConditionFn }
-
-    interface Request extends Express.Request {
-      form: {
-        values: Record<string, string | string[]>
-        options: {
-          allFields: { [key: string]: Field }
-          journeyName: string
-          section: string
-          sectionProgressRules: Array<SectionProgressRule>
-          fields: Fields
-          steps: Steps
-          locals: Record<string, boolean | string>
-          next?: string
-          fullPath?: string
-        }
-        persistedAnswers: Record<string, string | string[]>
-      }
-      isEditing: boolean
-      journeyModel: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        set(key: string, value: any): void
-        get: (key: string) => unknown
-        reset: () => unknown
-      }
-      sessionModel: {
-        updateSessionData(changes: object): unknown
-        save(): void
-        set: (key: string, value: unknown, options?: { silent?: boolean }) => void
-        get: <T>(key: string) => T
-        reset: () => unknown
-        unset: (key: string | string[]) => void
-      }
-    }
-
-    class Controller {
-      constructor(options: unknown)
-
-      middlewareSetup(): void
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      use(...args: ((req: Request, res: Express.Response, next: Express.NextFunction) => any)[]): any
-
-      get(req: Request, res: Express.Response, next: Express.NextFunction): Promise
-
-      post(req: Request, res: Express.Response, next: Express.NextFunction): Promise
-
-      configure(req: Request, res: Express.Response, next: Express.NextFunction): Promise
-
-      process(req: Request, res: Express.Response, next: Express.NextFunction): Promise
-
-      validate(req: Request, res: Express.Response, next: Express.NextFunction): Promise
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      validateFields(req: FormWizard.Request, res: Express.Response, callback: (errors: any) => void)
-
-      // eslint-disable-next-line no-underscore-dangle
-      _locals(req: Request, res: Express.Response, next: Express.NextFunction): Promise
-
-      locals(req: Request, res: Express.Response, next: Express.NextFunction): object
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      getValues(req: Request, res: Express.Response, next: (err: any, values?: any) => void): Promise
-
-      saveValues(req: Request, res: Express.Response, next: Express.NextFunction): Promise
-
-      successHandler(req: Request, res: Express.Response, next: Express.NextFunction): Promise | void
-
-      errorHandler(error: Error, req: Request, res: Express.Response, next: Express.NextFunction): Promise
-
-      setErrors(error: Error, req: Request, res: Express.Response)
-
-      getErrors(req: Request, res: Express.Response)
-
-      render(req: FormWizard.Request, res: Express.Response, next: NextFunction)
-
-      setStepComplete(req: FormWizard.Request, res: Express.Response, path?: string)
-    }
-
-    namespace Controller {
-      type Options = {
-        key?: string
-        errorGroup?: string
-        field?: string
-        type?: string
-        redirect?: string
-        url?: string
-        message?: string
-        headerMessage?: string
-      }
-
-      export class Error {
-        key: string
-
-        type: string
-
-        redirect?: string
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        args: { [key: string]: any }
-
-        constructor(key?: string, options = {}, req?: Request): void
-      }
-    }
-
-    namespace Field {
-      type Option = {
-        text: string
-        value: string
-        checked?: boolean
-        conditional?: Conditional
-        hint?: { text: string } | { html: string }
-        behaviour?: string
-        kind: 'option'
-        summary?: {
-          displayFn?: (text: string, value: string) => string
-        }
-      }
-
-      type Divider = {
-        divider: string
-        kind: 'divider'
-      }
-
-      type Options = Array<Option | Divider>
-    }
-
-    type AnswerValue = string | number | Array<string | number>
-
-    type FormatterFn = (val: AnswerValue) => AnswerValue
-
-    type Formatter =
-      | { type: FormatterType; arguments?: (string | number)[] }
-      | { fn: FormatterFn; arguments?: (string | number)[] }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    type ValidatorFn = (val: AnswerValue, ...args: any) => boolean
-
-    type Validate =
+  export namespace FormWizard {
+    type NextStep =
+      /** next can be a relative string path */
       | string
-      | ValidatorFn
-      | { type: ValidationType; arguments?: (string | number | object)[]; message: string }
-      | { fn: ValidatorFn; arguments?: (string | number | object)[]; message?: string }
-
-    type Dependent = { field: string; value: string | string[]; displayInline?: boolean }
-
-    type Hint = { kind?: 'html'; html: string } | { kind?: 'text'; text: string }
-
-    interface Item {
-      text?: string
-      value: string
-      label?: string
-      conditional?: Conditional
-      id?: string
-      hint?: Hint
-      divider?: string
-    }
-
-    interface Field {
-      attributes?: { [attribute: string]: string | number }
-      default?: string | number | []
-      name?: string
-      text?: string
-      component?: string
-      prefix?: string
-      code?: string
-      id?: string
-      hint?: Hint
-      type?: FieldType
-      multiple?: boolean
-      options?: FormWizard.Field.Options
-      formatter?: Formatter[]
-      validate?: Validate[]
-      dependent?: Dependent
-      invalidates?: string[]
-      value?: string | string[]
-      label?: { text: string }
-      labelClasses?: string
-      formGroupClasses?: string
-      characterCountMax?: number
-      classes?: string
-      fieldset?: {
-        legend?: {
-          text: string
-          classes?: string
-        }
-      }
-      items?: Item[]
-      summary?: {
-        displayFn?: (value: string) => string
-        displayAlways?: boolean
-      }
-      errorMessage?: { href: string; text: string }
-    }
-
-    interface Fields {
-      [key: string]: Field
-    }
-
-    namespace Step {
-      type NextStepCondition = (req: Request, res: Response) => boolean
-      type Op = (fieldValue, req, res, con) => boolean
-      type FieldValueCondition = { field: string; op?: string | Op; value: string | string[]; next: NextStep }
-      type CallbackCondition = { fn: NextStepCondition; next: string }
-
-      type NextStep = FieldValueCondition | CallbackCondition | string | NextStep[]
-    }
+      /** next can be an array of conditions */
+      | (
+          | {
+              /** field, op and value. op defaults to '===' */
+              field: string
+              op?: '>' | '>=' | '<' | '<=' | '==' | '===' | '!=' | 'before' | 'after' | 'in' | 'all' | 'some'
+              value: Value
+              next: string
+            }
+          | {
+              /** an operator can be a function */
+              field: string
+              op: (fieldValue: Value, req: Request, res: Express.Response, con: unknown) => boolean
+              value: Value
+              next: string
+            }
+          | {
+              /** next can be an array of conditions */
+              field: string
+              value: Value
+              next: NextStep[]
+            }
+          | {
+              /** a condition can be a function specified by fn */
+              fn: (req: Request, res: Express.Response, con: unknown) => boolean
+              next: string
+            }
+          | {
+              /** a condition can be a controller method specified by name */
+              fn: string
+              next: string
+            }
+          | {
+              /** the next option can be a function to return a dynamic next step */
+              field: string
+              value: Value
+              next: (req: Request, res: Express.Response, con: unknown) => string
+            }
+          /** use a string as a default next step */
+          | string
+        )[]
 
     interface Step {
-      pageTitle?: string
-      reset?: boolean
-      resetJourney?: boolean
-      skip?: boolean
+      /** The next step for each step can be a relative path, an external URL, or an array of conditional next steps. Each condition next step can contain a next location, a field name, operator and value, or a custom condition function */
+      next?: NextStep
+      /** A namespace identifier for the wizard. This is used to store wizard data on the session. This defaults to a unique value for a wizard. */
+      name?: string
+      /** A namespace identifier for the entire journey. This is used to store journey-wide data such as step history on the session. Defaults to "default". */
+      journeyName?: string
+      /** Allows a user to navigate to this step with no journey step history. Defaults to false. */
       entryPoint?: boolean
-      template?: string
-      next?: FormWizard.Step.NextStep
-      fields?: string[]
-      controller?: typeof FormWizard.Controller
-      navigationOrder?: number
-      backLink?: string
+      /** Check if the session has expired. Defaults to true. */
       checkSession?: boolean
-      section?: string
-      sectionProgressRules?: Array<SectionProgressRule>
-      noPost?: boolean
-      locals?: Record<string, boolean | string>
-      invalid?: boolean
-    }
-
-    interface RenderedStep {
-      pageTitle: string
+      /** Check if session has expired on entry points. Defaults to false */
+      checkEntryPointSession?: boolean
+      /** Check this step is allowed based on the journey step history. If this step is not allowed the user is redirected to the last allowed step, or an error is returned if no step is allowed. Defaults to true. */
+      checkJourney?: boolean
+      /** Set to false to disable cross-site request forgery protection */
+      csrf?: boolean
+      /** Reset the wizard sessionModel when this step is accessed. Defaults to false. */
       reset?: boolean
-      entryPoint?: boolean
+      /** Reset the journey journeyModel when this step is accessed. */
+      resetJourney?: boolean
+      /** A template is not rendered on a GET request. The post() lifecycle is called instead. Defaults to false. */
+      skip?: boolean
+      /** Only allow POST requests. The get method is set to null */
+      noGet?: boolean
+      /** Don't allow posting to this step. The post method is set to null and the step is completed if there is a next step */
+      noPost?: boolean
+      /** forward the query params when internally redirecting. Defaults to false. */
+      forwardQuery?: boolean
+      /** This step is editable. This allows accessing this step with the editSuffix and sets the back link and next step to the editBackStep. Defaults to false. */
+      editable?: boolean
+      /** Suffix to use for editing steps. Defaults to "/edit". */
+      editSuffix?: string
+      /** Location to return to after editing a step. Defaults to "confirm" */
+      editBackStep?: string
+      /** While editing, if the step marked with this is evaluated to be the next step, continue to editing it instead of returning to editBackStep. Defaults to false. */
+      continueOnEdit?: boolean
+      /** specifies which of the fields from the field definition list are applied to this step. Form inputs which are not named on this list will not be processed. Default: [] */
+      fields?: string[]
+      /** Specifies the template to render for GET requests to this step. Defaults to the route (without trailing slash) */
       template?: string
-      next?: FormWizard.Step.NextStep
-      fields?: Fields
-      controller?: typeof FormWizard.Controller
-      navigationOrder?: number
+      /** Provides the location within app.get('views') that templates are stored. */
+      templatePath?: string
+      /** Specifies the location of the step previous to this one. */
       backLink?: string
-      section: string
-      sectionProgressRules?: Array<SectionProgressRule>
+      /** Specifies valid referrers that can be used as a back link. If this or backLink are not specified then an algorithm is applied which checks the previously visited steps which have the current step set as next. */
+      backLinks?: string[]
+      /** The constructor for the controller to be used for this step's request handling. The default is exported as a Controller property of this module. If custom behaviour is required for a particular form step then custom extensions can be defined */
+      controller?: typeof Controller
+      /** Additional fields that we be recorded as being part of this step's routing decision. Default: [] */
+      decisionFields?: string[]
+      /** Show this page instead of only recalculating the routing if this page is marked invalid. Default: false */
+      revalidate?: boolean
+      /** Show this page instead of only recalculating the routing if one of these values is changed. Default: [] */
+      revalidateIf?: string[]
+      /** provide a function for translating validation error codes into usable messages. Previous implementations have used i18next to do translations. */
+      translate?: (string) => string
+      /** Define express parameters for the route for supporting additional URL parameters. */
+      params?: string
     }
 
     interface Steps {
-      [key: string]: Step
+      [path: string]: Step
     }
 
-    interface RenderedSteps {
-      [key: string]: RenderedStep
+    interface Field {
+      /** Name of the cross-wizard field storage name. To facilitate sharing form values between wizards in the same journey a field can be specified to save into the journeyModel instead of the sessionModel using the journeyKey property */
+      journeyKey?: string
+      /** A default value for a field can be specified with the default property. This is used if the value loaded from the session is missing or undefined. */
+      default?: string
+      /** Allow multiple incomming values for a field. The result is presented as an array */
+      multiple?: boolean
+      /** Array of formatter names for this field in addition to the default formatter set, or formatter objects */
+      formatter?:
+        | DefaultFormatter[]
+        | (
+            | {
+                /** Formatter name */
+                type: DefaultFormatter
+                /** Array of formatter arguments, eg. { type: 'truncate', arguments: [24] } */
+                arguments?: unknown[]
+              }
+            | {
+                /** Formatter function */
+                fn: Formatter
+              }
+          )[]
+
+      /** Disables the default set of formatters for this field */
+      ['ignore-defaults']?: boolean
+      /** An array of validator names, or validator objects */
+      validate?:
+        | DefaultValidator[]
+        | (
+            | {
+                /** Validator name */
+                type: DefaultValidator
+                /** Array of validator arguments, eg. { type: 'minlength', arguments: [24] } */
+                arguments?: unknown[]
+              }
+            | {
+                /** Validator function */
+                fn: Validator
+              }
+          )[]
+      /** Array of select box or radio button options */
+      items?: FieldItem[]
+      /** Name of field to make this field conditional upon. This field will not be validated or stored if this condition is not met. Can also also be an object to specify a specific value instead of the default of true: */
+      dependent?:
+        | string
+        | {
+            /** Field name */
+            field: string
+            /** Field value */
+            value: Value
+          }
+      /** an array of field names that will be 'invalidated' when this field value is set or changed. Any fields specified in the invalidates array will be removed from the sessionModel. Future steps that have used this value to make a branching decision will also be invalidated, making the user go through those steps and decisions again. */
+      invalidates?: string[]
+      /** localisation key to use for this field instead of the field name */
+      contentKey?: string
     }
 
-    interface Answers {
-      [key: string]: string | string[]
+    interface FieldItem {
+      /** Item value */
+      value: Value
+    }
+
+    interface Fields {
+      [name: string]: Field
+    }
+
+    interface Config extends Step {
+      name?: string
+    }
+
+    interface Request extends Express.Request {
+      isEditing: boolean
+      journeyModel: JourneyModel
+      sessionModel: WizardModel
+      form: Form
+    }
+
+    /** Represents form errors; does not extend native Error class */
+    class Error {
+      constructor(
+        key: string | undefined | null,
+        options: {
+          key?: string
+          errorGroup?: string
+          field?: string
+          type?: string
+          redirect?: string
+          message?: string
+          headerMessage?: string
+          arguments?: unknown
+        } = {},
+        req?: Request,
+      )
+
+      key: string
+
+      errorGroup: string | undefined
+
+      field: string | undefined
+
+      type: 'default' | string
+
+      redirect: string | undefined
+
+      url: string | undefined
+
+      message: string | undefined
+
+      headerMessage: string | undefined
+
+      args: { [type: string]: unknown }
+    }
+
+    interface Options extends Step {
+      route: string
+      steps: Steps
+      fields: Fields
+      allFields: Fields
+      defaultFormatters: DefaultFormatter[]
+    }
+
+    interface Form {
+      options: Options
+      values: Values
+      errors: Record<string, Error>
+    }
+
+    interface Callback {
+      (err: Error | undefined, values: Values | undefined): void
+    }
+
+    interface Locals {
+      errors: Record<string, Error>
+      errorlist: Error[]
+      values: Values
+      options: Options
+      action: string
+      nextPage: Step
+      isEditing: boolean
+      editSuffix: string
+      baseUrl: Request['baseUrl']
+      backLink: string | undefined
+      ['csrf-token']: string
+    }
+
+    /**
+     * Base class which instantiates a request handler for each form step
+     */
+    abstract class BaseController {
+      constructor(options: Options)
+
+      static Error: typeof Error
+
+      options: Options
+
+      router: Express.Router
+
+      middlewareSetup(): void
+
+      middlewareChecks(): void
+
+      middlewareActions(): void
+
+      middlewareLocals(): void
+
+      middlewareMixins(): void
+
+      use(...requestHandlers: Express.RequestHandler[]): void
+
+      useWithMethod(
+        method: 'all' | 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head',
+        ...requestHandlers: Express.RequestHandler[]
+      ): void
+
+      requestHandler(): Express.Router
+
+      rejectUnsupportedMethods(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      methodNotSupported(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      configure(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      get(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      post(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      getErrors(req: Request, res: Express.Response): Record<string, Error>
+
+      getValues(req: Request, res: Express.Response, callback: Callback): void
+
+      locals(req: Request, res: Express.Response, callback?: Callback): Partial<Locals>
+
+      render(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      setErrors(err: Record<string, Error>, req: Request, res: Express.Response): void
+
+      process(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      validateFields(req: Request, res: Express.Response, callback: Callback): void
+
+      validateField(key: string, req: Request, res: Express.Response): Error | false | undefined
+
+      validate(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      saveValues(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      successHandler(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      isValidationError(err: unknown): err is Error
+
+      errorHandler(err: Error, req: Request, res: Express.Response, next: Express.NextFunction): void
+    }
+
+    /**
+     * Class with various mixins which instantiates a request handler for each form step
+     */
+    class Controller extends BaseController {
+      validators: Record<string, Validator>
+
+      formatters: Record<string, Formatter>
+
+      resolvePath(base: string, url: string, forceRelative: boolean): void
+
+      setBaseUrlLocal(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      setTranslateEngine(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      createJourneyModel(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      createSessionModel(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      resetSessionModel(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      checkSession(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      checkJourneyProgress(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      checkProceedToNextStep(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      walkJourneyHistory(
+        req: Request,
+        res: Express.Response,
+        fn: (this: Controller, step: Step, next: Step | undefined) => boolean,
+        stopAtInvalid: boolean = true,
+        start: Step | null = null,
+      ): Step | false
+
+      completedJourneyStep(req: Request, res: Express.Response, path: string): Step | false
+
+      allowedJourneyStep(req: Request, res: Express.Response, path: string): Step | false
+
+      allowedPrereqStep(req: Request, res: Express.Response, prereqs: string[]): Step | false
+
+      lastAllowedStep(req: Request, res: Express.Response): Step | false
+
+      getJourneyFieldNames(
+        req: Request,
+        res: Express.Response,
+        fields: string[],
+        ignoreLocalFields = false,
+        undefinedIfEmpty = false,
+      )
+
+      setStepComplete(req: Request, res: Express.Response, path: string): void
+
+      addJourneyHistoryStep(req: Request, res: Express.Response, step: Step): void
+
+      invalidateJourneyHistoryStep(req: Request, res: Express.Response, path: string): void
+
+      removeJourneyHistoryStep(req: Request, res: Express.Response, path: string): void
+
+      resetJourneyHistory(req: Request, res: Express.Response): void
+
+      csrfGenerateSecret(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      csrfGenerateSecret(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      csrfSetToken(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      checkJourneyInvalidations(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      invalidateFields(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      backlinksSetLocals(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      backlinksSetLocals(req: Request, res: Express.Response): string | undefined
+
+      decodeConditions(
+        req: Request,
+        res: Express.Response,
+        nextStep: NextStep,
+      ): { condition: NextStep | null; fields: string[]; url: string | null } | undefined
+
+      getNextStepObject(req: Request, res: Express.Response): ReturnType<Controller['decodeConditions']>
+
+      getNextStep(req: Request, res: Express.Response): string | undefined
+
+      getErrorStep(err: Error, req: Request, res: Express.Response): string | undefined
+
+      editing(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      checkEditing(req: Request, res: Express.Response, next: Express.NextFunction): void
+
+      clearEditing(req: Request, res: Express.Response): void
+
+      getBackLink(req: Request, res: Express.Response): string | undefined
+    }
+
+    interface SessionModelOptions extends LocalModelOptions {
+      /** req.session key */
+      key: string
+      req: Request | null
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    class SessionModel<Values = any, Opts = SessionModelOptions> extends LocalModel<Values, Opts> {
+      getSessionData(): object
+
+      /** On-change listener */
+      updateSessionData(changes: object): void
+
+      /** On-reset listener */
+      resetSessionData(): void
+
+      save(callback?: (err: unknown) => void): void
+
+      reload(callback?: (err: unknown) => void): void
+
+      destroy(): void
+    }
+
+    interface WizardModelOptions extends SessionModelOptions {
+      fields: Fields
+      journeyModel: JourneyModel
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    class WizardModel<Values = any, Opts = WizardModelOptions> extends SessionModel<Values, Opts> {
+      getJourneyKeys(): string[]
+
+      getDefaults(): Record<string, unknown>
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    class JourneyModel<Values = any, Opts = SessionModelOptions> extends SessionModel<Values, Opts> {
+      currentModels: WizardModel[]
+
+      registerModel(model: WizardModel): void
+    }
+
+    /** A form value as submitted to the wizard */
+    // TODO: this can be string[]; can it be anything else??
+    type Value = string | undefined
+
+    /** A form as submitted to the wizard; typically req.body */
+    interface Values {
+      [field: string]: Value
+    }
+
+    interface FormattingContext {
+      sessionModel: SessionModel
+      fields: Fields
+      values: Values
+    }
+
+    interface Formatter<ReturnType = string> {
+      (this: FormattingContext, value: Value, ...arguments: unknown[]): ReturnType
+    }
+
+    interface ValidationContext {
+      sessionModel: SessionModel
+      fields: Fields
+      values: Values
+    }
+
+    interface Validator {
+      (this: ValidationContext, value: Value, ...args: unknown[]): boolean
     }
   }
 
   export default FormWizard
 }
-/* eslint-enable max-classes-per-file */
+
+declare module 'hmpo-form-wizard/lib/formatting' {
+  import FormWizard from 'hmpo-form-wizard'
+
+  export function format<T>(
+    fields: FormWizard.Fields,
+    key: string,
+    value: FormWizard.Value,
+    defaultFormatters: Record<string, FormWizard.Formatter>,
+    context: FormWizard.FormattingContext,
+  ): T
+
+  declare let formatters: {
+    trim(value: FormWizard.Value): string | undefined
+    boolean(value: FormWizard.Value): boolean | undefined
+    uppercase(value: FormWizard.Value): string | undefined
+    lowercase(value: FormWizard.Value): string | undefined
+    removespaces(value: FormWizard.Value): string | undefined
+    singlespaces(value: FormWizard.Value): string | undefined
+    hyphens(value: FormWizard.Value): string | undefined
+    apostrophes(value: FormWizard.Value): string | undefined
+    quotes(value: FormWizard.Value): string | undefined
+    removeroundbrackets(value: FormWizard.Value): string | undefined
+    removehyphens(value: FormWizard.Value): string | undefined
+    removeslashes(value: FormWizard.Value): string | undefined
+    ukphoneprefix(value: FormWizard.Value): string | undefined
+    base64decode(value: FormWizard.Value): string
+  } // satisfies Record<string, FormWizard.Formatter>
+
+  type DefaultFormatter = keyof typeof formatters
+}
+
+declare module 'hmpo-form-wizard/lib/validation' {
+  import FormWizard from 'hmpo-form-wizard'
+
+  export function isAllowedDependent(fields: FormWizard.Fields, key: string, values: FormWizard.Values): boolean
+
+  interface ValidationError {
+    key: string
+    errorGroup: string
+    type: string
+    arguments: unknown[]
+  }
+
+  export function validate(
+    fields: FormWizard.Fields,
+    key: string,
+    value: FormWizard.Value,
+    context: FormWizard.ValidationContext,
+  ): ValidationError | false
+
+  declare let validators: {
+    string(value: FormWizard.Value): boolean
+    regex(value: FormWizard.Value, match: string | RegExp): boolean
+    required(value: FormWizard.Value): boolean
+    email(value: FormWizard.Value): boolean
+    minlength(value: FormWizard.Value, length: number): boolean
+    maxlength(value: FormWizard.Value, length: number): boolean
+    exactlength(value: FormWizard.Value, length: number): boolean
+    alpha(value: FormWizard.Value): boolean
+    alphaex(value: FormWizard.Value): boolean
+    alphaex1(value: FormWizard.Value): boolean
+    alphanum(value: FormWizard.Value): boolean
+    alphanumex(value: FormWizard.Value): boolean
+    alphanumex1(value: FormWizard.Value): boolean
+    numeric(value: FormWizard.Value): boolean
+    equal(value: FormWizard.Value, ...allowedValues: unknown[]): boolean
+    phonenumber(value: FormWizard.Value): boolean
+    ukmobilephone(value: FormWizard.Value): boolean
+    date(value: FormWizard.Value): boolean
+    'date-year': (value: FormWizard.Value) => boolean
+    'date-month': (value: FormWizard.Value) => boolean
+    'date-day': (value: FormWizard.Value) => boolean
+    before(value: FormWizard.Value, date: string): boolean
+    before(value: FormWizard.Value, years: number): boolean
+    before(value: FormWizard.Value, diff: number, unit: string): boolean
+    after(value: FormWizard.Value, date: string): boolean
+    after(value: FormWizard.Value, years: number): boolean
+    after(value: FormWizard.Value, diff: number, unit: string): boolean
+    postcode(value: FormWizard.Value): boolean
+    match(
+      this: FormWizard.ValidationContext,
+      value: FormWizard.Value,
+      fieldName: string,
+      fromSession?: boolean, // = false (forbidden by esbuild 0.23.1)
+    ): boolean
+    beforeField(
+      this: FormWizard.ValidationContext,
+      value: FormWizard.Value,
+      fieldName: string,
+      fromSession?: boolean, // = false (forbidden by esbuild 0.23.1)
+    ): boolean
+    afterField(
+      this: FormWizard.ValidationContext,
+      value: FormWizard.Value,
+      fieldName: string,
+      fromSession?: boolean, // = false (forbidden by esbuild 0.23.1)
+    ): boolean
+  } // satisfies Record<string, FormWizard.Validator>
+
+  type DefaultValidator = keyof typeof validators
+}

--- a/server/@types/hmpo-model/index.d.ts
+++ b/server/@types/hmpo-model/index.d.ts
@@ -1,0 +1,56 @@
+// eslint-disable-next-line max-classes-per-file
+declare module 'hmpo-model/lib/local-model' {
+  import type { EventEmitter } from 'node:events'
+
+  export interface LocalModelOptions {
+    silent?: boolean
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export default class LocalModel<Values = any, Options = LocalModelOptions> extends EventEmitter {
+    constructor(attributes?: Values | null, options?: Options)
+
+    options: Options
+
+    attributes: Values
+
+    get<Key extends keyof Values>(key: Key): Values[Key]
+
+    set<Key extends keyof Values>(key: Key, value: Values[Key], options?: Options): this
+
+    set(values: Partial<Values>, options?: Options): this
+
+    unset(fields: string | string[], options?: Options): this
+
+    reset(options?: Options): void
+
+    increment<Key extends keyof Values = string>(key: Key, amount?: number): this
+
+    toJSON(bare = false): Values
+  }
+}
+
+declare module 'hmpo-model/lib/remote-model' {
+  import type LocalModel from 'hmpo-model/lib/local-model'
+  import type { LocalModelOptions } from 'hmpo-model/lib/local-model'
+
+  export interface RemoteModelOptions extends LocalModelOptions {
+    label?: string
+    url?: string
+    // NB: many options omitted!
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export default class RemoteModel<Values = any, Options = RemoteModelOptions> extends LocalModel<Values, Options> {
+    requestConfig<Config = object>(config: Config, args: object): Config & { url: string }
+    // NB: many methods omitted!
+  }
+}
+
+declare module 'hmpo-model' {
+  import type LocalModel from 'hmpo-model/lib/local-model'
+  import type RemoteModel from 'hmpo-model/lib/remote-model'
+
+  export default RemoteModel
+  export { LocalModel as Local, RemoteModel as Remote }
+}

--- a/server/controllers/base/formInitialStep.ts
+++ b/server/controllers/base/formInitialStep.ts
@@ -1,5 +1,8 @@
 import { NextFunction, Response } from 'express'
 import FormWizard from 'hmpo-form-wizard'
+
+import type { ErrorSummaryItem } from '../../utils/utils'
+
 import { flattenConditionalFields, reduceDependentFields, renderConditionalFields } from '../../helpers/field'
 import { FieldEntry } from '../../helpers/field/renderConditionalFields'
 
@@ -33,12 +36,12 @@ export default class FormInitialStep extends FormWizard.Controller {
     })
   }
 
-  valueOrFieldName(arg: number | { field: string }, fields: Record<string, { label: { text: string } }>) {
+  valueOrFieldName(arg: number | { field: string }, fields: FormWizard.Fields) {
     return typeof arg === 'number' ? arg : `the ${fields[arg?.field]?.label?.text?.toLowerCase()}`
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getErrorDetail(error: { args: any; key: string; type: string }, res: Response): { text: string; href: string } {
+  getErrorDetail(error: { args: any; key: string; type: string }, res: Response): ErrorSummaryItem {
     const { fields } = res.locals.options
     const field = fields[error.key]
     const fieldName: string = field.nameForErrors || field?.label?.text
@@ -98,8 +101,7 @@ export default class FormInitialStep extends FormWizard.Controller {
     next()
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  locals(req: FormWizard.Request, res: Response): Record<string, any> {
+  locals(req: FormWizard.Request, res: Response): Partial<FormWizard.Locals> {
     const { options, values } = res.locals
     if (!options?.fields) {
       return {}
@@ -108,7 +110,7 @@ export default class FormInitialStep extends FormWizard.Controller {
     const { allFields } = options
     const fields = this.setupFields(req, allFields, options.fields, values)
 
-    const validationErrors: { text: string; href: string }[] = []
+    const validationErrors: ErrorSummaryItem[] = []
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     res.locals.errorlist.forEach((error: { args: any; key: string; type: string }) => {
@@ -126,9 +128,11 @@ export default class FormInitialStep extends FormWizard.Controller {
     }
   }
 
-  formError(fieldName: string, type: string): FormWizard.Controller.Error {
-    return new FormWizard.Controller.Error(fieldName, { args: {}, type, url: '/' })
-  }
+  // TODO: remove, it appears unused and FormWizard.Controller.Error constructor ignores `args` and `url`
+  //   and it should probably be `new FormInitialStep.Error(…)`
+  // formError(fieldName: string, type: string): FormWizard.Error {
+  //   return new FormWizard.Controller.Error(fieldName, { args: {}, type, url: '/' })
+  // }
 
   setupFields(
     req: FormWizard.Request,

--- a/server/data/incidentTypeConfiguration/formWizard.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.ts
@@ -1,5 +1,5 @@
 import FormWizard from 'hmpo-form-wizard'
-import { IncidentTypeConfiguration } from './types'
+import type { IncidentTypeConfiguration } from './types'
 import QuestionsController from '../../controllers/wip/questionsController'
 
 // TODO: Add tests once steps structure is more stable

--- a/server/data/incidentTypeConfiguration/wip/generateFieldsWithConditionals.ts
+++ b/server/data/incidentTypeConfiguration/wip/generateFieldsWithConditionals.ts
@@ -1,5 +1,6 @@
-import FormWizard from 'hmpo-form-wizard'
-import { IncidentTypeConfiguration, QuestionConfiguration } from '../types'
+import type FormWizard from 'hmpo-form-wizard'
+
+import type { IncidentTypeConfiguration, QuestionConfiguration } from '../types'
 import { convertToTitleCase } from '../../../utils/utils'
 
 type FieldTypeOptions = 'comment' | 'date'
@@ -40,7 +41,7 @@ function mapQuestionToField(question: QuestionConfiguration): FormWizard.Fields 
   let commentRequired = false
   let dateRequired = false
 
-  const items: FormWizard.Item[] = question.answers
+  const items: FormWizard.FieldItem[] = question.answers
     .filter(answer => answer.active)
     .map(answer => {
       if (answer.commentRequired === true) {

--- a/server/data/incidentTypeConfiguration/wip/generateStepsWithConditionals.ts
+++ b/server/data/incidentTypeConfiguration/wip/generateStepsWithConditionals.ts
@@ -1,5 +1,6 @@
-import FormWizard from 'hmpo-form-wizard'
-import { IncidentTypeConfiguration, QuestionConfiguration } from '../types'
+import type FormWizard from 'hmpo-form-wizard'
+
+import type { IncidentTypeConfiguration, QuestionConfiguration } from '../types'
 import QuestionsController from '../../../controllers/wip/questionsController'
 
 function mapQuestionToStep(question: QuestionConfiguration): FormWizard.Steps {
@@ -8,7 +9,7 @@ function mapQuestionToStep(question: QuestionConfiguration): FormWizard.Steps {
   let commentRequired = false
   let dateRequired = false
 
-  const next: FormWizard.Step.NextStep = question.answers
+  const next: FormWizard.NextStep = question.answers
     .filter(answer => answer.active)
     .map(answer => {
       if (answer.commentRequired === true) {

--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -80,7 +80,7 @@ describe('Error handling', () => {
   describe('of errors from form wizard', () => {
     beforeEach(() => {
       const router = Router()
-      const steps = {
+      const steps: FormWizard.Steps = {
         // entrypoint has no fields so redirects to name
         '/': {
           entryPoint: true,
@@ -100,8 +100,8 @@ describe('Error handling', () => {
           template: 'pages/index',
         },
       }
-      const fields = { name: { validate: ['required'] } }
-      const formConfig = { name: 'redirect-test', checkSession: false, csrf: false }
+      const fields: FormWizard.Fields = { name: { validate: ['required'] } }
+      const formConfig: FormWizard.Config = { name: 'redirect-test', checkSession: false, csrf: false }
       router.use(FormWizard(steps, fields, formConfig))
       mockedRoutes.mockReturnValue(router)
     })

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -7,7 +7,7 @@ import logger from '../logger'
 
 export default function createErrorHandler(production: boolean) {
   return (
-    error: HttpError | SuperagentHttpError | FormWizard.Controller.Error,
+    error: HttpError | SuperagentHttpError | FormWizard.Error,
     req: Request,
     res: Response,
     next: NextFunction,

--- a/server/helpers/field/flattenConditionalFields.test.ts
+++ b/server/helpers/field/flattenConditionalFields.test.ts
@@ -1,11 +1,11 @@
 import flattenConditionalFields from './flattenConditionalFields'
-import { FieldEntry } from './renderConditionalFields'
+import type { FieldEntry } from './renderConditionalFields'
 
 describe('Field helpers', () => {
   describe('#flattenConditionalFields()', () => {
     describe('when field does not have items', () => {
       it('should return original field', () => {
-        const field = ['court', { name: 'court' }] as FieldEntry
+        const field: FieldEntry = ['court', { name: 'court' }]
         const response = flattenConditionalFields(field)
 
         expect(response).toEqual(['court', { name: 'court' }])
@@ -15,7 +15,7 @@ describe('Field helpers', () => {
     describe('when field has items', () => {
       describe('with no conditional items', () => {
         it('should return original field', () => {
-          const field = [
+          const field: FieldEntry = [
             'court',
             {
               name: 'options-field',
@@ -26,7 +26,7 @@ describe('Field helpers', () => {
                 },
               ],
             },
-          ] as FieldEntry
+          ]
           const response = flattenConditionalFields(field)
 
           expect(response).toEqual([
@@ -47,7 +47,7 @@ describe('Field helpers', () => {
       describe('with conditional items', () => {
         describe('when conditional is a string', () => {
           it('should return original field', () => {
-            const field = [
+            const field: FieldEntry = [
               'court',
               {
                 name: 'options-field',
@@ -59,7 +59,7 @@ describe('Field helpers', () => {
                   },
                 ],
               },
-            ] as FieldEntry
+            ]
             const response = flattenConditionalFields(field)
 
             expect(response).toEqual([
@@ -80,7 +80,7 @@ describe('Field helpers', () => {
 
         describe('when conditional is an object', () => {
           it('should flatten conditional', () => {
-            const field = [
+            const field: FieldEntry = [
               'court',
               {
                 name: 'options-field',
@@ -95,7 +95,7 @@ describe('Field helpers', () => {
                   },
                 ],
               },
-            ] as FieldEntry
+            ]
             const response = flattenConditionalFields(field)
 
             expect(response).toEqual([
@@ -116,7 +116,7 @@ describe('Field helpers', () => {
 
         describe('when conditionals is an array', () => {
           it('should flatten conditionals', () => {
-            const field = [
+            const field: FieldEntry = [
               'court',
               {
                 name: 'options-field',
@@ -134,7 +134,7 @@ describe('Field helpers', () => {
                   },
                 ],
               },
-            ] as FieldEntry
+            ]
             const response = flattenConditionalFields(field)
 
             expect(response).toEqual([

--- a/server/helpers/field/flattenConditionalFields.ts
+++ b/server/helpers/field/flattenConditionalFields.ts
@@ -1,4 +1,4 @@
-import { FieldEntry } from './renderConditionalFields'
+import type { FieldEntry } from './renderConditionalFields'
 
 export default function flattenConditionalFields([key, field]: FieldEntry) {
   if (!field.items) {

--- a/server/helpers/field/reduceDependentFields.test.ts
+++ b/server/helpers/field/reduceDependentFields.test.ts
@@ -1,6 +1,7 @@
 import FormWizard from 'hmpo-form-wizard'
+
 import reduceDependentFields from './reduceDependentFields'
-import { FieldEntry } from './renderConditionalFields'
+import { type FieldEntry } from './renderConditionalFields'
 
 describe('Field helpers', () => {
   describe('#reduceDependentFields', () => {
@@ -8,7 +9,7 @@ describe('Field helpers', () => {
       foo: {
         name: 'foo',
       },
-    } as { [key: string]: FormWizard.Field }
+    }
     const mockAllFields: { [key: string]: FormWizard.Field } = {
       conditionalField1: {
         name: 'conditionalField1',
@@ -16,11 +17,11 @@ describe('Field helpers', () => {
       conditionalField2: {
         name: 'conditionalField2',
       },
-    } as { [key: string]: FormWizard.Field }
+    }
 
     describe('when field does not have items', () => {
       it('should not add to accumulator', () => {
-        const field = ['court', { name: 'court' }] as FieldEntry
+        const field: FieldEntry = ['court', { name: 'court' }]
         const response = reduceDependentFields()(mockAccumulator, field)
 
         expect(response).toEqual(mockAccumulator)
@@ -30,7 +31,7 @@ describe('Field helpers', () => {
     describe('when field has items', () => {
       describe('with no conditional values', () => {
         it('should not add to accumulator', () => {
-          const field = [
+          const field: FieldEntry = [
             'court',
             {
               name: 'options-field',
@@ -41,7 +42,7 @@ describe('Field helpers', () => {
                 },
               ],
             },
-          ] as FieldEntry
+          ]
           const response = reduceDependentFields()(mockAccumulator, field)
 
           expect(response).toEqual(mockAccumulator)
@@ -49,7 +50,7 @@ describe('Field helpers', () => {
       })
 
       describe('when conditional is a string', () => {
-        const field = [
+        const field: FieldEntry = [
           'court',
           {
             name: 'options-field',
@@ -61,7 +62,7 @@ describe('Field helpers', () => {
               },
             ],
           },
-        ] as FieldEntry
+        ]
 
         describe('when conditional field does not exist', () => {
           it('should not add to accumulator', () => {
@@ -96,7 +97,7 @@ describe('Field helpers', () => {
       })
 
       describe('when conditional is an array', () => {
-        const field = [
+        const field: FieldEntry = [
           'court',
           {
             name: 'options-field',
@@ -108,7 +109,7 @@ describe('Field helpers', () => {
               },
             ],
           },
-        ] as FieldEntry
+        ]
 
         describe('when conditional fields do not exist', () => {
           it('should not add to accumulator', () => {

--- a/server/helpers/field/reduceDependentFields.ts
+++ b/server/helpers/field/reduceDependentFields.ts
@@ -1,5 +1,6 @@
 import FormWizard from 'hmpo-form-wizard'
-import { FieldEntry } from './renderConditionalFields'
+
+import type { FieldEntry } from './renderConditionalFields'
 
 export default function reduceDependentFields(allFields: { [key: string]: FormWizard.Field } = {}) {
   return function reducer(accumulator: { [key: string]: FormWizard.Field }, [key, field]: FieldEntry) {
@@ -19,7 +20,7 @@ export default function reduceDependentFields(allFields: { [key: string]: FormWi
         },
       }
 
-      conditionals.forEach((conditional: FormWizard.Field['items'][0]['conditional']) => {
+      conditionals.forEach(conditional => {
         const conditionalField = (
           conditional instanceof Object ? conditional : allFields[conditional]
         ) as FormWizard.Field

--- a/server/helpers/field/renderConditionalFields.test.ts
+++ b/server/helpers/field/renderConditionalFields.test.ts
@@ -3,13 +3,13 @@ import FormWizard from 'hmpo-form-wizard'
 
 import nunjucksSetup from '../../utils/nunjucksSetup'
 import * as utils from '../../utils/utils'
-import renderConditionalFields, { FieldEntry } from './renderConditionalFields'
+import renderConditionalFields, { type FieldEntry } from './renderConditionalFields'
 
 jest.mock('../../utils/utils')
 
-const req: FormWizard.Request = {
+const req = {
   services: {},
-} as unknown as typeof req
+} as unknown as FormWizard.Request
 
 describe('Field helpers', () => {
   describe('#renderConditionalFields()', () => {
@@ -28,7 +28,7 @@ describe('Field helpers', () => {
 
     describe("when field doesn't contain items", () => {
       it('should return the original field as object', () => {
-        const field = ['court', { name: 'court' }] as FieldEntry
+        const field: FieldEntry = ['court', { name: 'court' }]
         const response = renderConditionalFields(req, field, [field])
 
         expect(response).toEqual(['court', { name: 'court' }])
@@ -38,7 +38,7 @@ describe('Field helpers', () => {
     describe('when field contains items', () => {
       describe('when conditional is a string', () => {
         describe('when field exists', () => {
-          const field = [
+          const field: FieldEntry = [
             'field',
             {
               name: 'field',
@@ -55,8 +55,8 @@ describe('Field helpers', () => {
                 },
               ],
             },
-          ] as FieldEntry
-          const fields = [
+          ]
+          const fields: FieldEntry[] = [
             field,
             [
               'conditional_field_one',
@@ -72,7 +72,7 @@ describe('Field helpers', () => {
                 classes: 'input-classes',
               },
             ],
-          ] as FieldEntry[]
+          ]
           let response: ReturnType<typeof renderConditionalFields>
 
           beforeEach(() => {
@@ -100,7 +100,7 @@ describe('Field helpers', () => {
         })
 
         describe('when field doesn’t exist', () => {
-          const field = [
+          const field: FieldEntry = [
             'field',
             {
               name: 'field',
@@ -112,7 +112,7 @@ describe('Field helpers', () => {
                 },
               ],
             },
-          ] as FieldEntry
+          ]
           let response: ReturnType<typeof renderConditionalFields>
 
           beforeEach(() => {
@@ -132,7 +132,7 @@ describe('Field helpers', () => {
       })
 
       describe('when conditional is not a string ', () => {
-        const field = [
+        const field: FieldEntry = [
           'field',
           {
             id: 'field',
@@ -147,7 +147,7 @@ describe('Field helpers', () => {
               },
             ],
           },
-        ] as FieldEntry
+        ]
         let response: ReturnType<typeof renderConditionalFields>
 
         beforeEach(() => {
@@ -168,7 +168,7 @@ describe('Field helpers', () => {
       })
 
       describe('when conditional is an array', () => {
-        const field = [
+        const field: FieldEntry = [
           'field',
           {
             id: 'field',
@@ -185,8 +185,8 @@ describe('Field helpers', () => {
               },
             ],
           },
-        ] as FieldEntry
-        const fields = [
+        ]
+        const fields: FieldEntry[] = [
           field,
           [
             'conditional_field_one',
@@ -202,7 +202,7 @@ describe('Field helpers', () => {
               classes: 'input-classes',
             },
           ],
-        ] as FieldEntry[]
+        ]
         let response: ReturnType<typeof renderConditionalFields>
 
         beforeEach(() => {

--- a/server/routes/addPrisoner/fields.ts
+++ b/server/routes/addPrisoner/fields.ts
@@ -1,4 +1,6 @@
-const fields = {
+import type FormWizard from 'hmpo-form-wizard'
+
+const fields: FormWizard.Fields = {
   prisonerRole: {
     component: 'govukRadios',
     validate: ['required'],

--- a/server/routes/addPrisoner/steps.ts
+++ b/server/routes/addPrisoner/steps.ts
@@ -1,6 +1,8 @@
+import type FormWizard from 'hmpo-form-wizard'
+
 import AddPrisoner from '../../controllers/addPrisoner/addPrisoner'
 
-const steps = {
+const steps: FormWizard.Steps = {
   '/': {
     entryPoint: true,
     reset: true,

--- a/server/routes/changeIncident/fields.ts
+++ b/server/routes/changeIncident/fields.ts
@@ -1,4 +1,6 @@
-const fields = {
+import type FormWizard from 'hmpo-form-wizard'
+
+const fields: FormWizard.Fields = {
   incidentDate: {
     component: 'mojDatePicker',
     id: 'incidentDate',

--- a/server/routes/changeIncident/steps.ts
+++ b/server/routes/changeIncident/steps.ts
@@ -1,6 +1,8 @@
+import type FormWizard from 'hmpo-form-wizard'
+
 import ChangeIncident from '../../controllers/changeIncident/changeIncident'
 
-const steps = {
+const steps: FormWizard.Steps = {
   '/': {
     entryPoint: true,
     reset: true,

--- a/server/routes/createIncident/fields.ts
+++ b/server/routes/createIncident/fields.ts
@@ -1,4 +1,6 @@
-const fields = {
+import type FormWizard from 'hmpo-form-wizard'
+
+const fields: FormWizard.Fields = {
   incidentType: {
     component: 'govukSelect',
     validate: ['required'],

--- a/server/routes/createIncident/steps.ts
+++ b/server/routes/createIncident/steps.ts
@@ -1,6 +1,8 @@
+import type FormWizard from 'hmpo-form-wizard'
+
 import CreateIncident from '../../controllers/createIncident/createIncident'
 
-const steps = {
+const steps: FormWizard.Steps = {
   '/': {
     entryPoint: true,
     reset: true,

--- a/server/routes/generic/fields.ts
+++ b/server/routes/generic/fields.ts
@@ -1,4 +1,6 @@
-const fields = {
+import type FormWizard from 'hmpo-form-wizard'
+
+const fields: FormWizard.Fields = {
   incidentType: {
     component: 'govukRadios',
     validate: ['required'],

--- a/server/routes/generic/steps.ts
+++ b/server/routes/generic/steps.ts
@@ -1,8 +1,10 @@
+import type FormWizard from 'hmpo-form-wizard'
+
 import GenericPage1 from '../../controllers/generic/genericPage1'
 import GenericPage2 from '../../controllers/generic/genericPage2'
 import GenericPage3 from '../../controllers/generic/genericPage3'
 
-const steps = {
+const steps: FormWizard.Steps = {
   '/': {
     entryPoint: true,
     reset: true,

--- a/server/routes/questions/router.ts
+++ b/server/routes/questions/router.ts
@@ -10,7 +10,7 @@ import asyncMiddleware from '../../middleware/asyncMiddleware'
 const router = express.Router({ mergeParams: true })
 
 router.use(
-  asyncMiddleware(async (req, res) => {
+  asyncMiddleware(async (req, res, next) => {
     const { reportType } = req.params
 
     const found = types.find(type => type.code === reportType)
@@ -29,7 +29,7 @@ router.use(
       checkSession: false,
       // TODO: When omitted submitting form throw the error above
       csrf: false,
-    })(req, res)
+    })(req, res, next)
   }),
 )
 

--- a/server/utils/backUrl.ts
+++ b/server/utils/backUrl.ts
@@ -1,10 +1,6 @@
-import { Request } from 'express'
-import FormWizard from 'hmpo-form-wizard'
+import type { Request } from 'express'
 
-const backUrl = (
-  req: Request | FormWizard.Request,
-  { fallbackUrl, nextStepUrl = '' }: { fallbackUrl?: string; nextStepUrl?: string },
-) => {
+const backUrl = (req: Request, { fallbackUrl, nextStepUrl = '' }: { fallbackUrl?: string; nextStepUrl?: string }) => {
   let backLink
   const { referrerUrl } = req.session
 


### PR DESCRIPTION
…with clear separation between library and custom additional properties. It’s better to use declaration merging.

Types copied from `hmpps-locations-inside-prison` & `hmpps-strengths-based-needs-assessments-ui` include a lot of application-specific properties that are not applicable to incident reporting and associated code does not exist in this repository.

This PR is easiest to review by first looking at changes made to application code: nearly none! Some types have been tightened up, other declarations now specify types rather than using type assertions (i.e. types are checked rather than assumed).

In future, we will need to tidy up custom properties hanging off form wizard types:
- reuse existing functionality (back links & conditional fields are already supported by the library)
- custom field properties should be nested into sub-objects to not pollute the namespace