### PR TITLE
Added answers IDs to DPS config

### DIFF
--- a/server/data/incidentTypeConfiguration/conversion.ts
+++ b/server/data/incidentTypeConfiguration/conversion.ts
@@ -47,6 +47,7 @@ export function fromNomis(nomisConfig: NomisIncidentTypeConfiguration): DpsIncid
         answers: nomisAnswers.map(ans => {
           const nextQuestionId = ans.nextQuestionnaireQueId?.toString() ?? null
           return {
+            id: ans.questionnaireAnsId.toString(),
             code: ans.answerDesc,
             active: ans.answerActiveFlag === true,
             label: ans.answerDesc,

--- a/server/data/incidentTypeConfiguration/types.ts
+++ b/server/data/incidentTypeConfiguration/types.ts
@@ -27,7 +27,7 @@ export interface QuestionConfiguration {
 }
 
 export interface AnswerConfiguration {
-  /** Answer identifier */
+  /** Answer ID, useful to generate unique names for comment/date inputs */
   id: string
   /** Answer as seen by machines, e.g. it shouldn't change.
    *

--- a/server/data/incidentTypeConfiguration/types.ts
+++ b/server/data/incidentTypeConfiguration/types.ts
@@ -27,6 +27,8 @@ export interface QuestionConfiguration {
 }
 
 export interface AnswerConfiguration {
+  /** Answer identifier */
+  id: string
   /** Answer as seen by machines, e.g. it shouldn't change.
    *
    * For example 'DRONE RECOVERY' */

--- a/server/data/incidentTypeConfiguration/validation.test.ts
+++ b/server/data/incidentTypeConfiguration/validation.test.ts
@@ -143,10 +143,12 @@ describe('DPS config validation', () => {
           label: '1st question?',
           answers: [
             buildAnswer({
+              id: 'yes',
               label: 'yes',
               nextQuestionId: '2',
             }),
             buildAnswer({
+              id: 'no',
               label: 'no',
               nextQuestionId: '3',
             }),
@@ -191,10 +193,12 @@ describe('DPS config validation', () => {
           label: '1st question?',
           answers: [
             buildAnswer({
+              id: 'yes',
               label: 'yes',
               nextQuestionId: '2',
             }),
             buildAnswer({
+              id: 'no',
               label: 'no',
               nextQuestionId: '3',
             }),
@@ -206,10 +210,12 @@ describe('DPS config validation', () => {
           label: '3rd question?',
           answers: [
             buildAnswer({
+              id: 'yes',
               label: 'yes',
               nextQuestionId: '4',
             }),
             buildAnswer({
+              id: 'no',
               label: 'no',
               nextQuestionId: '5',
             }),
@@ -277,11 +283,23 @@ function buildQuestion({
 }
 
 function yesNoAnswers(nextQuestionId: string | null): AnswerConfiguration[] {
-  return [buildAnswer({ label: 'yes', nextQuestionId }), buildAnswer({ label: 'no', nextQuestionId })]
+  return [
+    buildAnswer({ id: 'yes', label: 'yes', nextQuestionId }),
+    buildAnswer({ id: 'no', label: 'no', nextQuestionId }),
+  ]
 }
 
-function buildAnswer({ label, nextQuestionId }: { label: string; nextQuestionId: string | null }): AnswerConfiguration {
+function buildAnswer({
+  id,
+  label,
+  nextQuestionId,
+}: {
+  id: string
+  label: string
+  nextQuestionId: string | null
+}): AnswerConfiguration {
   return {
+    id,
     code: label.toUpperCase(),
     active: true,
     label,

--- a/server/reportConfiguration/types/ABSCONDER.ts
+++ b/server/reportConfiguration/types/ABSCONDER.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:40.554Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:07.286Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179161',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44854',
         },
         {
+          id: '179162',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179380',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -48,6 +51,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44284',
         },
         {
+          id: '179379',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -65,6 +69,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179406',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -73,6 +78,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44861',
         },
         {
+          id: '179405',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -90,6 +96,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179607',
           code: 'YES (ENTER DATE)',
           active: true,
           label: 'YES (ENTER DATE)',
@@ -98,6 +105,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44717',
         },
         {
+          id: '179606',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -115,6 +123,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179847',
           code: 'POLICE ARREST',
           active: true,
           label: 'POLICE ARREST',
@@ -123,6 +132,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44198',
         },
         {
+          id: '179848',
           code: 'PRISON STAFF ARREST',
           active: true,
           label: 'PRISON STAFF ARREST',
@@ -131,6 +141,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44198',
         },
         {
+          id: '179849',
           code: 'SURRENDER',
           active: true,
           label: 'SURRENDER',
@@ -139,6 +150,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44198',
         },
         {
+          id: '179846',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -156,6 +168,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179890',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -164,6 +177,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44615',
         },
         {
+          id: '179889',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -181,6 +195,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180085',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: true,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -198,6 +213,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180389',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -206,6 +222,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44941',
         },
         {
+          id: '180390',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -223,6 +240,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180628',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -231,6 +249,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '45077',
         },
         {
+          id: '180627',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -248,6 +267,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180641',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -256,6 +276,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44868',
         },
         {
+          id: '180642',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -273,6 +294,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180993',
           code: 'FROM ESTABLISHMENT',
           active: true,
           label: 'FROM ESTABLISHMENT',
@@ -281,6 +303,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44271',
         },
         {
+          id: '180995',
           code: 'SUPERVISED OUTSIDE PARTY',
           active: true,
           label: 'SUPERVISED OUTSIDE PARTY',
@@ -289,6 +312,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44271',
         },
         {
+          id: '180996',
           code: 'UNSUPERVISED OUTSIDE PARTY',
           active: true,
           label: 'UNSUPERVISED OUTSIDE PARTY',
@@ -297,6 +321,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44271',
         },
         {
+          id: '180994',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -314,6 +339,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181146',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -322,6 +348,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44609',
         },
         {
+          id: '181145',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -339,6 +366,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181258',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -347,6 +375,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44467',
         },
         {
+          id: '181259',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -355,6 +384,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44467',
         },
         {
+          id: '181257',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -372,6 +402,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181404',
           code: 'MURDER/ATTEMPTED MURDER',
           active: true,
           label: 'MURDER/ATTEMPTED MURDER',
@@ -380,6 +411,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181403',
           code: 'MANSLAUGHTER',
           active: true,
           label: 'MANSLAUGHTER',
@@ -388,6 +420,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181400',
           code: 'ASSAULT',
           active: true,
           label: 'ASSAULT',
@@ -396,6 +429,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181408',
           code: 'RAPE/ATTEMPTED RAPE',
           active: true,
           label: 'RAPE/ATTEMPTED RAPE',
@@ -404,6 +438,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181406',
           code: 'OTHER SEXUAL OFFENCE',
           active: true,
           label: 'OTHER SEXUAL OFFENCE',
@@ -412,6 +447,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181410',
           code: 'THEFT',
           active: true,
           label: 'THEFT',
@@ -420,6 +456,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181409',
           code: 'ROBBERY',
           active: true,
           label: 'ROBBERY',
@@ -428,6 +465,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181402',
           code: 'FIREARM OFFENCE',
           active: true,
           label: 'FIREARM OFFENCE',
@@ -436,6 +474,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181401',
           code: 'DRUG OFFENCE',
           active: true,
           label: 'DRUG OFFENCE',
@@ -444,6 +483,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181411',
           code: 'VEHICLE CRIME',
           active: true,
           label: 'VEHICLE CRIME',
@@ -452,6 +492,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181407',
           code: 'PUBLIC ORDER OFFENCE',
           active: true,
           label: 'PUBLIC ORDER OFFENCE',
@@ -460,6 +501,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44416',
         },
         {
+          id: '181405',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -477,6 +519,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181439',
           code: 'YES (ENTER DATE)',
           active: true,
           label: 'YES (ENTER DATE)',
@@ -485,6 +528,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44402',
         },
         {
+          id: '181440',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -502,6 +546,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181455',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -510,6 +555,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44976',
         },
         {
+          id: '181456',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -518,6 +564,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44976',
         },
         {
+          id: '181454',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -535,6 +582,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181762',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -543,6 +591,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44766',
         },
         {
+          id: '181761',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -560,6 +609,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181892',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -568,6 +618,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44800',
         },
         {
+          id: '181893',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -585,6 +636,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182275',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -593,6 +645,7 @@ const ABSCONDER: IncidentTypeConfiguration = {
           nextQuestionId: '44326',
         },
         {
+          id: '182274',
           code: 'NO',
           active: true,
           label: 'NO',

--- a/server/reportConfiguration/types/ASSAULT.ts
+++ b/server/reportConfiguration/types/ASSAULT.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:45.070Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:12.368Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213062',
           code: 'NO FURTHER ACTION',
           active: true,
           label: 'NO FURTHER ACTION',
@@ -23,6 +24,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61280',
         },
         {
+          id: '213063',
           code: 'IEP REGRESSION',
           active: true,
           label: 'IEP REGRESSION',
@@ -31,6 +33,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61280',
         },
         {
+          id: '213064',
           code: 'PLACED ON REPORT/ADJUDICATION REFERRAL',
           active: true,
           label: 'PLACED ON REPORT/ADJUDICATION REFERRAL',
@@ -39,6 +42,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61280',
         },
         {
+          id: '213065',
           code: 'POLICE REFERRAL',
           active: true,
           label: 'POLICE REFERRAL',
@@ -56,6 +60,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213066',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -64,6 +69,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61281',
         },
         {
+          id: '213067',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -81,6 +87,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213068',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -89,6 +96,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61282',
         },
         {
+          id: '213069',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -106,6 +114,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213070',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -114,6 +123,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61283',
         },
         {
+          id: '213071',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -131,6 +141,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213072',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -139,6 +150,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61284',
         },
         {
+          id: '213073',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -156,6 +168,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213074',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -164,6 +177,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213075',
           code: 'ASSOCIATION AREA',
           active: true,
           label: 'ASSOCIATION AREA',
@@ -172,6 +186,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213076',
           code: 'CELL',
           active: true,
           label: 'CELL',
@@ -180,6 +195,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213077',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -188,6 +204,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213078',
           code: 'DINING ROOM',
           active: true,
           label: 'DINING ROOM',
@@ -196,6 +213,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213079',
           code: 'DORMITORY',
           active: true,
           label: 'DORMITORY',
@@ -204,6 +222,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213080',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -212,6 +231,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213081',
           code: 'EXERCISE YARD',
           active: true,
           label: 'EXERCISE YARD',
@@ -220,6 +240,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213082',
           code: 'GATE',
           active: true,
           label: 'GATE',
@@ -228,6 +249,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213083',
           code: 'GYM',
           active: true,
           label: 'GYM',
@@ -236,6 +258,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213084',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -244,6 +267,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213085',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -252,6 +276,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213086',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -260,6 +285,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213087',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -268,6 +294,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213088',
           code: 'RECESS',
           active: true,
           label: 'RECESS',
@@ -276,6 +303,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213089',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -284,6 +312,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213090',
           code: 'SPECIAL UNIT',
           active: true,
           label: 'SPECIAL UNIT',
@@ -292,6 +321,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213091',
           code: 'SHOWERS/CHANGING ROOM',
           active: true,
           label: 'SHOWERS/CHANGING ROOM',
@@ -300,6 +330,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213092',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -308,6 +339,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213093',
           code: 'WING',
           active: true,
           label: 'WING',
@@ -316,6 +348,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213094',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -324,6 +357,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213095',
           code: 'WORKSHOP',
           active: true,
           label: 'WORKSHOP',
@@ -332,6 +366,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213096',
           code: 'WITHIN PERIMETER',
           active: true,
           label: 'WITHIN PERIMETER',
@@ -340,6 +375,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213097',
           code: 'ELSEWHERE',
           active: true,
           label: 'ELSEWHERE',
@@ -348,6 +384,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213098',
           code: 'FUNERAL',
           active: true,
           label: 'FUNERAL',
@@ -356,6 +393,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213099',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: true,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -364,6 +402,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213100',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: true,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -372,6 +411,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213101',
           code: 'OUTSIDE WORKING PARTY',
           active: true,
           label: 'OUTSIDE WORKING PARTY',
@@ -380,6 +420,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213102',
           code: 'SPORTS FIELD',
           active: true,
           label: 'SPORTS FIELD',
@@ -388,6 +429,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213103',
           code: 'VEHICLE',
           active: true,
           label: 'VEHICLE',
@@ -396,6 +438,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213104',
           code: 'WEDDINGS',
           active: true,
           label: 'WEDDINGS',
@@ -404,6 +447,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213105',
           code: 'MAGISTRATES COURT',
           active: true,
           label: 'MAGISTRATES COURT',
@@ -412,6 +456,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213106',
           code: 'CROWN COURT',
           active: true,
           label: 'CROWN COURT',
@@ -420,6 +465,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213107',
           code: 'INDUCTION/FIRST NIGHT CENTRE',
           active: true,
           label: 'INDUCTION/FIRST NIGHT CENTRE',
@@ -428,6 +474,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213108',
           code: 'MAIL ROOM',
           active: true,
           label: 'MAIL ROOM',
@@ -436,6 +483,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213109',
           code: 'VULNERABLE PRISONERS UNIT (VPU)',
           active: true,
           label: 'VULNERABLE PRISONERS UNIT (VPU)',
@@ -444,6 +492,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61285',
         },
         {
+          id: '213110',
           code: 'EXTERNAL ROOF',
           active: true,
           label: 'EXTERNAL ROOF',
@@ -461,6 +510,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213111',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -469,6 +519,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61286',
         },
         {
+          id: '213112',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -486,6 +537,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213113',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -494,6 +546,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61287',
         },
         {
+          id: '213114',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -511,6 +564,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213115',
           code: 'PRISONER ON PRISONER',
           active: true,
           label: 'PRISONER ON PRISONER',
@@ -519,6 +573,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61288',
         },
         {
+          id: '213116',
           code: 'PRISONER ON STAFF',
           active: true,
           label: 'PRISONER ON STAFF',
@@ -527,6 +582,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61289',
         },
         {
+          id: '213117',
           code: 'PRISONER ON OTHER',
           active: true,
           label: 'PRISONER ON OTHER',
@@ -535,6 +591,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61288',
         },
         {
+          id: '213118',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -552,6 +609,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213119',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -560,6 +618,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61290',
         },
         {
+          id: '213120',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -577,6 +636,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213121',
           code: 'OPERATIONAL STAFF - PRISON OFFICER',
           active: true,
           label: 'OPERATIONAL STAFF - PRISON OFFICER',
@@ -585,6 +645,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61290',
         },
         {
+          id: '213122',
           code: 'OPERATIONAL STAFF - OTHER',
           active: true,
           label: 'OPERATIONAL STAFF - OTHER',
@@ -593,6 +654,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61290',
         },
         {
+          id: '213123',
           code: 'NON-OPERATIONAL STAFF',
           active: true,
           label: 'NON-OPERATIONAL STAFF',
@@ -601,6 +663,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61290',
         },
         {
+          id: '213124',
           code: 'NON-DIRECTLY EMPLOYED STAFF',
           active: true,
           label: 'NON-DIRECTLY EMPLOYED STAFF',
@@ -618,6 +681,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213125',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -626,6 +690,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61294',
         },
         {
+          id: '213126',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -643,6 +708,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213127',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -651,6 +717,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61292',
         },
         {
+          id: '213128',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -668,6 +735,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213129',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -676,6 +744,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61294',
         },
         {
+          id: '213130',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -693,6 +762,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213131',
           code: 'NECK OR ABOVE',
           active: true,
           label: 'NECK OR ABOVE',
@@ -701,6 +771,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61294',
         },
         {
+          id: '213132',
           code: 'TORSO',
           active: true,
           label: 'TORSO',
@@ -709,6 +780,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61294',
         },
         {
+          id: '213133',
           code: 'ARMS OR HANDS',
           active: true,
           label: 'ARMS OR HANDS',
@@ -717,6 +789,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61294',
         },
         {
+          id: '213134',
           code: 'LEGS OR FEET',
           active: true,
           label: 'LEGS OR FEET',
@@ -734,6 +807,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213135',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -742,6 +816,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61295',
         },
         {
+          id: '213136',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -759,6 +834,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213137',
           code: 'FIREARM',
           active: true,
           label: 'FIREARM',
@@ -767,6 +843,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213138',
           code: 'CHEMICAL INCAPACITANT',
           active: true,
           label: 'CHEMICAL INCAPACITANT',
@@ -775,6 +852,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213139',
           code: 'KNIFE/BLADE',
           active: true,
           label: 'KNIFE/BLADE',
@@ -783,6 +861,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213140',
           code: 'OTHER SHARP INSTRUMENT',
           active: true,
           label: 'OTHER SHARP INSTRUMENT',
@@ -791,6 +870,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213141',
           code: 'BLUNT INSTRUMENT',
           active: true,
           label: 'BLUNT INSTRUMENT',
@@ -799,6 +879,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213142',
           code: 'LIGATURE',
           active: true,
           label: 'LIGATURE',
@@ -807,6 +888,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213143',
           code: 'DANGEROUS LIQUID',
           active: true,
           label: 'DANGEROUS LIQUID',
@@ -815,6 +897,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213144',
           code: 'EXCRETA/URINE',
           active: true,
           label: 'EXCRETA/URINE',
@@ -823,6 +906,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213145',
           code: 'FOOD',
           active: true,
           label: 'FOOD',
@@ -831,6 +915,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213146',
           code: 'THROWN FURNITURE',
           active: true,
           label: 'THROWN FURNITURE',
@@ -839,6 +924,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213147',
           code: 'THROWN EQUIPMENT',
           active: true,
           label: 'THROWN EQUIPMENT',
@@ -847,6 +933,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61296',
         },
         {
+          id: '213148',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -864,6 +951,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213149',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -872,6 +960,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61297',
         },
         {
+          id: '213150',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -889,6 +978,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213151',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -897,6 +987,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61298',
         },
         {
+          id: '213152',
           code: 'OPERATIONAL STAFF - PRISON OFFICER',
           active: true,
           label: 'OPERATIONAL STAFF - PRISON OFFICER',
@@ -905,6 +996,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61298',
         },
         {
+          id: '213153',
           code: 'OPERATIONAL STAFF - OTHER',
           active: true,
           label: 'OPERATIONAL STAFF - OTHER',
@@ -913,6 +1005,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61298',
         },
         {
+          id: '213154',
           code: 'NON-OPERATIONAL STAFF',
           active: true,
           label: 'NON-OPERATIONAL STAFF',
@@ -921,6 +1014,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61298',
         },
         {
+          id: '213155',
           code: 'NON-DIRECTLY EMPLOYED STAFF',
           active: true,
           label: 'NON-DIRECTLY EMPLOYED STAFF',
@@ -929,6 +1023,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61298',
         },
         {
+          id: '213156',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -937,6 +1032,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61298',
         },
         {
+          id: '213157',
           code: 'VISITOR',
           active: true,
           label: 'VISITOR',
@@ -945,6 +1041,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61298',
         },
         {
+          id: '213158',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -962,6 +1059,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213159',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -970,6 +1068,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61299',
         },
         {
+          id: '213160',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -987,6 +1086,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213161',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -995,6 +1095,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213162',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -1003,6 +1104,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213163',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -1011,6 +1113,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213164',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -1019,6 +1122,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213165',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -1027,6 +1131,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213166',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -1035,6 +1140,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213167',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -1043,6 +1149,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213168',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -1051,6 +1158,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213169',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -1059,6 +1167,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213170',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -1067,6 +1176,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213171',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -1075,6 +1185,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61300',
         },
         {
+          id: '213172',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -1092,6 +1203,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213173',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1100,6 +1212,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61301',
         },
         {
+          id: '213174',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1117,6 +1230,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213175',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -1125,6 +1239,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61302',
         },
         {
+          id: '213176',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -1133,6 +1248,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61302',
         },
         {
+          id: '213177',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -1141,6 +1257,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61302',
         },
         {
+          id: '213178',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -1149,6 +1266,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61302',
         },
         {
+          id: '213179',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1166,6 +1284,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213180',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1174,6 +1293,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61305',
         },
         {
+          id: '213181',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1191,6 +1311,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213182',
           code: 'A AND E',
           active: true,
           label: 'A AND E',
@@ -1199,6 +1320,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61304',
         },
         {
+          id: '213183',
           code: 'INPATIENT (OVERNIGHT ONLY)',
           active: true,
           label: 'INPATIENT (OVERNIGHT ONLY)',
@@ -1207,6 +1329,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61304',
         },
         {
+          id: '213184',
           code: 'INPATIENT (OVER 24HR)',
           active: true,
           label: 'INPATIENT (OVER 24HR)',
@@ -1215,6 +1338,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61304',
         },
         {
+          id: '213185',
           code: 'LIFE SUPPORT',
           active: true,
           label: 'LIFE SUPPORT',
@@ -1232,6 +1356,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213186',
           code: 'PRISONERS',
           active: false,
           label: 'PRISONERS',
@@ -1240,6 +1365,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61305',
         },
         {
+          id: '213187',
           code: 'OPERATIONAL STAFF - PRISON OFFICER',
           active: false,
           label: 'OPERATIONAL STAFF - PRISON OFFICER',
@@ -1248,6 +1374,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61305',
         },
         {
+          id: '213188',
           code: 'OPERATIONAL STAFF - OTHER',
           active: false,
           label: 'OPERATIONAL STAFF - OTHER',
@@ -1265,6 +1392,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213197',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1273,6 +1401,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61306',
         },
         {
+          id: '213198',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1290,6 +1419,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213199',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1298,6 +1428,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61307',
         },
         {
+          id: '213200',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1315,6 +1446,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213201',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1323,6 +1455,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61308',
         },
         {
+          id: '213202',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1340,6 +1473,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213203',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1348,6 +1482,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61309',
         },
         {
+          id: '213204',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1365,6 +1500,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213205',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1373,6 +1509,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61311',
         },
         {
+          id: '213206',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1390,6 +1527,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213207',
           code: 'BODY WORN VIDEO CAMERA',
           active: true,
           label: 'BODY WORN VIDEO CAMERA',
@@ -1398,6 +1536,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61311',
         },
         {
+          id: '213208',
           code: 'CCTV',
           active: true,
           label: 'CCTV',
@@ -1406,6 +1545,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61311',
         },
         {
+          id: '213209',
           code: 'PIN PHONES',
           active: true,
           label: 'PIN PHONES',
@@ -1414,6 +1554,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61311',
         },
         {
+          id: '213210',
           code: 'RADIO NET',
           active: true,
           label: 'RADIO NET',
@@ -1422,6 +1563,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61311',
         },
         {
+          id: '213211',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1439,6 +1581,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213212',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1447,6 +1590,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '213213',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1464,6 +1608,7 @@ const ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213189',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1472,6 +1617,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61305',
         },
         {
+          id: '213190',
           code: 'OPERATIONAL STAFF - PRISON OFFICER',
           active: true,
           label: 'OPERATIONAL STAFF - PRISON OFFICER',
@@ -1480,6 +1626,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61305',
         },
         {
+          id: '213191',
           code: 'OPERATIONAL STAFF - OTHER',
           active: true,
           label: 'OPERATIONAL STAFF - OTHER',
@@ -1488,6 +1635,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61305',
         },
         {
+          id: '213192',
           code: 'NON-OPERATIONAL STAFF',
           active: true,
           label: 'NON-OPERATIONAL STAFF',
@@ -1496,6 +1644,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61305',
         },
         {
+          id: '213193',
           code: 'NON-DIRECTLY EMPLOYED STAFF',
           active: true,
           label: 'NON-DIRECTLY EMPLOYED STAFF',
@@ -1504,6 +1653,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61305',
         },
         {
+          id: '213194',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -1512,6 +1662,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61305',
         },
         {
+          id: '213195',
           code: 'VISITOR',
           active: true,
           label: 'VISITOR',
@@ -1520,6 +1671,7 @@ const ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '61305',
         },
         {
+          id: '213196',
           code: 'OTHER',
           active: true,
           label: 'OTHER',

--- a/server/reportConfiguration/types/ATTEMPTED_ESCAPE_FROM_CUSTODY.ts
+++ b/server/reportConfiguration/types/ATTEMPTED_ESCAPE_FROM_CUSTODY.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:47.286Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:14.160Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178990',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45096',
         },
         {
+          id: '178991',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179004',
           code: 'LADDER',
           active: true,
           label: 'LADDER',
@@ -48,6 +51,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44297',
         },
         {
+          id: '179006',
           code: 'ROPE',
           active: true,
           label: 'ROPE',
@@ -56,6 +60,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44297',
         },
         {
+          id: '179001',
           code: 'CLIMBING AIDS',
           active: true,
           label: 'CLIMBING AIDS',
@@ -64,6 +69,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44297',
         },
         {
+          id: '179002',
           code: 'FURNITURE ITEMS',
           active: true,
           label: 'FURNITURE ITEMS',
@@ -72,6 +78,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44297',
         },
         {
+          id: '179007',
           code: 'SPORTS ITEMS',
           active: true,
           label: 'SPORTS ITEMS',
@@ -80,6 +87,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44297',
         },
         {
+          id: '179003',
           code: 'GROUNDS ITEMS',
           active: true,
           label: 'GROUNDS ITEMS',
@@ -88,6 +96,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44297',
         },
         {
+          id: '179005',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -105,6 +114,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179037',
           code: 'SSU',
           active: true,
           label: 'SSU',
@@ -113,6 +123,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44506',
         },
         {
+          id: '179032',
           code: 'CRC',
           active: true,
           label: 'CRC',
@@ -121,6 +132,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44506',
         },
         {
+          id: '179038',
           code: 'WING/HOUSEBLOCK',
           active: true,
           label: 'WING/HOUSEBLOCK',
@@ -129,6 +141,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44506',
         },
         {
+          id: '179033',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -137,6 +150,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44506',
         },
         {
+          id: '179036',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -145,6 +159,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44506',
         },
         {
+          id: '179035',
           code: 'RULE 43 UNIT (OR)',
           active: true,
           label: 'RULE 43 UNIT (OR)',
@@ -153,6 +168,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44506',
         },
         {
+          id: '179034',
           code: 'RULE 43 UNIT (GOAD)',
           active: true,
           label: 'RULE 43 UNIT (GOAD)',
@@ -170,6 +186,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179068',
           code: 'WINDOW',
           active: true,
           label: 'WINDOW',
@@ -178,6 +195,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44952',
         },
         {
+          id: '179063',
           code: 'EXTERNAL WALL',
           active: true,
           label: 'EXTERNAL WALL',
@@ -186,6 +204,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44952',
         },
         {
+          id: '179064',
           code: 'FLOOR',
           active: true,
           label: 'FLOOR',
@@ -194,6 +213,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44952',
         },
         {
+          id: '179065',
           code: 'ROOF',
           active: true,
           label: 'ROOF',
@@ -202,6 +222,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44952',
         },
         {
+          id: '179062',
           code: 'DOOR/GATE',
           active: true,
           label: 'DOOR/GATE',
@@ -210,6 +231,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44952',
         },
         {
+          id: '179066',
           code: 'THROUGH FENCE',
           active: true,
           label: 'THROUGH FENCE',
@@ -218,6 +240,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44952',
         },
         {
+          id: '179067',
           code: 'UNDER FENCE',
           active: true,
           label: 'UNDER FENCE',
@@ -226,6 +249,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44952',
         },
         {
+          id: '179061',
           code: 'OVER FENCE',
           active: true,
           label: 'OVER FENCE',
@@ -243,6 +267,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179228',
           code: 'CLAD',
           active: true,
           label: 'CLAD',
@@ -251,6 +276,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45019',
         },
         {
+          id: '179229',
           code: 'UNCLAD',
           active: true,
           label: 'UNCLAD',
@@ -268,6 +294,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179242',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -276,6 +303,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179241',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -293,6 +321,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179268',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -301,6 +330,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45014',
         },
         {
+          id: '179267',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -309,6 +339,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45014',
         },
         {
+          id: '179264',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -317,6 +348,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45014',
         },
         {
+          id: '179266',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -325,6 +357,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45014',
         },
         {
+          id: '179265',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -342,6 +375,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179298',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -350,6 +384,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45006',
         },
         {
+          id: '179299',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -367,6 +402,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179316',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -375,6 +411,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45170',
         },
         {
+          id: '179317',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -392,6 +429,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179333',
           code: 'FULL',
           active: true,
           label: 'FULL',
@@ -400,6 +438,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44346',
         },
         {
+          id: '179334',
           code: 'PARTIAL (ENTER DETAILS)',
           active: true,
           label: 'PARTIAL (ENTER DETAILS)',
@@ -417,6 +456,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179386',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -425,6 +465,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179385',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -442,6 +483,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179392',
           code: 'INSIDE',
           active: true,
           label: 'INSIDE',
@@ -450,6 +492,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44225',
         },
         {
+          id: '179393',
           code: 'OUTSIDE',
           active: true,
           label: 'OUTSIDE',
@@ -467,6 +510,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179408',
           code: 'LOCAL',
           active: true,
           label: 'LOCAL',
@@ -475,6 +519,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45150',
         },
         {
+          id: '179407',
           code: 'SERVICE SUPPLIER',
           active: true,
           label: 'SERVICE SUPPLIER',
@@ -492,6 +537,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179445',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -500,6 +546,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179435',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -508,6 +555,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179436',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -516,6 +564,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179439',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -524,6 +573,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179437',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -532,6 +582,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179438',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -540,6 +591,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179446',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -548,6 +600,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179441',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -556,6 +609,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179440',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -564,6 +618,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179434',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -572,6 +627,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179444',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -580,6 +636,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179443',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -588,6 +645,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '179442',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -605,6 +663,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179463',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -613,6 +672,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179452',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -621,6 +681,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179453',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -629,6 +690,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179456',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -637,6 +699,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179454',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -645,6 +708,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179455',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -653,6 +717,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179464',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -661,6 +726,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179458',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -669,6 +735,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179457',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -677,6 +744,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179451',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -685,6 +753,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179462',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -693,6 +762,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179461',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -701,6 +771,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179459',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -709,6 +780,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '179460',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -726,6 +798,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179536',
           code: 'INSIDE',
           active: true,
           label: 'INSIDE',
@@ -734,6 +807,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44992',
         },
         {
+          id: '179537',
           code: 'OUTSIDE',
           active: true,
           label: 'OUTSIDE',
@@ -751,6 +825,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179543',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -759,6 +834,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44869',
         },
         {
+          id: '179546',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -767,6 +843,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44869',
         },
         {
+          id: '179548',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -775,6 +852,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44869',
         },
         {
+          id: '179540',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -783,6 +861,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44869',
         },
         {
+          id: '179542',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -791,6 +870,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44869',
         },
         {
+          id: '179541',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -799,6 +879,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44869',
         },
         {
+          id: '179544',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -807,6 +888,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44869',
         },
         {
+          id: '179547',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -815,6 +897,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44869',
         },
         {
+          id: '179545',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -832,6 +915,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179560',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -840,6 +924,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44554',
         },
         {
+          id: '179561',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -857,6 +942,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179608',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -865,6 +951,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44875',
         },
         {
+          id: '179609',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -882,6 +969,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179642',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -890,6 +978,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45107',
         },
         {
+          id: '179643',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -907,6 +996,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179644',
           code: 'ANOTHER CELL',
           active: true,
           label: 'ANOTHER CELL',
@@ -915,6 +1005,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '179650',
           code: 'RECESS/SHOWERS',
           active: true,
           label: 'RECESS/SHOWERS',
@@ -923,6 +1014,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '179652',
           code: 'STORE ROOM',
           active: true,
           label: 'STORE ROOM',
@@ -931,6 +1023,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '179645',
           code: 'ASSOCIATION AREA',
           active: true,
           label: 'ASSOCIATION AREA',
@@ -939,6 +1032,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '179649',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -947,6 +1041,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '179647',
           code: 'CANTEEN',
           active: true,
           label: 'CANTEEN',
@@ -955,6 +1050,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '179648',
           code: 'KITCHEN/SERVERY',
           active: true,
           label: 'KITCHEN/SERVERY',
@@ -963,6 +1059,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '179651',
           code: 'ROOF SPACE',
           active: true,
           label: 'ROOF SPACE',
@@ -971,6 +1068,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '179646',
           code: 'BASEMENT',
           active: true,
           label: 'BASEMENT',
@@ -979,6 +1077,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '3921',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -996,6 +1095,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179666',
           code: 'GOVERNOR',
           active: true,
           label: 'GOVERNOR',
@@ -1004,6 +1104,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44958',
         },
         {
+          id: '179664',
           code: 'DEPUTY GOVERNOR',
           active: true,
           label: 'DEPUTY GOVERNOR',
@@ -1012,6 +1113,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44958',
         },
         {
+          id: '179665',
           code: 'DUTY GOVERNOR',
           active: true,
           label: 'DUTY GOVERNOR',
@@ -1020,6 +1122,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44958',
         },
         {
+          id: '179667',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1037,6 +1140,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179676',
           code: 'STAFF INTERVENTION',
           active: true,
           label: 'STAFF INTERVENTION',
@@ -1045,6 +1149,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44447',
         },
         {
+          id: '179674',
           code: 'PRISONER ABANDONED ATTEMPT',
           active: true,
           label: 'PRISONER ABANDONED ATTEMPT',
@@ -1053,6 +1158,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44447',
         },
         {
+          id: '179675',
           code: 'PRISONER INJURED',
           active: true,
           label: 'PRISONER INJURED',
@@ -1061,6 +1167,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44447',
         },
         {
+          id: '179673',
           code: 'PHYSICAL BARRIER',
           active: true,
           label: 'PHYSICAL BARRIER',
@@ -1078,6 +1185,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179681',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1086,6 +1194,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45090',
         },
         {
+          id: '179682',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1103,6 +1212,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179695',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -1111,6 +1221,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179684',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -1119,6 +1230,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179685',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -1127,6 +1239,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179688',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -1135,6 +1248,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179686',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -1143,6 +1257,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179687',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -1151,6 +1266,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179696',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -1159,6 +1275,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179690',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -1167,6 +1284,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179689',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -1175,6 +1293,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179683',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -1183,6 +1302,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179694',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -1191,6 +1311,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179693',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -1199,6 +1320,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179691',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1207,6 +1329,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179692',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1224,6 +1347,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179736',
           code: 'THROUGH THE CLADDING',
           active: true,
           label: 'THROUGH THE CLADDING',
@@ -1232,6 +1356,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44592',
         },
         {
+          id: '179734',
           code: 'ABOVE THE CLADDING',
           active: true,
           label: 'ABOVE THE CLADDING',
@@ -1240,6 +1365,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44592',
         },
         {
+          id: '179735',
           code: 'BELOW THE CLADDING',
           active: true,
           label: 'BELOW THE CLADDING',
@@ -1257,6 +1383,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179930',
           code: 'ENTER COMMENT AND DATE',
           active: true,
           label: 'ENTER COMMENT AND DATE',
@@ -1274,6 +1401,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179947',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -1282,6 +1410,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44498',
         },
         {
+          id: '179950',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -1290,6 +1419,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44498',
         },
         {
+          id: '179952',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -1298,6 +1428,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44498',
         },
         {
+          id: '179944',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -1306,6 +1437,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44498',
         },
         {
+          id: '179946',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -1314,6 +1446,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44498',
         },
         {
+          id: '179945',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -1322,6 +1455,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44498',
         },
         {
+          id: '179948',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -1330,6 +1464,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44498',
         },
         {
+          id: '179951',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -1338,6 +1473,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44498',
         },
         {
+          id: '179949',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1355,6 +1491,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179953',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1363,6 +1500,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45111',
         },
         {
+          id: '179954',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1380,6 +1518,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179971',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -1388,6 +1527,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179961',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -1396,6 +1536,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179962',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -1404,6 +1545,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179965',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -1412,6 +1554,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179963',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -1420,6 +1563,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179964',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -1428,6 +1572,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179972',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -1436,6 +1581,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179967',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -1444,6 +1590,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179966',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -1452,6 +1599,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179960',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -1460,6 +1608,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179970',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -1468,6 +1617,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179969',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -1476,6 +1626,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '179968',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1493,6 +1644,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179977',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1501,6 +1653,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44843',
         },
         {
+          id: '179978',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1518,6 +1671,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179986',
           code: 'ANOTHER PRISONER',
           active: true,
           label: 'ANOTHER PRISONER',
@@ -1526,6 +1680,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '179985',
           code: 'A VISITOR (ENTER IDENTITY IF KNOWN)',
           active: true,
           label: 'A VISITOR (ENTER IDENTITY IF KNOWN)',
@@ -1543,6 +1698,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180104',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -1551,6 +1707,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180093',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -1559,6 +1716,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180094',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -1567,6 +1725,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180097',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -1575,6 +1734,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180095',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -1583,6 +1743,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180096',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -1591,6 +1752,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180105',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -1599,6 +1761,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180099',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -1607,6 +1770,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180098',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -1615,6 +1779,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180092',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -1623,6 +1788,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180103',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -1631,6 +1797,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180102',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -1639,6 +1806,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180100',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1647,6 +1815,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '180101',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1664,6 +1833,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180149',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -1672,6 +1842,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180139',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -1680,6 +1851,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180140',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -1688,6 +1860,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180143',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -1696,6 +1869,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180141',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -1704,6 +1878,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180142',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -1712,6 +1887,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180150',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -1720,6 +1896,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180145',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -1728,6 +1905,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180144',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -1736,6 +1914,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180138',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -1744,6 +1923,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180148',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -1752,6 +1932,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180147',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -1760,6 +1941,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180146',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1768,6 +1950,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '3923',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1785,6 +1968,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180157',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1793,6 +1977,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '180156',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1810,6 +1995,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180191',
           code: 'PRISON HEALTH CARE CENTRE',
           active: true,
           label: 'PRISON HEALTH CARE CENTRE',
@@ -1818,6 +2004,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45073',
         },
         {
+          id: '180190',
           code: 'OUTSIDE HOSPITAL',
           active: true,
           label: 'OUTSIDE HOSPITAL',
@@ -1835,6 +2022,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180221',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -1843,6 +2031,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180210',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -1851,6 +2040,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180211',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -1859,6 +2049,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180214',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -1867,6 +2058,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180212',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -1875,6 +2067,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180213',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -1883,6 +2076,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180222',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -1891,6 +2085,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180216',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -1899,6 +2094,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180215',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -1907,6 +2103,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180209',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -1915,6 +2112,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180220',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -1923,6 +2121,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180219',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -1931,6 +2130,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180217',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1939,6 +2139,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '180218',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1956,6 +2157,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180242',
           code: 'SINGLE',
           active: true,
           label: 'SINGLE',
@@ -1964,6 +2166,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44242',
         },
         {
+          id: '180241',
           code: 'MULTIPLE OCCUPANCY (ENTER CAPACITY)',
           active: true,
           label: 'MULTIPLE OCCUPANCY (ENTER CAPACITY)',
@@ -1981,6 +2184,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180272',
           code: 'UV HAND STAMP',
           active: true,
           label: 'UV HAND STAMP',
@@ -1989,6 +2193,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44597',
         },
         {
+          id: '180268',
           code: 'HAND GEOMETRY',
           active: true,
           label: 'HAND GEOMETRY',
@@ -1997,6 +2202,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44597',
         },
         {
+          id: '180270',
           code: 'PHOTOGRAPHIC RECORD',
           active: true,
           label: 'PHOTOGRAPHIC RECORD',
@@ -2005,6 +2211,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44597',
         },
         {
+          id: '180269',
           code: 'IDENTIFYING CLOTHING',
           active: true,
           label: 'IDENTIFYING CLOTHING',
@@ -2013,6 +2220,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44597',
         },
         {
+          id: '180271',
           code: 'STAFF SUPERVISION',
           active: true,
           label: 'STAFF SUPERVISION',
@@ -2021,6 +2229,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44597',
         },
         {
+          id: '3922',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -2038,6 +2247,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180295',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -2046,6 +2256,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44471',
         },
         {
+          id: '180298',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -2054,6 +2265,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44471',
         },
         {
+          id: '180300',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -2062,6 +2274,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44471',
         },
         {
+          id: '180292',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -2070,6 +2283,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44471',
         },
         {
+          id: '180294',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -2078,6 +2292,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44471',
         },
         {
+          id: '180293',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -2086,6 +2301,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44471',
         },
         {
+          id: '180296',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -2094,6 +2310,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44471',
         },
         {
+          id: '180299',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -2102,6 +2319,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44471',
         },
         {
+          id: '180297',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2119,6 +2337,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180336',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2127,6 +2346,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45021',
         },
         {
+          id: '180337',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2144,6 +2364,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180419',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: true,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -2161,6 +2382,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180420',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2169,6 +2391,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44171',
         },
         {
+          id: '180421',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2186,6 +2409,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180433',
           code: 'DESCRIPTION',
           active: true,
           label: 'DESCRIPTION',
@@ -2203,6 +2427,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180444',
           code: 'FIREARM',
           active: true,
           label: 'FIREARM',
@@ -2211,6 +2436,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180441',
           code: 'CHEMICAL INCAPACITANT',
           active: true,
           label: 'CHEMICAL INCAPACITANT',
@@ -2219,6 +2445,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180446',
           code: 'KNIFE/BLADE',
           active: true,
           label: 'KNIFE/BLADE',
@@ -2227,6 +2454,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180449',
           code: 'OTHER SHARP INSTRUMENT',
           active: true,
           label: 'OTHER SHARP INSTRUMENT',
@@ -2235,6 +2463,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180440',
           code: 'BLUNT INSTRUMENT',
           active: true,
           label: 'BLUNT INSTRUMENT',
@@ -2243,6 +2472,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180447',
           code: 'LIGATURE',
           active: true,
           label: 'LIGATURE',
@@ -2251,6 +2481,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180442',
           code: 'DANGEROUS LIQUID',
           active: true,
           label: 'DANGEROUS LIQUID',
@@ -2259,6 +2490,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180443',
           code: 'EXCRETA/URINE',
           active: true,
           label: 'EXCRETA/URINE',
@@ -2267,6 +2499,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180450',
           code: 'SPITTING',
           active: true,
           label: 'SPITTING',
@@ -2275,6 +2508,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180445',
           code: 'FOOD',
           active: true,
           label: 'FOOD',
@@ -2283,6 +2517,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180452',
           code: 'THROWN FURNITURE',
           active: true,
           label: 'THROWN FURNITURE',
@@ -2291,6 +2526,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180451',
           code: 'THROWN EQUIPMENT',
           active: true,
           label: 'THROWN EQUIPMENT',
@@ -2299,6 +2535,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44731',
         },
         {
+          id: '180448',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -2316,6 +2553,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180500',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2324,6 +2562,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44440',
         },
         {
+          id: '180501',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2341,6 +2580,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180524',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2349,6 +2589,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44315',
         },
         {
+          id: '180525',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2366,6 +2607,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180545',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2374,6 +2616,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44525',
         },
         {
+          id: '180546',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2391,6 +2634,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180558',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2399,6 +2643,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44617',
         },
         {
+          id: '180559',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2416,6 +2661,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180572',
           code: 'SPORTS FIELD',
           active: true,
           label: 'SPORTS FIELD',
@@ -2424,6 +2670,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44274',
         },
         {
+          id: '180573',
           code: 'CELL (ENTER LOCATION)',
           active: true,
           label: 'CELL (ENTER LOCATION)',
@@ -2432,6 +2679,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44163',
         },
         {
+          id: '180574',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -2440,6 +2688,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45124',
         },
         {
+          id: '180588',
           code: 'WING/HOUSEBLOCK',
           active: true,
           label: 'WING/HOUSEBLOCK',
@@ -2448,6 +2697,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180577',
           code: 'DORMITORY',
           active: true,
           label: 'DORMITORY',
@@ -2456,6 +2706,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180583',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -2464,6 +2715,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180576',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -2472,6 +2724,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180584',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -2480,6 +2733,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180578',
           code: 'EDUCATION/LIBRARY',
           active: true,
           label: 'EDUCATION/LIBRARY',
@@ -2488,6 +2742,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180590',
           code: 'WORKSHOP',
           active: true,
           label: 'WORKSHOP',
@@ -2496,6 +2751,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180587',
           code: 'STORES',
           active: true,
           label: 'STORES',
@@ -2504,6 +2760,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180575',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -2512,6 +2769,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180582',
           code: 'GYMNASIUM',
           active: true,
           label: 'GYMNASIUM',
@@ -2520,6 +2778,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180586',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -2528,6 +2787,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180589',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -2536,6 +2796,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180579',
           code: 'EXERCISE YARD',
           active: true,
           label: 'EXERCISE YARD',
@@ -2544,6 +2805,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180585',
           code: 'OTHER SECURE AREA',
           active: true,
           label: 'OTHER SECURE AREA',
@@ -2552,6 +2814,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180581',
           code: 'GROUNDS WITH NO ACCESS TO EXTERNAL PERIMITER',
           active: true,
           label: 'GROUNDS WITH NO ACCESS TO EXTERNAL PERIMITER',
@@ -2560,6 +2823,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44545',
         },
         {
+          id: '180580',
           code: 'GROUNDS WITH ACCESS TO EXTERNAL PERIMITER',
           active: true,
           label: 'GROUNDS WITH ACCESS TO EXTERNAL PERIMITER',
@@ -2577,6 +2841,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180591',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2585,6 +2850,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44912',
         },
         {
+          id: '180592',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2602,6 +2868,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180595',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2610,6 +2877,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44450',
         },
         {
+          id: '180596',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2627,6 +2895,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180647',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -2635,6 +2904,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44300',
         },
         {
+          id: '180650',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -2643,6 +2913,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44300',
         },
         {
+          id: '180652',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -2651,6 +2922,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44300',
         },
         {
+          id: '180644',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -2659,6 +2931,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44300',
         },
         {
+          id: '180646',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -2667,6 +2940,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44300',
         },
         {
+          id: '180645',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -2675,6 +2949,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44300',
         },
         {
+          id: '180648',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -2683,6 +2958,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44300',
         },
         {
+          id: '180651',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -2691,6 +2967,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44300',
         },
         {
+          id: '180649',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2708,6 +2985,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180695',
           code: 'ON FOOT',
           active: true,
           label: 'ON FOOT',
@@ -2716,6 +2994,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '180697',
           code: 'DROVE VEHICLE OUT',
           active: true,
           label: 'DROVE VEHICLE OUT',
@@ -2724,6 +3003,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45152',
         },
         {
+          id: '180696',
           code: 'CONCEALED IN VEHICLE',
           active: true,
           label: 'CONCEALED IN VEHICLE',
@@ -2741,6 +3021,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180712',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2749,6 +3030,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44749',
         },
         {
+          id: '180711',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2766,6 +3048,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180822',
           code: 'DIGGING THROUGH',
           active: true,
           label: 'DIGGING THROUGH',
@@ -2774,6 +3057,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44574',
         },
         {
+          id: '180823',
           code: 'DIGGING UNDER',
           active: true,
           label: 'DIGGING UNDER',
@@ -2782,6 +3066,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44574',
         },
         {
+          id: '180824',
           code: 'EXPLOSION',
           active: true,
           label: 'EXPLOSION',
@@ -2790,6 +3075,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44574',
         },
         {
+          id: '180827',
           code: 'RAMMED BY VEHICLE',
           active: true,
           label: 'RAMMED BY VEHICLE',
@@ -2798,6 +3084,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44574',
         },
         {
+          id: '180826',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -2806,6 +3093,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44574',
         },
         {
+          id: '180825',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2823,6 +3111,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180833',
           code: 'LOCAL',
           active: true,
           label: 'LOCAL',
@@ -2831,6 +3120,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '180834',
           code: 'SERVICE SUPPLIER',
           active: true,
           label: 'SERVICE SUPPLIER',
@@ -2848,6 +3138,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180848',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2856,6 +3147,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44940',
         },
         {
+          id: '180849',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2873,6 +3165,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180857',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2881,6 +3174,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44909',
         },
         {
+          id: '180858',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2898,6 +3192,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180971',
           code: 'CLAD',
           active: true,
           label: 'CLAD',
@@ -2906,6 +3201,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44368',
         },
         {
+          id: '180972',
           code: 'UNCLAD',
           active: true,
           label: 'UNCLAD',
@@ -2923,6 +3219,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180986',
           code: 'ENTER TIME',
           active: true,
           label: 'ENTER TIME',
@@ -2940,6 +3237,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181058',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2948,6 +3246,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44233',
         },
         {
+          id: '181059',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2965,6 +3264,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181073',
           code: 'FROM INSIDE',
           active: true,
           label: 'FROM INSIDE',
@@ -2973,6 +3273,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44670',
         },
         {
+          id: '181074',
           code: 'FROM OUTSIDE',
           active: true,
           label: 'FROM OUTSIDE',
@@ -2990,6 +3291,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181097',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2998,6 +3300,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44595',
         },
         {
+          id: '181096',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3015,6 +3318,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181104',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3023,6 +3327,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44594',
         },
         {
+          id: '181103',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3040,6 +3345,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181108',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3048,6 +3354,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45152',
         },
         {
+          id: '181109',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3065,6 +3372,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181123',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3073,6 +3381,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44313',
         },
         {
+          id: '181124',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3090,6 +3399,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181154',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3098,6 +3408,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44919',
         },
         {
+          id: '181153',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3115,6 +3426,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181218',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -3123,6 +3435,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181207',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -3131,6 +3444,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181208',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -3139,6 +3453,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181211',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -3147,6 +3462,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181209',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -3155,6 +3471,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181210',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -3163,6 +3480,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181219',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -3171,6 +3489,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181213',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -3179,6 +3498,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181212',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -3187,6 +3507,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181206',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -3195,6 +3516,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181217',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -3203,6 +3525,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181216',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -3211,6 +3534,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181214',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -3219,6 +3543,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181215',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -3236,6 +3561,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181306',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3244,6 +3570,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44278',
         },
         {
+          id: '181307',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3261,6 +3588,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181351',
           code: 'LADDER',
           active: true,
           label: 'LADDER',
@@ -3269,6 +3597,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44480',
         },
         {
+          id: '181353',
           code: 'ROPE',
           active: true,
           label: 'ROPE',
@@ -3277,6 +3606,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44480',
         },
         {
+          id: '181348',
           code: 'CLIMBING AIDS',
           active: true,
           label: 'CLIMBING AIDS',
@@ -3285,6 +3615,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44480',
         },
         {
+          id: '181349',
           code: 'FURNITURE ITEMS',
           active: true,
           label: 'FURNITURE ITEMS',
@@ -3293,6 +3624,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44480',
         },
         {
+          id: '181354',
           code: 'SPORTS ITEMS',
           active: true,
           label: 'SPORTS ITEMS',
@@ -3301,6 +3633,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44480',
         },
         {
+          id: '181350',
           code: 'GROUNDS ITEMS',
           active: true,
           label: 'GROUNDS ITEMS',
@@ -3309,6 +3642,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44480',
         },
         {
+          id: '181352',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -3326,6 +3660,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181361',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -3334,6 +3669,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44544',
         },
         {
+          id: '181362',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -3342,6 +3678,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44544',
         },
         {
+          id: '181360',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -3359,6 +3696,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181379',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3367,6 +3705,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44737',
         },
         {
+          id: '181380',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3384,6 +3723,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181443',
           code: 'YES (ENTER DATE)',
           active: true,
           label: 'YES (ENTER DATE)',
@@ -3392,6 +3732,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44285',
         },
         {
+          id: '181444',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3409,6 +3750,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181469',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -3417,6 +3759,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181458',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -3425,6 +3768,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181459',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -3433,6 +3777,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181462',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -3441,6 +3786,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181460',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -3449,6 +3795,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181461',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -3457,6 +3804,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181470',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -3465,6 +3813,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181464',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -3473,6 +3822,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181463',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -3481,6 +3831,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181457',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -3489,6 +3840,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181468',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -3497,6 +3849,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181467',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -3505,6 +3858,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181465',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -3513,6 +3867,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44746',
         },
         {
+          id: '181466',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -3530,6 +3885,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181488',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -3538,6 +3894,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181477',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -3546,6 +3903,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181478',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -3554,6 +3912,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181481',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -3562,6 +3921,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181479',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -3570,6 +3930,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181480',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -3578,6 +3939,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181489',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -3586,6 +3948,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181483',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -3594,6 +3957,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181482',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -3602,6 +3966,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181476',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -3610,6 +3975,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181487',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -3618,6 +3984,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181486',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -3626,6 +3993,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181484',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -3634,6 +4002,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44352',
         },
         {
+          id: '181485',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -3651,6 +4020,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181499',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -3659,6 +4029,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44789',
         },
         {
+          id: '181502',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -3667,6 +4038,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44789',
         },
         {
+          id: '181504',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -3675,6 +4047,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44789',
         },
         {
+          id: '181496',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -3683,6 +4056,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44789',
         },
         {
+          id: '181498',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -3691,6 +4065,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44789',
         },
         {
+          id: '181497',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -3699,6 +4074,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44789',
         },
         {
+          id: '181500',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -3707,6 +4083,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44789',
         },
         {
+          id: '181503',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -3715,6 +4092,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44789',
         },
         {
+          id: '181501',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -3732,6 +4110,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181616',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -3740,6 +4119,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44353',
         },
         {
+          id: '181619',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -3748,6 +4128,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44353',
         },
         {
+          id: '181621',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -3756,6 +4137,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44353',
         },
         {
+          id: '181613',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -3764,6 +4146,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44353',
         },
         {
+          id: '181615',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -3772,6 +4155,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44353',
         },
         {
+          id: '181614',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -3780,6 +4164,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44353',
         },
         {
+          id: '181617',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -3788,6 +4173,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44353',
         },
         {
+          id: '181620',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -3796,6 +4182,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44353',
         },
         {
+          id: '181618',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -3813,6 +4200,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181627',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3821,6 +4209,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44983',
         },
         {
+          id: '181626',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3838,6 +4227,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181648',
           code: 'INVESTIGATION BY POLICE',
           active: true,
           label: 'INVESTIGATION BY POLICE',
@@ -3846,6 +4236,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45033',
         },
         {
+          id: '181649',
           code: 'INVESTIGATION INTERNALLY',
           active: true,
           label: 'INVESTIGATION INTERNALLY',
@@ -3854,6 +4245,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45033',
         },
         {
+          id: '181647',
           code: "GOVERNOR'S ADJUDICATION",
           active: true,
           label: "GOVERNOR'S ADJUDICATION",
@@ -3862,6 +4254,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45033',
         },
         {
+          id: '181650',
           code: 'NO INVESTIGATION',
           active: true,
           label: 'NO INVESTIGATION',
@@ -3879,6 +4272,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181651',
           code: 'NUMBER',
           active: true,
           label: 'NUMBER',
@@ -3896,6 +4290,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181660',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -3904,6 +4299,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44871',
         },
         {
+          id: '181663',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -3912,6 +4308,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44871',
         },
         {
+          id: '181665',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -3920,6 +4317,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44871',
         },
         {
+          id: '181657',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -3928,6 +4326,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44871',
         },
         {
+          id: '181659',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -3936,6 +4335,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44871',
         },
         {
+          id: '181658',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -3944,6 +4344,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44871',
         },
         {
+          id: '181661',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -3952,6 +4353,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44871',
         },
         {
+          id: '181664',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -3960,6 +4362,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44871',
         },
         {
+          id: '181662',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -3977,6 +4380,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181729',
           code: 'CUT',
           active: true,
           label: 'CUT',
@@ -3985,6 +4389,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44327',
         },
         {
+          id: '181730',
           code: 'REMOVED',
           active: true,
           label: 'REMOVED',
@@ -4002,6 +4407,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181744',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4010,6 +4416,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44681',
         },
         {
+          id: '181743',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4027,6 +4434,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181759',
           code: 'MAIN GATE',
           active: true,
           label: 'MAIN GATE',
@@ -4035,6 +4443,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44631',
         },
         {
+          id: '181760',
           code: 'OTHER GATE IN PERIMETER',
           active: true,
           label: 'OTHER GATE IN PERIMETER',
@@ -4043,6 +4452,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44631',
         },
         {
+          id: '181754',
           code: 'OVER WALL',
           active: true,
           label: 'OVER WALL',
@@ -4051,6 +4461,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44840',
         },
         {
+          id: '181753',
           code: 'OVER FENCE',
           active: true,
           label: 'OVER FENCE',
@@ -4059,6 +4470,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44840',
         },
         {
+          id: '181755',
           code: 'THROUGH FENCE',
           active: true,
           label: 'THROUGH FENCE',
@@ -4067,6 +4479,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44822',
         },
         {
+          id: '181756',
           code: 'UNDER FENCE',
           active: true,
           label: 'UNDER FENCE',
@@ -4075,6 +4488,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44822',
         },
         {
+          id: '181757',
           code: 'THROUGH WALL',
           active: true,
           label: 'THROUGH WALL',
@@ -4083,6 +4497,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44759',
         },
         {
+          id: '181758',
           code: 'UNDER WALL',
           active: true,
           label: 'UNDER WALL',
@@ -4100,6 +4515,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181800',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4108,6 +4524,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45172',
         },
         {
+          id: '181801',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4125,6 +4542,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181804',
           code: 'CUT WINDOW OR BARS',
           active: true,
           label: 'CUT WINDOW OR BARS',
@@ -4133,6 +4551,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44582',
         },
         {
+          id: '181809',
           code: 'FORCED WINDOW OR BARS',
           active: true,
           label: 'FORCED WINDOW OR BARS',
@@ -4141,6 +4560,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44582',
         },
         {
+          id: '181803',
           code: 'CUT AND FORCED WINDOW AND BARS',
           active: true,
           label: 'CUT AND FORCED WINDOW AND BARS',
@@ -4149,6 +4569,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44582',
         },
         {
+          id: '181805',
           code: 'DUG THROUGH EXTERNAL WALL',
           active: true,
           label: 'DUG THROUGH EXTERNAL WALL',
@@ -4157,6 +4578,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44582',
         },
         {
+          id: '181807',
           code: 'DUG THROUGH INTERNAL WALL',
           active: true,
           label: 'DUG THROUGH INTERNAL WALL',
@@ -4165,6 +4587,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44582',
         },
         {
+          id: '181806',
           code: 'DUG THROUGH FLOOR',
           active: true,
           label: 'DUG THROUGH FLOOR',
@@ -4173,6 +4596,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44582',
         },
         {
+          id: '181802',
           code: 'BROKE THROUGH CEILING',
           active: true,
           label: 'BROKE THROUGH CEILING',
@@ -4181,6 +4605,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44582',
         },
         {
+          id: '181808',
           code: 'FORCED DOOR',
           active: true,
           label: 'FORCED DOOR',
@@ -4198,6 +4623,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181818',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4206,6 +4632,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44550',
         },
         {
+          id: '181819',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4223,6 +4650,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181898',
           code: 'SMUGGLED WEAPONS',
           active: true,
           label: 'SMUGGLED WEAPONS',
@@ -4231,6 +4659,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44320',
         },
         {
+          id: '181897',
           code: 'SMUGGLED TOOLS/EQUIPMENT',
           active: true,
           label: 'SMUGGLED TOOLS/EQUIPMENT',
@@ -4239,6 +4668,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44320',
         },
         {
+          id: '181899',
           code: 'SWAPPED IDENTITY',
           active: true,
           label: 'SWAPPED IDENTITY',
@@ -4247,6 +4677,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44320',
         },
         {
+          id: '181894',
           code: 'BREACHED PERIMETER',
           active: true,
           label: 'BREACHED PERIMETER',
@@ -4255,6 +4686,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44320',
         },
         {
+          id: '181896',
           code: 'PROVIDED GET AWAY VEHICLE',
           active: true,
           label: 'PROVIDED GET AWAY VEHICLE',
@@ -4263,6 +4695,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44320',
         },
         {
+          id: '181895',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -4280,6 +4713,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181910',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4288,6 +4722,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44977',
         },
         {
+          id: '181911',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4305,6 +4740,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181917',
           code: 'CUT WINDOW OR BARS',
           active: true,
           label: 'CUT WINDOW OR BARS',
@@ -4313,6 +4749,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '181919',
           code: 'FORCED WINDOW OR BARS',
           active: true,
           label: 'FORCED WINDOW OR BARS',
@@ -4321,6 +4758,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '181916',
           code: 'CUT AND FORCED WINDOW AND BARS',
           active: true,
           label: 'CUT AND FORCED WINDOW AND BARS',
@@ -4329,6 +4767,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '181918',
           code: 'DUG THROUGH EXTERNAL WALL',
           active: true,
           label: 'DUG THROUGH EXTERNAL WALL',
@@ -4337,6 +4776,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44528',
         },
         {
+          id: '181914',
           code: 'DUG THROUGH INTERNAL WALL',
           active: true,
           label: 'DUG THROUGH INTERNAL WALL',
@@ -4345,6 +4785,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44341',
         },
         {
+          id: '181913',
           code: 'DUG THROUGH FLOOR',
           active: true,
           label: 'DUG THROUGH FLOOR',
@@ -4353,6 +4794,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44341',
         },
         {
+          id: '181912',
           code: 'BROKE THROUGH CEILING',
           active: true,
           label: 'BROKE THROUGH CEILING',
@@ -4361,6 +4803,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44341',
         },
         {
+          id: '181915',
           code: 'FORCED DOOR',
           active: true,
           label: 'FORCED DOOR',
@@ -4378,6 +4821,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181934',
           code: 'DUG THROUGH',
           active: true,
           label: 'DUG THROUGH',
@@ -4386,6 +4830,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45047',
         },
         {
+          id: '181935',
           code: 'DUG UNDER',
           active: true,
           label: 'DUG UNDER',
@@ -4394,6 +4839,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45047',
         },
         {
+          id: '181936',
           code: 'EXPLOSION',
           active: true,
           label: 'EXPLOSION',
@@ -4402,6 +4848,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45047',
         },
         {
+          id: '181939',
           code: 'RAMMED BY VEHICLE',
           active: true,
           label: 'RAMMED BY VEHICLE',
@@ -4410,6 +4857,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45047',
         },
         {
+          id: '181938',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -4418,6 +4866,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45047',
         },
         {
+          id: '181937',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -4435,6 +4884,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181967',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4443,6 +4893,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44953',
         },
         {
+          id: '181968',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4460,6 +4911,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181972',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4468,6 +4920,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44984',
         },
         {
+          id: '181973',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4485,6 +4938,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181994',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4493,6 +4947,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44494',
         },
         {
+          id: '181995',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4510,6 +4965,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182012',
           code: 'THROUGH THE CLADDING',
           active: true,
           label: 'THROUGH THE CLADDING',
@@ -4518,6 +4974,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44933',
         },
         {
+          id: '182013',
           code: 'ABOVE THE CLADDING',
           active: true,
           label: 'ABOVE THE CLADDING',
@@ -4526,6 +4983,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44327',
         },
         {
+          id: '182014',
           code: 'BELOW THE CLADDING',
           active: true,
           label: 'BELOW THE CLADDING',
@@ -4543,6 +5001,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182024',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -4551,6 +5010,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45121',
         },
         {
+          id: '182027',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -4559,6 +5019,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45121',
         },
         {
+          id: '182029',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -4567,6 +5028,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45121',
         },
         {
+          id: '182021',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -4575,6 +5037,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45121',
         },
         {
+          id: '182023',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -4583,6 +5046,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45121',
         },
         {
+          id: '182022',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -4591,6 +5055,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45121',
         },
         {
+          id: '182025',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -4599,6 +5064,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45121',
         },
         {
+          id: '182028',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -4607,6 +5073,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45121',
         },
         {
+          id: '182026',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -4624,6 +5091,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182084',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4632,6 +5100,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44636',
         },
         {
+          id: '182083',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4649,6 +5118,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182166',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4657,6 +5127,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44923',
         },
         {
+          id: '182167',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4674,6 +5145,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182267',
           code: 'STAFF VIGILANCE',
           active: true,
           label: 'STAFF VIGILANCE',
@@ -4682,6 +5154,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44349',
         },
         {
+          id: '182263',
           code: 'EQUIPMENT FOUND',
           active: true,
           label: 'EQUIPMENT FOUND',
@@ -4690,6 +5163,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44349',
         },
         {
+          id: '182264',
           code: 'INFORMATION/INTELLIGENCE',
           active: true,
           label: 'INFORMATION/INTELLIGENCE',
@@ -4698,6 +5172,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44349',
         },
         {
+          id: '182265',
           code: 'OBSERVED IN PROGRESS',
           active: true,
           label: 'OBSERVED IN PROGRESS',
@@ -4706,6 +5181,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44349',
         },
         {
+          id: '182262',
           code: 'ALERTED BY SECURITY AID',
           active: true,
           label: 'ALERTED BY SECURITY AID',
@@ -4714,6 +5190,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44349',
         },
         {
+          id: '182266',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -4731,6 +5208,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182306',
           code: 'GANDER',
           active: true,
           label: 'GANDER',
@@ -4739,6 +5217,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182312',
           code: 'PIPE',
           active: true,
           label: 'PIPE',
@@ -4747,6 +5226,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182303',
           code: "'S' WIRE",
           active: true,
           label: "'S' WIRE",
@@ -4755,6 +5235,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182314',
           code: 'SCARE STRIP',
           active: true,
           label: 'SCARE STRIP',
@@ -4763,6 +5244,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182315',
           code: 'TAUT WIRE',
           active: true,
           label: 'TAUT WIRE',
@@ -4771,6 +5253,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182307',
           code: 'GEOPHONES',
           active: true,
           label: 'GEOPHONES',
@@ -4779,6 +5262,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182308',
           code: 'INFRA RED DETECTORS',
           active: true,
           label: 'INFRA RED DETECTORS',
@@ -4787,6 +5271,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182310',
           code: 'MICROPHONIC CABLE',
           active: true,
           label: 'MICROPHONIC CABLE',
@@ -4795,6 +5280,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182305',
           code: 'FIBRE OPTIC SYSTEM',
           active: true,
           label: 'FIBRE OPTIC SYSTEM',
@@ -4803,6 +5289,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182309',
           code: 'LEAKY CO-AXIL CABLE',
           active: true,
           label: 'LEAKY CO-AXIL CABLE',
@@ -4811,6 +5298,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182313',
           code: 'PRESSURE SENSORS',
           active: true,
           label: 'PRESSURE SENSORS',
@@ -4819,6 +5307,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182304',
           code: 'CCTV',
           active: true,
           label: 'CCTV',
@@ -4827,6 +5316,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44752',
         },
         {
+          id: '182311',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -4844,6 +5334,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182329',
           code: 'CUT WINDOW OR BARS',
           active: true,
           label: 'CUT WINDOW OR BARS',
@@ -4852,6 +5343,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44685',
         },
         {
+          id: '182334',
           code: 'FORCED WINDOW OR BARS',
           active: true,
           label: 'FORCED WINDOW OR BARS',
@@ -4860,6 +5352,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44685',
         },
         {
+          id: '182328',
           code: 'CUT AND FORCED WINDOW AND BARS',
           active: true,
           label: 'CUT AND FORCED WINDOW AND BARS',
@@ -4868,6 +5361,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44685',
         },
         {
+          id: '182330',
           code: 'DUG THROUGH EXTERNAL WALL',
           active: true,
           label: 'DUG THROUGH EXTERNAL WALL',
@@ -4876,6 +5370,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44685',
         },
         {
+          id: '182332',
           code: 'DUG THROUGH INTERNAL WALL',
           active: true,
           label: 'DUG THROUGH INTERNAL WALL',
@@ -4884,6 +5379,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44685',
         },
         {
+          id: '182331',
           code: 'DUG THROUGH FLOOR',
           active: true,
           label: 'DUG THROUGH FLOOR',
@@ -4892,6 +5388,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44685',
         },
         {
+          id: '182327',
           code: 'BROKE THROUGH CEILING',
           active: true,
           label: 'BROKE THROUGH CEILING',
@@ -4900,6 +5397,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44685',
         },
         {
+          id: '182333',
           code: 'FORCED DOOR',
           active: true,
           label: 'FORCED DOOR',
@@ -4917,6 +5415,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182372',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4925,6 +5424,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45150',
         },
         {
+          id: '182371',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4942,6 +5442,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182385',
           code: 'WINDOW',
           active: true,
           label: 'WINDOW',
@@ -4950,6 +5451,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44147',
         },
         {
+          id: '182380',
           code: 'EXTERNAL WALL',
           active: true,
           label: 'EXTERNAL WALL',
@@ -4958,6 +5460,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44147',
         },
         {
+          id: '182381',
           code: 'FLOOR',
           active: true,
           label: 'FLOOR',
@@ -4966,6 +5469,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44147',
         },
         {
+          id: '182382',
           code: 'ROOF',
           active: true,
           label: 'ROOF',
@@ -4974,6 +5478,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44147',
         },
         {
+          id: '182379',
           code: 'DOOR/GATE',
           active: true,
           label: 'DOOR/GATE',
@@ -4982,6 +5487,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44147',
         },
         {
+          id: '182383',
           code: 'THROUGH FENCE',
           active: true,
           label: 'THROUGH FENCE',
@@ -4990,6 +5496,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44147',
         },
         {
+          id: '182384',
           code: 'UNDER FENCE',
           active: true,
           label: 'UNDER FENCE',
@@ -4998,6 +5505,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44147',
         },
         {
+          id: '182378',
           code: 'OVER FENCE',
           active: true,
           label: 'OVER FENCE',
@@ -5015,6 +5523,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182404',
           code: 'LADDER',
           active: true,
           label: 'LADDER',
@@ -5023,6 +5532,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44444',
         },
         {
+          id: '182406',
           code: 'ROPE',
           active: true,
           label: 'ROPE',
@@ -5031,6 +5541,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44444',
         },
         {
+          id: '182401',
           code: 'CLIMBING AIDS',
           active: true,
           label: 'CLIMBING AIDS',
@@ -5039,6 +5550,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44444',
         },
         {
+          id: '182402',
           code: 'FURNITURE ITEMS',
           active: true,
           label: 'FURNITURE ITEMS',
@@ -5047,6 +5559,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44444',
         },
         {
+          id: '182407',
           code: 'SPORTS ITEMS',
           active: true,
           label: 'SPORTS ITEMS',
@@ -5055,6 +5568,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44444',
         },
         {
+          id: '182403',
           code: 'GROUNDS ITEMS',
           active: true,
           label: 'GROUNDS ITEMS',
@@ -5063,6 +5577,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44444',
         },
         {
+          id: '182405',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -5080,6 +5595,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182442',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -5088,6 +5604,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182431',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -5096,6 +5613,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182432',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -5104,6 +5622,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182435',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -5112,6 +5631,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182433',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -5120,6 +5640,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182434',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -5128,6 +5649,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182443',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -5136,6 +5658,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182437',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -5144,6 +5667,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182436',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -5152,6 +5676,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182430',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -5160,6 +5685,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182441',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -5168,6 +5694,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182440',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -5176,6 +5703,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182438',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -5184,6 +5712,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44935',
         },
         {
+          id: '182439',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -5201,6 +5730,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182452',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -5209,6 +5739,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44517',
         },
         {
+          id: '182451',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -5226,6 +5757,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182558',
           code: 'TELEPHONY',
           active: true,
           label: 'TELEPHONY',
@@ -5234,6 +5766,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44713',
         },
         {
+          id: '182557',
           code: 'IT',
           active: true,
           label: 'IT',
@@ -5251,6 +5784,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182565',
           code: 'PRISON SERVICE VEHICLE',
           active: true,
           label: 'PRISON SERVICE VEHICLE',
@@ -5259,6 +5793,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44484',
         },
         {
+          id: '182561',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -5267,6 +5802,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44484',
         },
         {
+          id: '182562',
           code: 'ESCORT CONTRACTOR',
           active: true,
           label: 'ESCORT CONTRACTOR',
@@ -5275,6 +5811,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44484',
         },
         {
+          id: '182563',
           code: 'OFFICIAL VEHICLE',
           active: true,
           label: 'OFFICIAL VEHICLE',
@@ -5283,6 +5820,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44484',
         },
         {
+          id: '182567',
           code: 'STAFF VEHICLE',
           active: true,
           label: 'STAFF VEHICLE',
@@ -5291,6 +5829,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44484',
         },
         {
+          id: '182566',
           code: 'PRIVATE VEHICLE',
           active: true,
           label: 'PRIVATE VEHICLE',
@@ -5299,6 +5838,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44484',
         },
         {
+          id: '182568',
           code: 'TAXI',
           active: true,
           label: 'TAXI',
@@ -5307,6 +5847,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44484',
         },
         {
+          id: '182564',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -5324,6 +5865,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182626',
           code: 'FROM INSIDE',
           active: true,
           label: 'FROM INSIDE',
@@ -5332,6 +5874,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44707',
         },
         {
+          id: '182627',
           code: 'FROM OUTSIDE',
           active: true,
           label: 'FROM OUTSIDE',
@@ -5349,6 +5892,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182631',
           code: 'CUT WINDOW OR BARS',
           active: true,
           label: 'CUT WINDOW OR BARS',
@@ -5357,6 +5901,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44589',
         },
         {
+          id: '182636',
           code: 'FORCED WINDOW OR BARS',
           active: true,
           label: 'FORCED WINDOW OR BARS',
@@ -5365,6 +5910,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44589',
         },
         {
+          id: '182630',
           code: 'CUT AND FORCED WINDOW AND BARS',
           active: true,
           label: 'CUT AND FORCED WINDOW AND BARS',
@@ -5373,6 +5919,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44589',
         },
         {
+          id: '182632',
           code: 'DUG THROUGH EXTERNAL WALL',
           active: true,
           label: 'DUG THROUGH EXTERNAL WALL',
@@ -5381,6 +5928,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44589',
         },
         {
+          id: '182634',
           code: 'DUG THROUGH INTERNAL WALL',
           active: true,
           label: 'DUG THROUGH INTERNAL WALL',
@@ -5389,6 +5937,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44589',
         },
         {
+          id: '182633',
           code: 'DUG THROUGH FLOOR',
           active: true,
           label: 'DUG THROUGH FLOOR',
@@ -5397,6 +5946,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44589',
         },
         {
+          id: '182629',
           code: 'BROKE THROUGH CEILING',
           active: true,
           label: 'BROKE THROUGH CEILING',
@@ -5405,6 +5955,7 @@ const ATTEMPTED_ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44589',
         },
         {
+          id: '182635',
           code: 'FORCED DOOR',
           active: true,
           label: 'FORCED DOOR',

--- a/server/reportConfiguration/types/ATTEMPTED_ESCAPE_FROM_ESCORT.ts
+++ b/server/reportConfiguration/types/ATTEMPTED_ESCAPE_FROM_ESCORT.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:45.946Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:13.209Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178956',
           code: 'HOSPITAL OUTPATIENT',
           active: true,
           label: 'HOSPITAL OUTPATIENT',
@@ -23,6 +24,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44168',
         },
         {
+          id: '178955',
           code: 'HOSPITAL INPATIENT',
           active: true,
           label: 'HOSPITAL INPATIENT',
@@ -31,6 +33,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44168',
         },
         {
+          id: '178962',
           code: 'INTER PRISON TRANSFER',
           active: true,
           label: 'INTER PRISON TRANSFER',
@@ -39,6 +42,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44496',
         },
         {
+          id: '178963',
           code: 'MAGISTRATES COURT',
           active: true,
           label: 'MAGISTRATES COURT',
@@ -47,6 +51,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44496',
         },
         {
+          id: '178958',
           code: 'CROWN COURT',
           active: true,
           label: 'CROWN COURT',
@@ -55,6 +60,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44496',
         },
         {
+          id: '178957',
           code: 'COUNTY COURT',
           active: true,
           label: 'COUNTY COURT',
@@ -63,6 +69,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44496',
         },
         {
+          id: '178959',
           code: 'FUNERAL',
           active: true,
           label: 'FUNERAL',
@@ -71,6 +78,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44496',
         },
         {
+          id: '178965',
           code: 'WEDDING',
           active: true,
           label: 'WEDDING',
@@ -79,6 +87,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44496',
         },
         {
+          id: '178960',
           code: 'HOME VISIT',
           active: true,
           label: 'HOME VISIT',
@@ -87,6 +96,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44496',
         },
         {
+          id: '178961',
           code: 'HOSP VISIT (DYING RELATIVE)',
           active: true,
           label: 'HOSP VISIT (DYING RELATIVE)',
@@ -95,6 +105,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44496',
         },
         {
+          id: '178964',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -112,6 +123,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178995',
           code: 'SECRETED ON THE PRISONER',
           active: true,
           label: 'SECRETED ON THE PRISONER',
@@ -120,6 +132,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44157',
         },
         {
+          id: '178993',
           code: 'FOUND IN VEHICLE/AREA',
           active: true,
           label: 'FOUND IN VEHICLE/AREA',
@@ -128,6 +141,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44157',
         },
         {
+          id: '178992',
           code: 'BROUGHT BY ACCOMPLICE',
           active: true,
           label: 'BROUGHT BY ACCOMPLICE',
@@ -136,6 +150,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44157',
         },
         {
+          id: '178994',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -153,6 +168,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179017',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -161,6 +177,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44638',
         },
         {
+          id: '179018',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -178,6 +195,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179057',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -186,6 +204,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44496',
         },
         {
+          id: '179056',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -203,6 +222,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179090',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -211,6 +231,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44881',
         },
         {
+          id: '179091',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -219,6 +240,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44881',
         },
         {
+          id: '179089',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -236,6 +258,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179172',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -244,6 +267,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44479',
         },
         {
+          id: '179171',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -261,6 +285,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179230',
           code: 'PRISONER USED KEY',
           active: true,
           label: 'PRISONER USED KEY',
@@ -269,6 +294,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44967',
         },
         {
+          id: '179231',
           code: 'SLIPPED RESTRAINT',
           active: true,
           label: 'SLIPPED RESTRAINT',
@@ -277,6 +303,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44819',
         },
         {
+          id: '179235',
           code: 'PICKED LOCK',
           active: true,
           label: 'PICKED LOCK',
@@ -285,6 +312,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '179236',
           code: 'STAFF UNLOCKED UNDER THREAT',
           active: true,
           label: 'STAFF UNLOCKED UNDER THREAT',
@@ -293,6 +321,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '179232',
           code: 'IMPROPER APPLICATION',
           active: true,
           label: 'IMPROPER APPLICATION',
@@ -301,6 +330,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '179234',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -309,6 +339,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '179233',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -326,6 +357,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179291',
           code: 'PHYSICAL BARRIER',
           active: true,
           label: 'PHYSICAL BARRIER',
@@ -334,6 +366,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44559',
         },
         {
+          id: '179293',
           code: 'PRISON STAFF INTERVENTION',
           active: true,
           label: 'PRISON STAFF INTERVENTION',
@@ -342,6 +375,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44559',
         },
         {
+          id: '179292',
           code: 'POLICE INTERVENTION',
           active: true,
           label: 'POLICE INTERVENTION',
@@ -350,6 +384,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44559',
         },
         {
+          id: '179289',
           code: 'MEMBER OF PUBLIC',
           active: true,
           label: 'MEMBER OF PUBLIC',
@@ -358,6 +393,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44559',
         },
         {
+          id: '179294',
           code: 'PRISONER ABANDONED ATTEMPT',
           active: true,
           label: 'PRISONER ABANDONED ATTEMPT',
@@ -366,6 +402,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44559',
         },
         {
+          id: '179295',
           code: 'PRISONER INJURED IN ATTEMPT',
           active: true,
           label: 'PRISONER INJURED IN ATTEMPT',
@@ -374,6 +411,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44559',
         },
         {
+          id: '179290',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -391,6 +429,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179372',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -399,6 +438,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179374',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -407,6 +447,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179375',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -415,6 +456,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179369',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -423,6 +465,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179371',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -431,6 +474,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179366',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -439,6 +483,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179367',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -447,6 +492,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179368',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -455,6 +501,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179370',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -463,6 +510,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179365',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -471,6 +519,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179373',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -479,6 +528,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44421',
         },
         {
+          id: '179376',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -496,6 +546,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179396',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -504,6 +555,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '179395',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -521,6 +573,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179414',
           code: 'REAL',
           active: true,
           label: 'REAL',
@@ -529,6 +582,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44701',
         },
         {
+          id: '179415',
           code: 'REPLICA',
           active: true,
           label: 'REPLICA',
@@ -537,6 +591,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44701',
         },
         {
+          id: '179413',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -554,6 +609,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179429',
           code: 'SECRETED ON THE PRISONER',
           active: true,
           label: 'SECRETED ON THE PRISONER',
@@ -562,6 +618,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44566',
         },
         {
+          id: '179427',
           code: 'FOUND IN VEHICLE/AREA',
           active: true,
           label: 'FOUND IN VEHICLE/AREA',
@@ -570,6 +627,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44566',
         },
         {
+          id: '179426',
           code: 'BROUGHT BY ACCOMPLICE',
           active: true,
           label: 'BROUGHT BY ACCOMPLICE',
@@ -578,6 +636,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44566',
         },
         {
+          id: '179428',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -595,6 +654,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179474',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -603,6 +663,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45034',
         },
         {
+          id: '179473',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -620,6 +681,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179516',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -628,6 +690,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45099',
         },
         {
+          id: '179517',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -645,6 +708,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179519',
           code: 'COACH',
           active: true,
           label: 'COACH',
@@ -653,6 +717,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '179520',
           code: 'MINIBUS',
           active: true,
           label: 'MINIBUS',
@@ -661,6 +726,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '179523',
           code: 'TAXI',
           active: true,
           label: 'TAXI',
@@ -669,6 +735,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '179518',
           code: 'CELLULAR VEHICLE',
           active: true,
           label: 'CELLULAR VEHICLE',
@@ -677,6 +744,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '179522',
           code: 'SECURE TRANSIT',
           active: true,
           label: 'SECURE TRANSIT',
@@ -685,6 +753,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '179521',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -702,6 +771,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179527',
           code: 'SECRETED ON THE PRISONER',
           active: true,
           label: 'SECRETED ON THE PRISONER',
@@ -710,6 +780,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44836',
         },
         {
+          id: '179525',
           code: 'FOUND IN VEHICLE/AREA',
           active: true,
           label: 'FOUND IN VEHICLE/AREA',
@@ -718,6 +789,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44836',
         },
         {
+          id: '179524',
           code: 'BROUGHT BY ACCOMPLICE',
           active: true,
           label: 'BROUGHT BY ACCOMPLICE',
@@ -726,6 +798,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44836',
         },
         {
+          id: '179526',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -743,6 +816,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179534',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -751,6 +825,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44288',
         },
         {
+          id: '179535',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -768,6 +843,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179899',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -776,6 +852,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44626',
         },
         {
+          id: '179900',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -793,6 +870,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179903',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -801,6 +879,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44900',
         },
         {
+          id: '179904',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -818,6 +897,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179917',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -826,6 +906,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45011',
         },
         {
+          id: '179916',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -843,6 +924,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179938',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -851,6 +933,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44226',
         },
         {
+          id: '179939',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -868,6 +951,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180006',
           code: 'LIVE',
           active: true,
           label: 'LIVE',
@@ -876,6 +960,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45138',
         },
         {
+          id: '180005',
           code: 'BLANK',
           active: true,
           label: 'BLANK',
@@ -884,6 +969,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45138',
         },
         {
+          id: '180007',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -901,6 +987,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180137',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -909,6 +996,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44960',
         },
         {
+          id: '180136',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -926,6 +1014,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180151',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -934,6 +1023,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44535',
         },
         {
+          id: '180152',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -951,6 +1041,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180183',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -959,6 +1050,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45094',
         },
         {
+          id: '180182',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -976,6 +1068,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180197',
           code: 'VEHICLE EN ROUTE TO VENUE',
           active: true,
           label: 'VEHICLE EN ROUTE TO VENUE',
@@ -984,6 +1077,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44307',
         },
         {
+          id: '180196',
           code: 'VEHICLE EN ROUTE FROM VENUE',
           active: true,
           label: 'VEHICLE EN ROUTE FROM VENUE',
@@ -992,6 +1086,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44307',
         },
         {
+          id: '180195',
           code: 'LEAVING VEHICLE (DEBUSSING)',
           active: true,
           label: 'LEAVING VEHICLE (DEBUSSING)',
@@ -1000,6 +1095,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44307',
         },
         {
+          id: '180194',
           code: 'ENTERING VEHICLE (EMBUSSING)',
           active: true,
           label: 'ENTERING VEHICLE (EMBUSSING)',
@@ -1008,6 +1104,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44307',
         },
         {
+          id: '180206',
           code: 'UNSCHEDULED STOP',
           active: true,
           label: 'UNSCHEDULED STOP',
@@ -1016,6 +1113,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '180198',
           code: 'CELL AT COURT',
           active: true,
           label: 'CELL AT COURT',
@@ -1024,6 +1122,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '180199',
           code: 'COURT CELLS AREA',
           active: true,
           label: 'COURT CELLS AREA',
@@ -1032,6 +1131,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '180201',
           code: 'COURT VISITS AREA',
           active: true,
           label: 'COURT VISITS AREA',
@@ -1040,6 +1140,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '180200',
           code: 'COURT DOCK',
           active: true,
           label: 'COURT DOCK',
@@ -1048,6 +1149,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '180204',
           code: 'HOSPITAL WARD/ROOM',
           active: true,
           label: 'HOSPITAL WARD/ROOM',
@@ -1056,6 +1158,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '180202',
           code: 'HOSPITAL TREATMENT ROOM',
           active: true,
           label: 'HOSPITAL TREATMENT ROOM',
@@ -1064,6 +1167,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '180203',
           code: 'HOSPITAL WAITING AREA',
           active: true,
           label: 'HOSPITAL WAITING AREA',
@@ -1072,6 +1176,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44886',
         },
         {
+          id: '180205',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1089,6 +1194,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180340',
           code: 'GOVERNORS INSTRUCTION',
           active: true,
           label: 'GOVERNORS INSTRUCTION',
@@ -1097,6 +1203,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180347',
           code: 'PREVENTED BY DISABILITY',
           active: true,
           label: 'PREVENTED BY DISABILITY',
@@ -1105,6 +1212,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180348',
           code: 'PREVENTED BY INJURY',
           active: true,
           label: 'PREVENTED BY INJURY',
@@ -1113,6 +1221,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180344',
           code: 'MEDICAL TREATMENT/REQUEST',
           active: true,
           label: 'MEDICAL TREATMENT/REQUEST',
@@ -1121,6 +1230,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180342',
           code: 'IN COURT ROOM',
           active: true,
           label: 'IN COURT ROOM',
@@ -1129,6 +1239,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180343',
           code: 'LOCATED IN SECURE AREA',
           active: true,
           label: 'LOCATED IN SECURE AREA',
@@ -1137,6 +1248,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180341',
           code: 'IN CELL OF CELLULAR VEHICLE',
           active: true,
           label: 'IN CELL OF CELLULAR VEHICLE',
@@ -1145,6 +1257,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180349',
           code: 'TRANSFER TO MENTAL HOSPITAL',
           active: true,
           label: 'TRANSFER TO MENTAL HOSPITAL',
@@ -1153,6 +1266,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180338',
           code: 'DURING MARRIAGE CEREMONY',
           active: true,
           label: 'DURING MARRIAGE CEREMONY',
@@ -1161,6 +1275,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180345',
           code: 'NONE AVAILABLE',
           active: true,
           label: 'NONE AVAILABLE',
@@ -1169,6 +1284,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180339',
           code: 'FAILURE TO USE',
           active: true,
           label: 'FAILURE TO USE',
@@ -1177,6 +1293,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '180346',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1194,6 +1311,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180392',
           code: 'PRISON HEALTH CARE CENTRE',
           active: true,
           label: 'PRISON HEALTH CARE CENTRE',
@@ -1202,6 +1320,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44240',
         },
         {
+          id: '180391',
           code: 'OUTSIDE HOSPITAL',
           active: true,
           label: 'OUTSIDE HOSPITAL',
@@ -1219,6 +1338,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180413',
           code: 'HANDCUFFS',
           active: true,
           label: 'HANDCUFFS',
@@ -1227,6 +1347,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44302',
         },
         {
+          id: '180415',
           code: 'ESCORT CHAIN',
           active: true,
           label: 'ESCORT CHAIN',
@@ -1235,6 +1356,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44437',
         },
         {
+          id: '180414',
           code: 'CLOSETING CHAIN',
           active: true,
           label: 'CLOSETING CHAIN',
@@ -1243,6 +1365,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44437',
         },
         {
+          id: '180416',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1260,6 +1383,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180461',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1268,6 +1392,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44180',
         },
         {
+          id: '180462',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1285,6 +1410,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180475',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1293,6 +1419,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44888',
         },
         {
+          id: '180476',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1310,6 +1437,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180600',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1318,6 +1446,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44312',
         },
         {
+          id: '180599',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1335,6 +1464,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180612',
           code: 'PRISONER WHO ATTEMPTED ESCAPE',
           active: true,
           label: 'PRISONER WHO ATTEMPTED ESCAPE',
@@ -1343,6 +1473,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44294',
         },
         {
+          id: '180610',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -1351,6 +1482,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44294',
         },
         {
+          id: '180611',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -1368,6 +1500,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180668',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -1376,6 +1509,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45041',
         },
         {
+          id: '180669',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -1384,6 +1518,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45041',
         },
         {
+          id: '180672',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -1392,6 +1527,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45041',
         },
         {
+          id: '180671',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -1400,6 +1536,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45041',
         },
         {
+          id: '180670',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1417,6 +1554,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180676',
           code: 'SECRETED ON PRISONER',
           active: true,
           label: 'SECRETED ON PRISONER',
@@ -1425,6 +1563,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44647',
         },
         {
+          id: '180674',
           code: 'FOUND IN VEHICLE/AREA',
           active: true,
           label: 'FOUND IN VEHICLE/AREA',
@@ -1433,6 +1572,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44647',
         },
         {
+          id: '180673',
           code: 'BROUGHT BY OUTSIDE ACCOMPLICE',
           active: true,
           label: 'BROUGHT BY OUTSIDE ACCOMPLICE',
@@ -1441,6 +1581,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44647',
         },
         {
+          id: '180675',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1458,6 +1599,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180721',
           code: 'OTHER SHARP INSTRUMENT',
           active: true,
           label: 'OTHER SHARP INSTRUMENT',
@@ -1466,6 +1608,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44739',
         },
         {
+          id: '180715',
           code: 'BLUNT INSTRUMENT',
           active: true,
           label: 'BLUNT INSTRUMENT',
@@ -1474,6 +1617,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44739',
         },
         {
+          id: '180719',
           code: 'LIGATURE',
           active: true,
           label: 'LIGATURE',
@@ -1482,6 +1626,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44739',
         },
         {
+          id: '180716',
           code: 'DANGEROUS LIQUID',
           active: true,
           label: 'DANGEROUS LIQUID',
@@ -1490,6 +1635,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44739',
         },
         {
+          id: '180717',
           code: 'EXCRETA/URINE',
           active: true,
           label: 'EXCRETA/URINE',
@@ -1498,6 +1644,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44739',
         },
         {
+          id: '180722',
           code: 'SPITTING',
           active: true,
           label: 'SPITTING',
@@ -1506,6 +1653,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44739',
         },
         {
+          id: '180718',
           code: 'FOOD',
           active: true,
           label: 'FOOD',
@@ -1514,6 +1662,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44739',
         },
         {
+          id: '180724',
           code: 'THROWN FURNITURE',
           active: true,
           label: 'THROWN FURNITURE',
@@ -1522,6 +1671,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44739',
         },
         {
+          id: '180723',
           code: 'THROWN EQUIPMENT',
           active: true,
           label: 'THROWN EQUIPMENT',
@@ -1530,6 +1680,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44739',
         },
         {
+          id: '180720',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1547,6 +1698,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180741',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1555,6 +1707,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45115',
         },
         {
+          id: '180742',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1572,6 +1725,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180955',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1580,6 +1734,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44457',
         },
         {
+          id: '180956',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1597,6 +1752,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180973',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -1605,6 +1761,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44481',
         },
         {
+          id: '180974',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -1613,6 +1770,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44481',
         },
         {
+          id: '180977',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -1621,6 +1779,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44481',
         },
         {
+          id: '180976',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -1629,6 +1788,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44481',
         },
         {
+          id: '180975',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1646,6 +1806,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181079',
           code: 'PRISONER WHO ATTEMPTED ESCAPE',
           active: true,
           label: 'PRISONER WHO ATTEMPTED ESCAPE',
@@ -1654,6 +1815,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44627',
         },
         {
+          id: '181077',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -1662,6 +1824,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44627',
         },
         {
+          id: '181078',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -1679,6 +1842,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181161',
           code: 'MALE',
           active: true,
           label: 'MALE',
@@ -1687,6 +1851,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45061',
         },
         {
+          id: '181160',
           code: 'FEMALE',
           active: true,
           label: 'FEMALE',
@@ -1704,6 +1869,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181182',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1712,6 +1878,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44269',
         },
         {
+          id: '181183',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1729,6 +1896,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181244',
           code: 'PRISON SERVICE',
           active: true,
           label: 'PRISON SERVICE',
@@ -1737,6 +1905,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44139',
         },
         {
+          id: '181243',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -1754,6 +1923,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181301',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1762,6 +1932,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44599',
         },
         {
+          id: '181300',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1779,6 +1950,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181337',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1787,6 +1959,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44915',
         },
         {
+          id: '181338',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1804,6 +1977,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181519',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: true,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -1821,6 +1995,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181537',
           code: 'MALE (ENTER NUMBER)',
           active: true,
           label: 'MALE (ENTER NUMBER)',
@@ -1829,6 +2004,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44771',
         },
         {
+          id: '181536',
           code: 'FEMALE (ENTER NUMBER)',
           active: true,
           label: 'FEMALE (ENTER NUMBER)',
@@ -1846,6 +2022,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181549',
           code: 'PURPOSE MADE',
           active: true,
           label: 'PURPOSE MADE',
@@ -1854,6 +2031,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44955',
         },
         {
+          id: '181547',
           code: 'IMPROVISED',
           active: true,
           label: 'IMPROVISED',
@@ -1862,6 +2040,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44955',
         },
         {
+          id: '181548',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1879,6 +2058,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181581',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1887,6 +2067,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44924',
         },
         {
+          id: '181580',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1904,6 +2085,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181600',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -1912,6 +2094,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181602',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -1920,6 +2103,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181603',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -1928,6 +2112,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181597',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -1936,6 +2121,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181599',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -1944,6 +2130,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181594',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -1952,6 +2139,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181595',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -1960,6 +2148,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181596',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -1968,6 +2157,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181598',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -1976,6 +2166,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181593',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -1984,6 +2175,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181601',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -1992,6 +2184,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45044',
         },
         {
+          id: '181604',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -2009,6 +2202,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181632',
           code: 'C.N (CHLORACETOPHEONE)',
           active: true,
           label: 'C.N (CHLORACETOPHEONE)',
@@ -2017,6 +2211,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44604',
         },
         {
+          id: '181633',
           code: 'C.S (ORTHO..NITRILE)',
           active: true,
           label: 'C.S (ORTHO..NITRILE)',
@@ -2025,6 +2220,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44604',
         },
         {
+          id: '181635',
           code: 'O.C (MACE/PEPPER)',
           active: true,
           label: 'O.C (MACE/PEPPER)',
@@ -2033,6 +2229,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44604',
         },
         {
+          id: '181636',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -2041,6 +2238,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44604',
         },
         {
+          id: '181634',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2058,6 +2256,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181667',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2066,6 +2265,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44203',
         },
         {
+          id: '181666',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2083,6 +2283,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181814',
           code: 'PRISONER WHO ATTEMPTED ESCAPE',
           active: true,
           label: 'PRISONER WHO ATTEMPTED ESCAPE',
@@ -2091,6 +2292,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44148',
         },
         {
+          id: '181812',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -2099,6 +2301,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44148',
         },
         {
+          id: '181813',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -2116,6 +2319,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181823',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2124,6 +2328,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44491',
         },
         {
+          id: '181822',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2141,6 +2346,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181843',
           code: 'REAL',
           active: true,
           label: 'REAL',
@@ -2149,6 +2355,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44280',
         },
         {
+          id: '181841',
           code: 'IMPROVISED',
           active: true,
           label: 'IMPROVISED',
@@ -2157,6 +2364,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44280',
         },
         {
+          id: '181842',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2174,6 +2382,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181989',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2182,6 +2391,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44542',
         },
         {
+          id: '181990',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2199,6 +2409,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182086',
           code: 'OFFICER',
           active: true,
           label: 'OFFICER',
@@ -2207,6 +2418,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44437',
         },
         {
+          id: '182085',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -2224,6 +2436,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182144',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2232,6 +2445,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45060',
         },
         {
+          id: '182145',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2249,6 +2463,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182160',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2257,6 +2472,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44708',
         },
         {
+          id: '182161',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2274,6 +2490,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182223',
           code: 'PRISON HEALTH CARE CENTRE',
           active: true,
           label: 'PRISON HEALTH CARE CENTRE',
@@ -2282,6 +2499,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44306',
         },
         {
+          id: '182221',
           code: 'OUTSIDE HOSPITAL',
           active: true,
           label: 'OUTSIDE HOSPITAL',
@@ -2290,6 +2508,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44306',
         },
         {
+          id: '182222',
           code: 'OWN GP',
           active: true,
           label: 'OWN GP',
@@ -2307,6 +2526,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182226',
           code: 'CATEGORY A',
           active: true,
           label: 'CATEGORY A',
@@ -2315,6 +2535,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44429',
         },
         {
+          id: '182227',
           code: 'CATEGORY B',
           active: true,
           label: 'CATEGORY B',
@@ -2323,6 +2544,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44429',
         },
         {
+          id: '182228',
           code: 'CATEGORY C',
           active: true,
           label: 'CATEGORY C',
@@ -2331,6 +2553,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44429',
         },
         {
+          id: '182229',
           code: 'CATEGORY D',
           active: true,
           label: 'CATEGORY D',
@@ -2339,6 +2562,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44429',
         },
         {
+          id: '182225',
           code: 'CATEGORISED YO',
           active: true,
           label: 'CATEGORISED YO',
@@ -2347,6 +2571,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44429',
         },
         {
+          id: '182232',
           code: 'UNCATEGORISED YO',
           active: true,
           label: 'UNCATEGORISED YO',
@@ -2355,6 +2580,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44429',
         },
         {
+          id: '182224',
           code: 'CATEGORISED FEMALE',
           active: true,
           label: 'CATEGORISED FEMALE',
@@ -2363,6 +2589,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44429',
         },
         {
+          id: '182231',
           code: 'UNCATEGORISED FEMALE',
           active: true,
           label: 'UNCATEGORISED FEMALE',
@@ -2371,6 +2598,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44429',
         },
         {
+          id: '182230',
           code: 'UNCATEGORISED ADULT MALE',
           active: true,
           label: 'UNCATEGORISED ADULT MALE',
@@ -2388,6 +2616,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182324',
           code: 'PUBLIC SECTOR',
           active: true,
           label: 'PUBLIC SECTOR',
@@ -2396,6 +2625,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44139',
         },
         {
+          id: '182323',
           code: 'PRIVATE SECTOR',
           active: true,
           label: 'PRIVATE SECTOR',
@@ -2413,6 +2643,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182340',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2421,6 +2652,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44905',
         },
         {
+          id: '182341',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2438,6 +2670,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182409',
           code: 'MALE (ENTER NUMBER)',
           active: true,
           label: 'MALE (ENTER NUMBER)',
@@ -2446,6 +2679,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44782',
         },
         {
+          id: '182408',
           code: 'FEMALE (ENTER NUMBER)',
           active: true,
           label: 'FEMALE (ENTER NUMBER)',
@@ -2463,6 +2697,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182521',
           code: 'PRISONER WHO ATTEMPTED ESCAPE',
           active: true,
           label: 'PRISONER WHO ATTEMPTED ESCAPE',
@@ -2471,6 +2706,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44308',
         },
         {
+          id: '182519',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -2479,6 +2715,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44308',
         },
         {
+          id: '182520',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -2496,6 +2733,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182528',
           code: 'A CO-DEFENDANT',
           active: true,
           label: 'A CO-DEFENDANT',
@@ -2504,6 +2742,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44437',
         },
         {
+          id: '182530',
           code: 'A RELATIVE',
           active: true,
           label: 'A RELATIVE',
@@ -2512,6 +2751,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44437',
         },
         {
+          id: '182529',
           code: 'A KNOWN ASSOCIATE',
           active: true,
           label: 'A KNOWN ASSOCIATE',
@@ -2520,6 +2760,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44437',
         },
         {
+          id: '182531',
           code: 'AN E LIST PRISONER',
           active: true,
           label: 'AN E LIST PRISONER',
@@ -2528,6 +2769,7 @@ const ATTEMPTED_ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44437',
         },
         {
+          id: '182532',
           code: 'NONE OF THE ABOVE',
           active: true,
           label: 'NONE OF THE ABOVE',

--- a/server/reportConfiguration/types/BOMB_THREAT.ts
+++ b/server/reportConfiguration/types/BOMB_THREAT.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:49.273Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:16.215Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '178914',
           code: 'BLAST BOMB',
           active: true,
           label: 'BLAST BOMB',
@@ -23,6 +24,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44669',
         },
         {
+          id: '178922',
           code: 'VEHICLE BOMB',
           active: true,
           label: 'VEHICLE BOMB',
@@ -31,6 +33,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44669',
         },
         {
+          id: '178920',
           code: 'POSTAL BOMB',
           active: true,
           label: 'POSTAL BOMB',
@@ -39,6 +42,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44669',
         },
         {
+          id: '178919',
           code: 'INCENDIARY DEVICE',
           active: true,
           label: 'INCENDIARY DEVICE',
@@ -47,6 +51,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44669',
         },
         {
+          id: '178918',
           code: 'HOAX PACKAGE',
           active: true,
           label: 'HOAX PACKAGE',
@@ -55,6 +60,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44669',
         },
         {
+          id: '178921',
           code: 'SUSPECT PACKAGE',
           active: true,
           label: 'SUSPECT PACKAGE',
@@ -63,6 +69,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44669',
         },
         {
+          id: '178915',
           code: 'DETONATORS',
           active: true,
           label: 'DETONATORS',
@@ -71,6 +78,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44669',
         },
         {
+          id: '178917',
           code: 'FUSES',
           active: true,
           label: 'FUSES',
@@ -79,6 +87,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44669',
         },
         {
+          id: '178916',
           code: 'EXPLOSIVE',
           active: true,
           label: 'EXPLOSIVE',
@@ -96,6 +105,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '178941',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -104,6 +114,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178943',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -112,6 +123,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178944',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -120,6 +132,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178938',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -128,6 +141,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178940',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -136,6 +150,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178935',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -144,6 +159,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178936',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -152,6 +168,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178937',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -160,6 +177,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178939',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -168,6 +186,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178934',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -176,6 +195,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178942',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -184,6 +204,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44745',
         },
         {
+          id: '178945',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -201,6 +222,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '178997',
           code: 'TELEPHONY',
           active: true,
           label: 'TELEPHONY',
@@ -209,6 +231,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '45109',
         },
         {
+          id: '178996',
           code: 'IT',
           active: true,
           label: 'IT',
@@ -226,6 +249,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179103',
           code: 'CONTROLLED',
           active: true,
           label: 'CONTROLLED',
@@ -234,6 +258,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44277',
         },
         {
+          id: '179104',
           code: 'UNCONTROLLED',
           active: true,
           label: 'UNCONTROLLED',
@@ -251,6 +276,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179159',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -259,6 +285,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44587',
         },
         {
+          id: '179160',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -276,6 +303,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179276',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: true,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -293,6 +321,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179347',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -301,6 +330,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44579',
         },
         {
+          id: '179346',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -318,6 +348,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179348',
           code: 'ENTER DESCRIPTION',
           active: true,
           label: 'ENTER DESCRIPTION',
@@ -335,6 +366,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179389',
           code: 'ENTER COMMENT AND DATE',
           active: true,
           label: 'ENTER COMMENT AND DATE',
@@ -352,6 +384,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179390',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -360,6 +393,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44523',
         },
         {
+          id: '179391',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -377,6 +411,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179404',
           code: 'SPECIFY',
           active: true,
           label: 'SPECIFY',
@@ -394,6 +429,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179515',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -402,6 +438,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44260',
         },
         {
+          id: '179514',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -419,6 +456,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179713',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -427,6 +465,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44380',
         },
         {
+          id: '179712',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -444,6 +483,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179714',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -452,6 +492,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44261',
         },
         {
+          id: '179715',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -469,6 +510,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179748',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -477,6 +519,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44978',
         },
         {
+          id: '179747',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -494,6 +537,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179787',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -502,6 +546,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44197',
         },
         {
+          id: '179786',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -519,6 +564,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179826',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -527,6 +573,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44716',
         },
         {
+          id: '179827',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -544,6 +591,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179852',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -552,6 +600,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44547',
         },
         {
+          id: '179851',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -569,6 +618,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180110',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -577,6 +627,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44393',
         },
         {
+          id: '180109',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -585,6 +636,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44393',
         },
         {
+          id: '180106',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -593,6 +645,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44393',
         },
         {
+          id: '180108',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -601,6 +654,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44393',
         },
         {
+          id: '180107',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -618,6 +672,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180255',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -626,6 +681,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '45113',
         },
         {
+          id: '180254',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -643,6 +699,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180267',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -651,6 +708,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44149',
         },
         {
+          id: '180266',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -668,6 +726,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180285',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -676,6 +735,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44236',
         },
         {
+          id: '180286',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -684,6 +744,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44236',
         },
         {
+          id: '180284',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -701,6 +762,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180425',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -709,6 +771,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44974',
         },
         {
+          id: '180424',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -726,6 +789,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180463',
           code: 'SPECIFY',
           active: true,
           label: 'SPECIFY',
@@ -743,6 +807,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180518',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -751,6 +816,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '45100',
         },
         {
+          id: '180519',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -768,6 +834,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180541',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -776,6 +843,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '45007',
         },
         {
+          id: '180542',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -793,6 +861,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180732',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -801,6 +870,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44510',
         },
         {
+          id: '180731',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -818,6 +888,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180821',
           code: 'SPECIFY',
           active: true,
           label: 'SPECIFY',
@@ -835,6 +906,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180828',
           code: 'ENTER NUMBER',
           active: true,
           label: 'ENTER NUMBER',
@@ -852,6 +924,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180991',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -860,6 +933,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44135',
         },
         {
+          id: '180992',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -877,6 +951,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181000',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -885,6 +960,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44187',
         },
         {
+          id: '181001',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -902,6 +978,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181089',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -910,6 +987,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44361',
         },
         {
+          id: '181088',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -918,6 +996,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44361',
         },
         {
+          id: '181085',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -926,6 +1005,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44361',
         },
         {
+          id: '181087',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -934,6 +1014,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44361',
         },
         {
+          id: '181086',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -951,6 +1032,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181094',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -959,6 +1041,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '45126',
         },
         {
+          id: '181095',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -976,6 +1059,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181174',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -984,6 +1068,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44516',
         },
         {
+          id: '181175',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1001,6 +1086,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181285',
           code: 'FULL',
           active: true,
           label: 'FULL',
@@ -1009,6 +1095,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '45140',
         },
         {
+          id: '181286',
           code: 'PARTIAL (ENTER DETAILS)',
           active: true,
           label: 'PARTIAL (ENTER DETAILS)',
@@ -1026,6 +1113,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181571',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -1034,6 +1122,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44956',
         },
         {
+          id: '181570',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1042,6 +1131,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44956',
         },
         {
+          id: '181567',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -1050,6 +1140,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44956',
         },
         {
+          id: '181569',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -1058,6 +1149,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44956',
         },
         {
+          id: '181568',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -1075,6 +1167,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181624',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1083,6 +1176,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '45178',
         },
         {
+          id: '181625',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1100,6 +1194,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181781',
           code: 'EVACUATION',
           active: true,
           label: 'EVACUATION',
@@ -1108,6 +1203,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '45040',
         },
         {
+          id: '181784',
           code: 'PARTIAL SEARCH',
           active: true,
           label: 'PARTIAL SEARCH',
@@ -1116,6 +1212,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44642',
         },
         {
+          id: '181783',
           code: 'FULL CLOSE DOWN',
           active: true,
           label: 'FULL CLOSE DOWN',
@@ -1124,6 +1221,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44642',
         },
         {
+          id: '181782',
           code: 'DOG SEARCH',
           active: true,
           label: 'DOG SEARCH',
@@ -1141,6 +1239,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181815',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1149,6 +1248,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44742',
         },
         {
+          id: '181816',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1166,6 +1266,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181884',
           code: 'THREAT',
           active: true,
           label: 'THREAT',
@@ -1174,6 +1275,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44283',
         },
         {
+          id: '181885',
           code: 'WARNING',
           active: true,
           label: 'WARNING',
@@ -1182,6 +1284,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44283',
         },
         {
+          id: '181887',
           code: 'EXPLOSION',
           active: true,
           label: 'EXPLOSION',
@@ -1190,6 +1293,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44948',
         },
         {
+          id: '181889',
           code: 'SUSPICIOUS PACKAGE',
           active: true,
           label: 'SUSPICIOUS PACKAGE',
@@ -1198,6 +1302,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44948',
         },
         {
+          id: '181888',
           code: 'INTELLIGENCE',
           active: true,
           label: 'INTELLIGENCE',
@@ -1206,6 +1311,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44948',
         },
         {
+          id: '181886',
           code: 'DOG SEARCH',
           active: true,
           label: 'DOG SEARCH',
@@ -1223,6 +1329,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181901',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1231,6 +1338,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44404',
         },
         {
+          id: '181900',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1248,6 +1356,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181975',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1256,6 +1365,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44305',
         },
         {
+          id: '181974',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1273,6 +1383,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181987',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1281,6 +1392,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44472',
         },
         {
+          id: '181988',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1298,6 +1410,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182142',
           code: 'TO ANOTHER AREA OF THE PRISON',
           active: true,
           label: 'TO ANOTHER AREA OF THE PRISON',
@@ -1306,6 +1419,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44642',
         },
         {
+          id: '182141',
           code: 'OUTSIDE THE PRISON',
           active: true,
           label: 'OUTSIDE THE PRISON',
@@ -1314,6 +1428,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44642',
         },
         {
+          id: '182143',
           code: 'TO ANOTHER PRISON',
           active: true,
           label: 'TO ANOTHER PRISON',
@@ -1331,6 +1446,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182343',
           code: 'LOCAL',
           active: true,
           label: 'LOCAL',
@@ -1339,6 +1455,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44149',
         },
         {
+          id: '182342',
           code: 'SERVICE SUPPLIER',
           active: true,
           label: 'SERVICE SUPPLIER',
@@ -1356,6 +1473,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182375',
           code: 'ENTER TIME',
           active: true,
           label: 'ENTER TIME',
@@ -1373,6 +1491,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182399',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1381,6 +1500,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44128',
         },
         {
+          id: '182400',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1398,6 +1518,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182456',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -1406,6 +1527,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44896',
         },
         {
+          id: '182457',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -1414,6 +1536,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44896',
         },
         {
+          id: '182460',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -1422,6 +1545,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44896',
         },
         {
+          id: '182459',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -1430,6 +1554,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44896',
         },
         {
+          id: '182458',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1447,6 +1572,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182526',
           code: 'GOVERNOR',
           active: true,
           label: 'GOVERNOR',
@@ -1455,6 +1581,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44362',
         },
         {
+          id: '182524',
           code: 'DEPUTY GOVERNOR',
           active: true,
           label: 'DEPUTY GOVERNOR',
@@ -1463,6 +1590,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44362',
         },
         {
+          id: '182525',
           code: 'DUTY GOVERNOR',
           active: true,
           label: 'DUTY GOVERNOR',
@@ -1471,6 +1599,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44362',
         },
         {
+          id: '182527',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1488,6 +1617,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182645',
           code: 'LOCAL',
           active: true,
           label: 'LOCAL',
@@ -1496,6 +1626,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182646',
           code: 'SERVICE SUPPLIER',
           active: true,
           label: 'SERVICE SUPPLIER',
@@ -1513,6 +1644,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182651',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -1521,6 +1653,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182652',
           code: 'ASSOCIATION AREA',
           active: true,
           label: 'ASSOCIATION AREA',
@@ -1529,6 +1662,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182653',
           code: 'CELL',
           active: true,
           label: 'CELL',
@@ -1537,6 +1671,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182654',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -1545,6 +1680,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182656',
           code: 'DINING ROOM',
           active: true,
           label: 'DINING ROOM',
@@ -1553,6 +1689,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182657',
           code: 'DORMITORY',
           active: true,
           label: 'DORMITORY',
@@ -1561,6 +1698,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182658',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -1569,6 +1707,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182660',
           code: 'EXERCISE YARD',
           active: true,
           label: 'EXERCISE YARD',
@@ -1577,6 +1716,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182662',
           code: 'GATE',
           active: true,
           label: 'GATE',
@@ -1585,6 +1725,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182663',
           code: 'GYM',
           active: true,
           label: 'GYM',
@@ -1593,6 +1734,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182664',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -1601,6 +1743,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182667',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -1609,6 +1752,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182669',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -1617,6 +1761,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182671',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -1625,6 +1770,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182672',
           code: 'RECESS',
           active: true,
           label: 'RECESS',
@@ -1633,6 +1779,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182673',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -1641,6 +1788,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182675',
           code: 'SPECIAL UNIT',
           active: true,
           label: 'SPECIAL UNIT',
@@ -1649,6 +1797,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182674',
           code: 'SHOWERS/CHANGING ROOM',
           active: true,
           label: 'SHOWERS/CHANGING ROOM',
@@ -1657,6 +1806,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182678',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -1665,6 +1815,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182680',
           code: 'WING',
           active: true,
           label: 'WING',
@@ -1673,6 +1824,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182682',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -1681,6 +1833,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182683',
           code: 'WORKSHOP',
           active: true,
           label: 'WORKSHOP',
@@ -1689,6 +1842,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182681',
           code: 'WITHIN PERIMETER',
           active: true,
           label: 'WITHIN PERIMETER',
@@ -1697,6 +1851,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182659',
           code: 'ELSEWHERE',
           active: true,
           label: 'ELSEWHERE',
@@ -1705,6 +1860,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182661',
           code: 'FUNERAL',
           active: true,
           label: 'FUNERAL',
@@ -1713,6 +1869,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182665',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: true,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -1721,6 +1878,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182666',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: true,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -1729,6 +1887,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182670',
           code: 'OUTSIDE WORKING PARTY',
           active: true,
           label: 'OUTSIDE WORKING PARTY',
@@ -1737,6 +1896,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182676',
           code: 'SPORTS FIELD',
           active: true,
           label: 'SPORTS FIELD',
@@ -1745,6 +1905,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182677',
           code: 'VEHICLE',
           active: true,
           label: 'VEHICLE',
@@ -1753,6 +1914,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182679',
           code: 'WEDDINGS',
           active: true,
           label: 'WEDDINGS',
@@ -1761,6 +1923,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182668',
           code: 'MAGISTRATES COURT',
           active: true,
           label: 'MAGISTRATES COURT',
@@ -1769,6 +1932,7 @@ const BOMB_THREAT: IncidentTypeConfiguration = {
           nextQuestionId: '44371',
         },
         {
+          id: '182655',
           code: 'CROWN COURT',
           active: true,
           label: 'CROWN COURT',

--- a/server/reportConfiguration/types/BREACH_OF_SECURITY.ts
+++ b/server/reportConfiguration/types/BREACH_OF_SECURITY.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:50.209Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:16.992Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178894',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44136',
         },
         {
+          id: '178895',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '178948',
           code: 'FURNITURE',
           active: true,
           label: 'FURNITURE',
@@ -48,6 +51,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '45016',
         },
         {
+          id: '178947',
           code: 'FITTINGS',
           active: true,
           label: 'FITTINGS',
@@ -56,6 +60,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '45016',
         },
         {
+          id: '178949',
           code: 'MACHINERY',
           active: true,
           label: 'MACHINERY',
@@ -64,6 +69,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '45016',
         },
         {
+          id: '178946',
           code: 'EQUIPMENT',
           active: true,
           label: 'EQUIPMENT',
@@ -72,6 +78,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '45016',
         },
         {
+          id: '178950',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -89,6 +96,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179321',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -97,6 +105,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '45137',
         },
         {
+          id: '179322',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -114,6 +123,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179329',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -122,6 +132,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44286',
         },
         {
+          id: '179330',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -139,6 +150,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179410',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -147,6 +159,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44364',
         },
         {
+          id: '179409',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -164,6 +177,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179472',
           code: 'WEAPONS',
           active: true,
           label: 'WEAPONS',
@@ -172,6 +186,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179465',
           code: 'ALCOHOL',
           active: true,
           label: 'ALCOHOL',
@@ -180,6 +195,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179467',
           code: 'CIGARETTES',
           active: true,
           label: 'CIGARETTES',
@@ -188,6 +204,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179470',
           code: 'TOBACCO',
           active: true,
           label: 'TOBACCO',
@@ -196,6 +213,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179466',
           code: 'CASH',
           active: true,
           label: 'CASH',
@@ -204,6 +222,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179468',
           code: 'ESCAPE EQUIPMENT',
           active: true,
           label: 'ESCAPE EQUIPMENT',
@@ -212,6 +231,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179471',
           code: 'TOOLS',
           active: true,
           label: 'TOOLS',
@@ -220,6 +240,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179469',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -237,6 +258,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179624',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -245,6 +267,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44124',
         },
         {
+          id: '179623',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -262,6 +285,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179718',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -270,6 +294,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44786',
         },
         {
+          id: '179717',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -287,6 +312,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179814',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -295,6 +321,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44883',
         },
         {
+          id: '179813',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -312,6 +339,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180225',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -320,6 +348,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44606',
         },
         {
+          id: '180226',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -337,6 +366,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180262',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -345,6 +375,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44543',
         },
         {
+          id: '180263',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -362,6 +393,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180417',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -370,6 +402,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44855',
         },
         {
+          id: '180418',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -387,6 +420,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180465',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -395,6 +429,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44500',
         },
         {
+          id: '180464',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -412,6 +447,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180618',
           code: 'INFORMATION FROM PRISONERS',
           active: true,
           label: 'INFORMATION FROM PRISONERS',
@@ -420,6 +456,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44658',
         },
         {
+          id: '180617',
           code: 'INFORMATION FROM POLICE',
           active: true,
           label: 'INFORMATION FROM POLICE',
@@ -428,6 +465,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44658',
         },
         {
+          id: '180616',
           code: 'INFORMATION FROM HQ/AM',
           active: true,
           label: 'INFORMATION FROM HQ/AM',
@@ -436,6 +474,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44658',
         },
         {
+          id: '180619',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -453,6 +492,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180643',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: true,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -470,6 +510,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180794',
           code: 'PARTICULAR PRISONER',
           active: true,
           label: 'PARTICULAR PRISONER',
@@ -478,6 +519,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44686',
         },
         {
+          id: '180792',
           code: 'LOCAL ISSUE',
           active: true,
           label: 'LOCAL ISSUE',
@@ -486,6 +528,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44686',
         },
         {
+          id: '180791',
           code: 'GENERAL ISSUE',
           active: true,
           label: 'GENERAL ISSUE',
@@ -494,6 +537,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44686',
         },
         {
+          id: '180793',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -511,6 +555,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180859',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -519,6 +564,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44728',
         },
         {
+          id: '180860',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -536,6 +582,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180978',
           code: 'ORGANISED',
           active: true,
           label: 'ORGANISED',
@@ -544,6 +591,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44561',
         },
         {
+          id: '180979',
           code: 'SPONTANEOUS',
           active: true,
           label: 'SPONTANEOUS',
@@ -561,6 +609,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181050',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -569,6 +618,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44333',
         },
         {
+          id: '181049',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -586,6 +636,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181201',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -594,6 +645,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '45095',
         },
         {
+          id: '181200',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -611,6 +663,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181412',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -619,6 +672,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44389',
         },
         {
+          id: '181413',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -636,6 +690,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181445',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -644,6 +699,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44918',
         },
         {
+          id: '181446',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -661,6 +717,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181530',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -669,6 +726,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44709',
         },
         {
+          id: '181531',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -686,6 +744,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181605',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -694,6 +753,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44301',
         },
         {
+          id: '181606',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -711,6 +771,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181645',
           code: 'THROWN OVER',
           active: true,
           label: 'THROWN OVER',
@@ -719,6 +780,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44514',
         },
         {
+          id: '181641',
           code: 'CLIMBED OVER',
           active: true,
           label: 'CLIMBED OVER',
@@ -727,6 +789,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44514',
         },
         {
+          id: '181642',
           code: 'CUT THROUGH',
           active: true,
           label: 'CUT THROUGH',
@@ -735,6 +798,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44514',
         },
         {
+          id: '181646',
           code: 'VEHICLE RAMMED',
           active: true,
           label: 'VEHICLE RAMMED',
@@ -743,6 +807,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44514',
         },
         {
+          id: '181643',
           code: 'EXPLOSIVES',
           active: true,
           label: 'EXPLOSIVES',
@@ -751,6 +816,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44514',
         },
         {
+          id: '181644',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -768,6 +834,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181777',
           code: 'INSIDE PRISON',
           active: true,
           label: 'INSIDE PRISON',
@@ -776,6 +843,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44864',
         },
         {
+          id: '181778',
           code: 'OUTSIDE PRISON',
           active: true,
           label: 'OUTSIDE PRISON',
@@ -793,6 +861,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182006',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -801,6 +870,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44616',
         },
         {
+          id: '182007',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -809,6 +879,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44616',
         },
         {
+          id: '182005',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -826,6 +897,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182326',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -834,6 +906,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44946',
         },
         {
+          id: '182325',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -851,6 +924,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182518',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -859,6 +933,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44906',
         },
         {
+          id: '182517',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -867,6 +942,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44906',
         },
         {
+          id: '182514',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -875,6 +951,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44906',
         },
         {
+          id: '182516',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -883,6 +960,7 @@ const BREACH_OF_SECURITY: IncidentTypeConfiguration = {
           nextQuestionId: '44906',
         },
         {
+          id: '182515',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',

--- a/server/reportConfiguration/types/DAMAGE.ts
+++ b/server/reportConfiguration/types/DAMAGE.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:54.406Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:21.069Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179054',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45002',
         },
         {
+          id: '179055',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179113',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -48,6 +51,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44572',
         },
         {
+          id: '179114',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -65,6 +69,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179166',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -73,6 +78,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45050',
         },
         {
+          id: '179165',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -90,6 +96,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179247',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -98,6 +105,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44167',
         },
         {
+          id: '179246',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -106,6 +114,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44167',
         },
         {
+          id: '179243',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -114,6 +123,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44167',
         },
         {
+          id: '179245',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -122,6 +132,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44167',
         },
         {
+          id: '179244',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -139,6 +150,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179430',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -147,6 +159,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44785',
         },
         {
+          id: '179431',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -164,6 +177,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179570',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -172,6 +186,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179571',
           code: 'ASSOCIATION AREA',
           active: true,
           label: 'ASSOCIATION AREA',
@@ -180,6 +195,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179572',
           code: 'CELL',
           active: true,
           label: 'CELL',
@@ -188,6 +204,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179573',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -196,6 +213,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179575',
           code: 'DINING ROOM',
           active: true,
           label: 'DINING ROOM',
@@ -204,6 +222,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179576',
           code: 'DORMITORY',
           active: true,
           label: 'DORMITORY',
@@ -212,6 +231,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179577',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -220,6 +240,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179579',
           code: 'EXERCISE YARD',
           active: true,
           label: 'EXERCISE YARD',
@@ -228,6 +249,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179581',
           code: 'GATE',
           active: true,
           label: 'GATE',
@@ -236,6 +258,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179582',
           code: 'GYM',
           active: true,
           label: 'GYM',
@@ -244,6 +267,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179583',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -252,6 +276,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179586',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -260,6 +285,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179588',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -268,6 +294,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179590',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -276,6 +303,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179591',
           code: 'RECESS',
           active: true,
           label: 'RECESS',
@@ -284,6 +312,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179592',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -292,6 +321,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179594',
           code: 'SPECIAL UNIT',
           active: true,
           label: 'SPECIAL UNIT',
@@ -300,6 +330,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179593',
           code: 'SHOWERS/CHANGING ROOM',
           active: true,
           label: 'SHOWERS/CHANGING ROOM',
@@ -308,6 +339,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179597',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -316,6 +348,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179599',
           code: 'WING',
           active: true,
           label: 'WING',
@@ -324,6 +357,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179601',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -332,6 +366,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179602',
           code: 'WORKSHOP',
           active: true,
           label: 'WORKSHOP',
@@ -340,6 +375,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179600',
           code: 'WITHIN PERIMETER',
           active: true,
           label: 'WITHIN PERIMETER',
@@ -348,6 +384,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179578',
           code: 'ELSEWHERE',
           active: true,
           label: 'ELSEWHERE',
@@ -356,6 +393,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179580',
           code: 'FUNERAL',
           active: true,
           label: 'FUNERAL',
@@ -364,6 +402,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179584',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: true,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -372,6 +411,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179585',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: true,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -380,6 +420,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179589',
           code: 'OUTSIDE WORKING PARTY',
           active: true,
           label: 'OUTSIDE WORKING PARTY',
@@ -388,6 +429,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179595',
           code: 'SPORTS FIELD',
           active: true,
           label: 'SPORTS FIELD',
@@ -396,6 +438,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179596',
           code: 'VEHICLE',
           active: true,
           label: 'VEHICLE',
@@ -404,6 +447,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179598',
           code: 'WEDDINGS',
           active: true,
           label: 'WEDDINGS',
@@ -412,6 +456,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179587',
           code: 'MAGISTRATES COURT',
           active: true,
           label: 'MAGISTRATES COURT',
@@ -420,6 +465,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44343',
         },
         {
+          id: '179574',
           code: 'CROWN COURT',
           active: true,
           label: 'CROWN COURT',
@@ -437,6 +483,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179657',
           code: 'FURNITURE',
           active: true,
           label: 'FURNITURE',
@@ -445,6 +492,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44466',
         },
         {
+          id: '179656',
           code: 'FITTINGS',
           active: true,
           label: 'FITTINGS',
@@ -453,6 +501,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44466',
         },
         {
+          id: '179658',
           code: 'MACHINERY',
           active: true,
           label: 'MACHINERY',
@@ -461,6 +510,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44466',
         },
         {
+          id: '179655',
           code: 'EQUIPMENT',
           active: true,
           label: 'EQUIPMENT',
@@ -469,6 +519,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44466',
         },
         {
+          id: '179659',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -486,6 +537,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179784',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -494,6 +546,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44295',
         },
         {
+          id: '179785',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -511,6 +564,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180083',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -519,6 +573,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44763',
         },
         {
+          id: '180084',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -527,6 +582,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44763',
         },
         {
+          id: '180082',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -544,6 +600,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180259',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -552,6 +609,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45082',
         },
         {
+          id: '180258',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -569,6 +627,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180492',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -577,6 +636,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44200',
         },
         {
+          id: '180491',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -594,6 +654,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180504',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -602,6 +663,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44230',
         },
         {
+          id: '180505',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -610,6 +672,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44230',
         },
         {
+          id: '180508',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -618,6 +681,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44230',
         },
         {
+          id: '180507',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -626,6 +690,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44230',
         },
         {
+          id: '180506',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -643,6 +708,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180775',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -651,6 +717,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44735',
         },
         {
+          id: '180774',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -668,6 +735,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181070',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -676,6 +744,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44324',
         },
         {
+          id: '181069',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -693,6 +762,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181140',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: true,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -710,6 +780,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181186',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -718,6 +789,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44190',
         },
         {
+          id: '181187',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -735,6 +807,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181195',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -743,6 +816,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181197',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -751,6 +825,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181198',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -759,6 +834,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181192',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -767,6 +843,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181194',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -775,6 +852,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181189',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -783,6 +861,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181190',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -791,6 +870,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181191',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -799,6 +879,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181193',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -807,6 +888,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181188',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -815,6 +897,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181196',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -823,6 +906,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44971',
         },
         {
+          id: '181199',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -840,6 +924,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181864',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -848,6 +933,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44576',
         },
         {
+          id: '181865',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -865,6 +951,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181966',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -873,6 +960,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44655',
         },
         {
+          id: '181965',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -881,6 +969,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44655',
         },
         {
+          id: '181962',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -889,6 +978,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44655',
         },
         {
+          id: '181964',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -897,6 +987,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44655',
         },
         {
+          id: '181963',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -914,6 +1005,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182174',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -922,6 +1014,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44512',
         },
         {
+          id: '182173',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -939,6 +1032,7 @@ const DAMAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182287',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -947,6 +1041,7 @@ const DAMAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44379',
         },
         {
+          id: '182286',
           code: 'NO',
           active: true,
           label: 'NO',

--- a/server/reportConfiguration/types/DEATH_IN_CUSTODY.ts
+++ b/server/reportConfiguration/types/DEATH_IN_CUSTODY.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:53.593Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:20.264Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179023',
           code: 'APPARENT SELF INFLICTED',
           active: true,
           label: 'APPARENT SELF INFLICTED',
@@ -23,6 +24,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44383',
         },
         {
+          id: '179024',
           code: 'APPARENT NATURAL CAUSES',
           active: true,
           label: 'APPARENT NATURAL CAUSES',
@@ -31,6 +33,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44384',
         },
         {
+          id: '179025',
           code: 'ACCIDENTAL',
           active: true,
           label: 'ACCIDENTAL',
@@ -39,6 +42,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45144',
         },
         {
+          id: '179026',
           code: 'SUSPICIOUS CIRCUMSTANCES',
           active: true,
           label: 'SUSPICIOUS CIRCUMSTANCES',
@@ -56,6 +60,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179423',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -64,6 +69,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44159',
         },
         {
+          id: '179422',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -81,6 +87,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179477',
           code: 'NATURAL CAUSES',
           active: true,
           label: 'NATURAL CAUSES',
@@ -89,6 +96,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179480',
           code: 'SUICIDE',
           active: true,
           label: 'SUICIDE',
@@ -97,6 +105,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179475',
           code: 'ACCIDENTAL',
           active: true,
           label: 'ACCIDENTAL',
@@ -105,6 +114,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179476',
           code: 'MISADVENTURE',
           active: true,
           label: 'MISADVENTURE',
@@ -113,6 +123,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179478',
           code: 'OPEN VERDICT',
           active: true,
           label: 'OPEN VERDICT',
@@ -121,6 +132,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179479',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -138,6 +150,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179724',
           code: 'SINGLE CELL: ORDINARY LOCATION',
           active: true,
           label: 'SINGLE CELL: ORDINARY LOCATION',
@@ -146,6 +159,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44680',
         },
         {
+          id: '179725',
           code: 'SINGLE CELL: SEGREGATION UNIT',
           active: true,
           label: 'SINGLE CELL: SEGREGATION UNIT',
@@ -154,6 +168,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44680',
         },
         {
+          id: '179723',
           code: 'SHARED CELL: ORDINARY LOCATION',
           active: true,
           label: 'SHARED CELL: ORDINARY LOCATION',
@@ -162,6 +177,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44680',
         },
         {
+          id: '179727',
           code: 'SPECIAL CELL: SEGREGATION UNIT',
           active: true,
           label: 'SPECIAL CELL: SEGREGATION UNIT',
@@ -170,6 +186,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44680',
         },
         {
+          id: '179726',
           code: 'SINGLE CELL:HEALTH CARE CENTRE',
           active: true,
           label: 'SINGLE CELL:HEALTH CARE CENTRE',
@@ -178,6 +195,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44680',
         },
         {
+          id: '179729',
           code: 'WARD: HEALTH CARE CENTRE',
           active: true,
           label: 'WARD: HEALTH CARE CENTRE',
@@ -186,6 +204,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44680',
         },
         {
+          id: '179728',
           code: 'UNFURNISHED ROOM: H.C.C.',
           active: true,
           label: 'UNFURNISHED ROOM: H.C.C.',
@@ -194,6 +213,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44680',
         },
         {
+          id: '179722',
           code: 'PROTECTIVE ROOM: H.C.C.',
           active: true,
           label: 'PROTECTIVE ROOM: H.C.C.',
@@ -202,6 +222,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44680',
         },
         {
+          id: '179721',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -219,6 +240,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179796',
           code: 'HANGING',
           active: true,
           label: 'HANGING',
@@ -227,6 +249,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44929',
         },
         {
+          id: '179797',
           code: 'CUTTING',
           active: true,
           label: 'CUTTING',
@@ -235,6 +258,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45023',
         },
         {
+          id: '179799',
           code: 'SUFFOCATION',
           active: true,
           label: 'SUFFOCATION',
@@ -243,6 +267,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45023',
         },
         {
+          id: '179798',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -260,6 +285,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179802',
           code: 'MYOCARDIAL INFARCTION',
           active: true,
           label: 'MYOCARDIAL INFARCTION',
@@ -268,6 +294,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44468',
         },
         {
+          id: '179800',
           code: 'LONG TERM ALCOHOL MISUSE',
           active: true,
           label: 'LONG TERM ALCOHOL MISUSE',
@@ -276,6 +303,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44468',
         },
         {
+          id: '179801',
           code: 'LONG TERM DRUG MISUSE',
           active: true,
           label: 'LONG TERM DRUG MISUSE',
@@ -284,6 +312,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44468',
         },
         {
+          id: '179803',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -301,6 +330,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179894',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -309,6 +339,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44691',
         },
         {
+          id: '179893',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -326,6 +357,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179898',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -334,6 +366,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44743',
         },
         {
+          id: '179897',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -351,6 +384,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180087',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -359,6 +393,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45063',
         },
         {
+          id: '180086',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -376,6 +411,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180395',
           code: 'IN THE PRISON',
           active: true,
           label: 'IN THE PRISON',
@@ -384,6 +420,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44366',
         },
         {
+          id: '180396',
           code: 'CUSTODY OF STAFF OUT OF PRISON',
           active: true,
           label: 'CUSTODY OF STAFF OUT OF PRISON',
@@ -392,6 +429,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45166',
         },
         {
+          id: '180397',
           code: 'ON TEMPORARY RELEASE',
           active: true,
           label: 'ON TEMPORARY RELEASE',
@@ -400,6 +438,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44721',
         },
         {
+          id: '180398',
           code: 'UNLAWFULLY AT LARGE',
           active: true,
           label: 'UNLAWFULLY AT LARGE',
@@ -417,6 +456,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180727',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -425,6 +465,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44303',
         },
         {
+          id: '180728',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -442,6 +483,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180739',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -450,6 +492,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45038',
         },
         {
+          id: '180740',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -467,6 +510,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180847',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -475,6 +519,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44418',
         },
         {
+          id: '180846',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -492,6 +537,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180883',
           code: 'PRISON STAFF',
           active: true,
           label: 'PRISON STAFF',
@@ -500,6 +546,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45108',
         },
         {
+          id: '180880',
           code: 'CELL MATE',
           active: true,
           label: 'CELL MATE',
@@ -508,6 +555,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45108',
         },
         {
+          id: '180882',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -516,6 +564,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45108',
         },
         {
+          id: '180881',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -533,6 +582,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181004',
           code: 'PRISON MEDICAL OFFICER',
           active: true,
           label: 'PRISON MEDICAL OFFICER',
@@ -541,6 +591,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44962',
         },
         {
+          id: '181002',
           code: 'HOSPITAL DOCTOR',
           active: true,
           label: 'HOSPITAL DOCTOR',
@@ -549,6 +600,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44962',
         },
         {
+          id: '181003',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -566,6 +618,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181005',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -574,6 +627,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44720',
         },
         {
+          id: '181006',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -591,6 +645,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181091',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -599,6 +654,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44537',
         },
         {
+          id: '181090',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -616,6 +672,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181159',
           code: 'WINDOW BARS',
           active: true,
           label: 'WINDOW BARS',
@@ -624,6 +681,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45023',
         },
         {
+          id: '181156',
           code: 'CELL DOOR',
           active: true,
           label: 'CELL DOOR',
@@ -632,6 +690,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45023',
         },
         {
+          id: '181157',
           code: 'LIGHT FITTINGS',
           active: true,
           label: 'LIGHT FITTINGS',
@@ -640,6 +699,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45023',
         },
         {
+          id: '181155',
           code: 'BED',
           active: true,
           label: 'BED',
@@ -648,6 +708,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45023',
         },
         {
+          id: '181158',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -665,6 +726,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181442',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -673,6 +735,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44420',
         },
         {
+          id: '181441',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -690,6 +753,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181506',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -698,6 +762,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44901',
         },
         {
+          id: '181505',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -715,6 +780,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181583',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -723,6 +789,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44720',
         },
         {
+          id: '181582',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -740,6 +807,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181719',
           code: 'BEDDING',
           active: true,
           label: 'BEDDING',
@@ -748,6 +816,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44770',
         },
         {
+          id: '181722',
           code: 'SHOELACES',
           active: true,
           label: 'SHOELACES',
@@ -756,6 +825,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44770',
         },
         {
+          id: '181720',
           code: 'CLOTHING',
           active: true,
           label: 'CLOTHING',
@@ -764,6 +834,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44770',
         },
         {
+          id: '181721',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -781,6 +852,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181829',
           code: 'DATE',
           active: true,
           label: 'DATE',
@@ -789,6 +861,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44292',
         },
         {
+          id: '181830',
           code: 'TIME',
           active: true,
           label: 'TIME',
@@ -806,6 +879,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182033',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -814,6 +888,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44468',
         },
         {
+          id: '182032',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -831,6 +906,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182127',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -839,6 +915,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45120',
         },
         {
+          id: '182126',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -856,6 +933,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182159',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -864,6 +942,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44159',
         },
         {
+          id: '182158',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -881,6 +960,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182239',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -889,6 +969,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44640',
         },
         {
+          id: '182238',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -906,6 +987,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182373',
           code: 'DATE',
           active: true,
           label: 'DATE',
@@ -914,6 +996,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44876',
         },
         {
+          id: '182374',
           code: 'TIME',
           active: true,
           label: 'TIME',
@@ -931,6 +1014,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182429',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -939,6 +1023,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44862',
         },
         {
+          id: '182428',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -956,6 +1041,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182541',
           code: 'DRUG OVERDOSE',
           active: true,
           label: 'DRUG OVERDOSE',
@@ -964,6 +1050,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44468',
         },
         {
+          id: '182542',
           code: 'FALL',
           active: true,
           label: 'FALL',
@@ -972,6 +1059,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44468',
         },
         {
+          id: '182544',
           code: 'TRANSPORT ACCIDENT',
           active: true,
           label: 'TRANSPORT ACCIDENT',
@@ -980,6 +1068,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44468',
         },
         {
+          id: '182540',
           code: 'ACCIDENT INVOLVING MACHINERY',
           active: true,
           label: 'ACCIDENT INVOLVING MACHINERY',
@@ -988,6 +1077,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44468',
         },
         {
+          id: '182543',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1005,6 +1095,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182615',
           code: 'OUTSIDE HOSPITAL',
           active: true,
           label: 'OUTSIDE HOSPITAL',
@@ -1013,6 +1104,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44720',
         },
         {
+          id: '182614',
           code: 'OUTSIDE WORKING PARTY',
           active: true,
           label: 'OUTSIDE WORKING PARTY',
@@ -1021,6 +1113,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44876',
         },
         {
+          id: '182613',
           code: 'OUTSIDE P.E. ACTIVITY',
           active: true,
           label: 'OUTSIDE P.E. ACTIVITY',
@@ -1029,6 +1122,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44876',
         },
         {
+          id: '182610',
           code: 'AT COURT',
           active: true,
           label: 'AT COURT',
@@ -1037,6 +1131,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44876',
         },
         {
+          id: '182612',
           code: 'OTHER ESCORT',
           active: true,
           label: 'OTHER ESCORT',
@@ -1045,6 +1140,7 @@ const DEATH_IN_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44876',
         },
         {
+          id: '182611',
           code: 'OTHER',
           active: true,
           label: 'OTHER',

--- a/server/reportConfiguration/types/DEATH_OTHER.ts
+++ b/server/reportConfiguration/types/DEATH_OTHER.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:52.812Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:19.486Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178925',
           code: 'NAME',
           active: true,
           label: 'NAME',
@@ -32,6 +33,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178971',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -40,6 +42,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44751',
         },
         {
+          id: '178970',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -57,6 +60,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179279',
           code: 'NATURAL CAUSES',
           active: true,
           label: 'NATURAL CAUSES',
@@ -65,6 +69,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179282',
           code: 'SUICIDE',
           active: true,
           label: 'SUICIDE',
@@ -73,6 +78,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179277',
           code: 'ACCIDENTAL',
           active: true,
           label: 'ACCIDENTAL',
@@ -81,6 +87,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179278',
           code: 'MISADVENTURE',
           active: true,
           label: 'MISADVENTURE',
@@ -89,6 +96,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179280',
           code: 'OPEN VERDICT',
           active: true,
           label: 'OPEN VERDICT',
@@ -97,6 +105,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179281',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -114,6 +123,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179320',
           code: 'PRISON MEDICAL OFFICER',
           active: true,
           label: 'PRISON MEDICAL OFFICER',
@@ -122,6 +132,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44702',
         },
         {
+          id: '179318',
           code: 'HOSPITAL DOCTOR',
           active: true,
           label: 'HOSPITAL DOCTOR',
@@ -130,6 +141,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44702',
         },
         {
+          id: '179319',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -147,6 +159,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179677',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -155,6 +168,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44237',
         },
         {
+          id: '179678',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -172,6 +186,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179795',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -180,6 +195,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44130',
         },
         {
+          id: '179794',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -197,6 +213,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179824',
           code: 'OFFICER',
           active: true,
           label: 'OFFICER',
@@ -205,6 +222,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44645',
         },
         {
+          id: '179822',
           code: 'CIVILIAN STAFF',
           active: true,
           label: 'CIVILIAN STAFF',
@@ -213,6 +231,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44645',
         },
         {
+          id: '179823',
           code: 'EXTERNAL CIVILIAN',
           active: true,
           label: 'EXTERNAL CIVILIAN',
@@ -221,6 +240,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44645',
         },
         {
+          id: '179825',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -238,6 +258,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179834',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -246,6 +267,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '45031',
         },
         {
+          id: '179833',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -263,6 +285,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179838',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -271,6 +294,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44350',
         },
         {
+          id: '179837',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -288,6 +312,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179909',
           code: 'APPARENT SELF INFLICTED',
           active: true,
           label: 'APPARENT SELF INFLICTED',
@@ -296,6 +321,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44382',
         },
         {
+          id: '179908',
           code: 'APPARENT NATURAL CAUSES',
           active: true,
           label: 'APPARENT NATURAL CAUSES',
@@ -304,6 +330,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44382',
         },
         {
+          id: '179907',
           code: 'ACCIDENTAL',
           active: true,
           label: 'ACCIDENTAL',
@@ -312,6 +339,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44382',
         },
         {
+          id: '179910',
           code: 'SUSPICIOUS CIRCUMSTANCES',
           active: true,
           label: 'SUSPICIOUS CIRCUMSTANCES',
@@ -329,6 +357,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179932',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -337,6 +366,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44839',
         },
         {
+          id: '179931',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -354,6 +384,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180738',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -362,6 +393,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44397',
         },
         {
+          id: '180737',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -379,6 +411,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180957',
           code: 'DATE',
           active: true,
           label: 'DATE',
@@ -387,6 +420,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44425',
         },
         {
+          id: '180958',
           code: 'TIME',
           active: true,
           label: 'TIME',
@@ -404,6 +438,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181102',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -412,6 +447,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44142',
         },
         {
+          id: '181101',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -429,6 +465,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181107',
           code: 'SPECIFY',
           active: true,
           label: 'SPECIFY',
@@ -446,6 +483,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181347',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -454,6 +492,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44748',
         },
         {
+          id: '181346',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -471,6 +510,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182063',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -479,6 +519,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44248',
         },
         {
+          id: '182062',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -496,6 +537,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182204',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -504,6 +546,7 @@ const DEATH_OTHER: IncidentTypeConfiguration = {
           nextQuestionId: '44434',
         },
         {
+          id: '182205',
           code: 'NO',
           active: true,
           label: 'NO',

--- a/server/reportConfiguration/types/DISORDER.ts
+++ b/server/reportConfiguration/types/DISORDER.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:56.946Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:23.684Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214684',
           code: 'BARRICADE/PREVENTION OF ACCESS',
           active: true,
           label: 'BARRICADE/PREVENTION OF ACCESS',
@@ -23,6 +24,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63180',
         },
         {
+          id: '214685',
           code: 'CONCERTED INDISCIPLINE',
           active: true,
           label: 'CONCERTED INDISCIPLINE',
@@ -31,6 +33,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63180',
         },
         {
+          id: '214686',
           code: 'HOSTAGE',
           active: true,
           label: 'HOSTAGE',
@@ -39,6 +42,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63180',
         },
         {
+          id: '214687',
           code: 'INCIDENT AT HEIGHT',
           active: true,
           label: 'INCIDENT AT HEIGHT',
@@ -56,6 +60,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214688',
           code: 'NO FURTHER ACTION',
           active: true,
           label: 'NO FURTHER ACTION',
@@ -64,6 +69,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63181',
         },
         {
+          id: '214689',
           code: 'PLACED ON REPORT/ADJUDICATION REFERRAL',
           active: true,
           label: 'PLACED ON REPORT/ADJUDICATION REFERRAL',
@@ -72,6 +78,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63181',
         },
         {
+          id: '214690',
           code: 'IEP REGRESSION',
           active: true,
           label: 'IEP REGRESSION',
@@ -80,6 +87,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63181',
         },
         {
+          id: '214691',
           code: 'POLICE REFERRAL',
           active: true,
           label: 'POLICE REFERRAL',
@@ -97,6 +105,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214692',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -105,6 +114,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214693',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -122,6 +132,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214694',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -130,6 +141,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214695',
           code: 'ASSOCIATION AREA',
           active: true,
           label: 'ASSOCIATION AREA',
@@ -138,6 +150,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214696',
           code: 'CELL',
           active: true,
           label: 'CELL',
@@ -146,6 +159,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214697',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -154,6 +168,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214698',
           code: 'CROWN COURT',
           active: true,
           label: 'CROWN COURT',
@@ -162,6 +177,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214699',
           code: 'DINING ROOM',
           active: true,
           label: 'DINING ROOM',
@@ -170,6 +186,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214700',
           code: 'DORMITORY',
           active: true,
           label: 'DORMITORY',
@@ -178,6 +195,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214701',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -186,6 +204,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214702',
           code: 'EXERCISE YARD',
           active: true,
           label: 'EXERCISE YARD',
@@ -194,6 +213,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214703',
           code: 'EXTERNAL ROOF',
           active: true,
           label: 'EXTERNAL ROOF',
@@ -202,6 +222,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214704',
           code: 'FUNERAL',
           active: true,
           label: 'FUNERAL',
@@ -210,6 +231,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214705',
           code: 'GATE',
           active: true,
           label: 'GATE',
@@ -218,6 +240,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214706',
           code: 'GYM',
           active: true,
           label: 'GYM',
@@ -226,6 +249,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214707',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -234,6 +258,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214708',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: true,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -242,6 +267,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214709',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: true,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -250,6 +276,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214710',
           code: 'INDUCTION/1ST NIGHT CENTRE',
           active: true,
           label: 'INDUCTION/1ST NIGHT CENTRE',
@@ -258,6 +285,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214711',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -266,6 +294,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214712',
           code: 'MAGISTRATES COURT',
           active: true,
           label: 'MAGISTRATES COURT',
@@ -274,6 +303,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214713',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -282,6 +312,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214714',
           code: 'OUTSIDE WORKING PARTY',
           active: true,
           label: 'OUTSIDE WORKING PARTY',
@@ -290,6 +321,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214715',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -298,6 +330,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214716',
           code: 'RECESS',
           active: true,
           label: 'RECESS',
@@ -306,6 +339,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214717',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -314,6 +348,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214718',
           code: 'SHOWERS/CHANGING ROOM',
           active: true,
           label: 'SHOWERS/CHANGING ROOM',
@@ -322,6 +357,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214719',
           code: 'SPECIAL UNIT',
           active: true,
           label: 'SPECIAL UNIT',
@@ -330,6 +366,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214720',
           code: 'SPORTS FIELD',
           active: true,
           label: 'SPORTS FIELD',
@@ -338,6 +375,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214721',
           code: 'VEHICLE',
           active: true,
           label: 'VEHICLE',
@@ -346,6 +384,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214722',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -354,6 +393,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214723',
           code: 'VULNERABLE PRISONERS UNIT',
           active: true,
           label: 'VULNERABLE PRISONERS UNIT',
@@ -362,6 +402,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214724',
           code: 'WEDDINGS',
           active: true,
           label: 'WEDDINGS',
@@ -370,6 +411,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214725',
           code: 'WING',
           active: true,
           label: 'WING',
@@ -378,6 +420,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214726',
           code: 'WITHIN PERIMETER',
           active: true,
           label: 'WITHIN PERIMETER',
@@ -386,6 +429,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214727',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -394,6 +438,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214728',
           code: 'WORKSHOP',
           active: true,
           label: 'WORKSHOP',
@@ -402,6 +447,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63183',
         },
         {
+          id: '214729',
           code: 'OTHER - ENTER DETAILS',
           active: true,
           label: 'OTHER - ENTER DETAILS',
@@ -419,6 +465,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214730',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -427,6 +474,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63184',
         },
         {
+          id: '214731',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -444,6 +492,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214732',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -452,6 +501,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63185',
         },
         {
+          id: '214733',
           code: 'DEMANDING EXTERNAL TRANSFER',
           active: true,
           label: 'DEMANDING EXTERNAL TRANSFER',
@@ -460,6 +510,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63185',
         },
         {
+          id: '214734',
           code: 'DEMANDING INTERNAL TRANSFER',
           active: true,
           label: 'DEMANDING INTERNAL TRANSFER',
@@ -468,6 +519,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63185',
         },
         {
+          id: '214735',
           code: 'FACILITIES',
           active: true,
           label: 'FACILITIES',
@@ -476,6 +528,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63185',
         },
         {
+          id: '214736',
           code: 'FOOD',
           active: true,
           label: 'FOOD',
@@ -484,6 +537,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63185',
         },
         {
+          id: '214737',
           code: 'PAY',
           active: true,
           label: 'PAY',
@@ -492,6 +546,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63185',
         },
         {
+          id: '214738',
           code: 'REFUSING EXTERNAL TRANSFER',
           active: true,
           label: 'REFUSING EXTERNAL TRANSFER',
@@ -500,6 +555,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63185',
         },
         {
+          id: '214739',
           code: 'REFUSING INTERNAL TRANSFER',
           active: true,
           label: 'REFUSING INTERNAL TRANSFER',
@@ -508,6 +564,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63185',
         },
         {
+          id: '214740',
           code: 'TIME OUT OF CELL',
           active: true,
           label: 'TIME OUT OF CELL',
@@ -516,6 +573,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63185',
         },
         {
+          id: '214741',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -524,6 +582,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63185',
         },
         {
+          id: '214742',
           code: 'OTHER - ENTER DETAILS',
           active: true,
           label: 'OTHER - ENTER DETAILS',
@@ -541,6 +600,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214743',
           code: 'ACCESS DIFFICULTIES',
           active: true,
           label: 'ACCESS DIFFICULTIES',
@@ -549,6 +609,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63186',
         },
         {
+          id: '214744',
           code: 'DAMAGE RESULTING IN LOSS OF FACILITIES OR UTILITIES',
           active: true,
           label: 'DAMAGE RESULTING IN LOSS OF FACILITIES OR UTILITIES',
@@ -557,6 +618,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63186',
         },
         {
+          id: '214745',
           code: 'DAMAGE RESULTING IN THE LOSS OF ACCOMMODATION',
           active: true,
           label: 'DAMAGE RESULTING IN THE LOSS OF ACCOMMODATION',
@@ -565,6 +627,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63186',
         },
         {
+          id: '214746',
           code: 'MEDIA INTEREST',
           active: true,
           label: 'MEDIA INTEREST',
@@ -573,6 +636,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63186',
         },
         {
+          id: '214747',
           code: 'ORRU ASSISTANCE REQUESTED',
           active: true,
           label: 'ORRU ASSISTANCE REQUESTED',
@@ -581,6 +645,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63186',
         },
         {
+          id: '214748',
           code: 'PERPETRATOR UNDER INFLUENCE OF DRUGS OR ALCOHOL',
           active: true,
           label: 'PERPETRATOR UNDER INFLUENCE OF DRUGS OR ALCOHOL',
@@ -589,6 +654,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63186',
         },
         {
+          id: '214749',
           code: 'THREAT OR ACTUAL SELF HARM',
           active: true,
           label: 'THREAT OR ACTUAL SELF HARM',
@@ -597,6 +663,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63186',
         },
         {
+          id: '214750',
           code: 'VIOLENCE DIRECTED AGAINST STAFF',
           active: true,
           label: 'VIOLENCE DIRECTED AGAINST STAFF',
@@ -614,6 +681,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214751',
           code: '< 1 minute',
           active: true,
           label: '< 1 minute',
@@ -622,6 +690,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63187',
         },
         {
+          id: '214752',
           code: '1 min to <5mins',
           active: true,
           label: '1 min to <5mins',
@@ -630,6 +699,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63187',
         },
         {
+          id: '214753',
           code: '10 mins to <15mins',
           active: true,
           label: '10 mins to <15mins',
@@ -638,6 +708,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63187',
         },
         {
+          id: '214754',
           code: '15 mins to <30mins',
           active: true,
           label: '15 mins to <30mins',
@@ -646,6 +717,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63187',
         },
         {
+          id: '214755',
           code: '30 mins to <1 hour',
           active: true,
           label: '30 mins to <1 hour',
@@ -654,6 +726,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63187',
         },
         {
+          id: '214756',
           code: '1 hour to <2 hours',
           active: true,
           label: '1 hour to <2 hours',
@@ -662,6 +735,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63187',
         },
         {
+          id: '214757',
           code: '2 hours to <3 hours',
           active: true,
           label: '2 hours to <3 hours',
@@ -670,6 +744,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63187',
         },
         {
+          id: '214758',
           code: '3 hours to <4 hours',
           active: true,
           label: '3 hours to <4 hours',
@@ -678,6 +753,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63187',
         },
         {
+          id: '214759',
           code: '4 hours to <5 hours',
           active: true,
           label: '4 hours to <5 hours',
@@ -686,6 +762,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63187',
         },
         {
+          id: '214760',
           code: '5 hours plus',
           active: true,
           label: '5 hours plus',
@@ -694,6 +771,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63187',
         },
         {
+          id: '214761',
           code: 'UNKNOWN - ENTER DETAILS',
           active: true,
           label: 'UNKNOWN - ENTER DETAILS',
@@ -711,6 +789,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214762',
           code: 'COMPLIED WITH ORDER OR INSTRUCTION',
           active: true,
           label: 'COMPLIED WITH ORDER OR INSTRUCTION',
@@ -719,6 +798,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63188',
         },
         {
+          id: '214763',
           code: 'NEGOTIATION',
           active: true,
           label: 'NEGOTIATION',
@@ -727,6 +807,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63188',
         },
         {
+          id: '214764',
           code: 'INTERVENTION (LOCAL STAFF)',
           active: true,
           label: 'INTERVENTION (LOCAL STAFF)',
@@ -735,6 +816,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63188',
         },
         {
+          id: '214765',
           code: 'INTERVENTION (ORRU STAFF)',
           active: true,
           label: 'INTERVENTION (ORRU STAFF)',
@@ -743,6 +825,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63188',
         },
         {
+          id: '214766',
           code: 'INTERVENTION (OPERATION TORNADO)',
           active: true,
           label: 'INTERVENTION (OPERATION TORNADO)',
@@ -751,6 +834,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63188',
         },
         {
+          id: '214767',
           code: 'OTHER - ENTER DETAILS',
           active: true,
           label: 'OTHER - ENTER DETAILS',
@@ -768,6 +852,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214768',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -776,6 +861,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63189',
         },
         {
+          id: '214769',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -793,6 +879,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214770',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -801,6 +888,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63190',
         },
         {
+          id: '214771',
           code: 'C & R ADVISOR',
           active: true,
           label: 'C & R ADVISOR',
@@ -809,6 +897,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63190',
         },
         {
+          id: '214772',
           code: 'INCIDENT LIAISON OFFICER',
           active: true,
           label: 'INCIDENT LIAISON OFFICER',
@@ -817,6 +906,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63190',
         },
         {
+          id: '214773',
           code: 'HEALTH CARE STAFF',
           active: true,
           label: 'HEALTH CARE STAFF',
@@ -825,6 +915,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63190',
         },
         {
+          id: '214774',
           code: 'WORKS SERVICES STAFF',
           active: true,
           label: 'WORKS SERVICES STAFF',
@@ -833,6 +924,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63190',
         },
         {
+          id: '214775',
           code: 'OTHER - ENTER DETAILS',
           active: true,
           label: 'OTHER - ENTER DETAILS',
@@ -850,6 +942,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214776',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -858,6 +951,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63191',
         },
         {
+          id: '214777',
           code: 'DOOR JACK',
           active: true,
           label: 'DOOR JACK',
@@ -866,6 +960,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63191',
         },
         {
+          id: '214778',
           code: 'EXTENDABLE BATONS',
           active: true,
           label: 'EXTENDABLE BATONS',
@@ -874,6 +969,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63191',
         },
         {
+          id: '214779',
           code: 'NEGOTIATION ADVISER (INCLUDING HOSTAGE)',
           active: true,
           label: 'NEGOTIATION ADVISER (INCLUDING HOSTAGE)',
@@ -882,6 +978,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63191',
         },
         {
+          id: '214780',
           code: 'OPERATIONAL RESILIENCE AND RESPONSE UNIT (ORRU)',
           active: true,
           label: 'OPERATIONAL RESILIENCE AND RESPONSE UNIT (ORRU)',
@@ -890,6 +987,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63191',
         },
         {
+          id: '214781',
           code: 'TORNADO',
           active: true,
           label: 'TORNADO',
@@ -898,6 +996,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63191',
         },
         {
+          id: '214782',
           code: 'WATER HOSES',
           active: true,
           label: 'WATER HOSES',
@@ -906,6 +1005,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63191',
         },
         {
+          id: '214783',
           code: 'OTHER - ENTER DETAILS',
           active: true,
           label: 'OTHER - ENTER DETAILS',
@@ -923,6 +1023,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214784',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -931,6 +1032,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63192',
         },
         {
+          id: '214785',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -939,6 +1041,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63192',
         },
         {
+          id: '214786',
           code: 'FIRE',
           active: true,
           label: 'FIRE',
@@ -947,6 +1050,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63192',
         },
         {
+          id: '214787',
           code: 'AMBULANCE',
           active: true,
           label: 'AMBULANCE',
@@ -955,6 +1059,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63192',
         },
         {
+          id: '214788',
           code: 'OTHER - ENTER DETAILS',
           active: true,
           label: 'OTHER - ENTER DETAILS',
@@ -972,6 +1077,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214789',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -980,6 +1086,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63193',
         },
         {
+          id: '214790',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -997,6 +1104,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214791',
           code: 'ACTIVE',
           active: true,
           label: 'ACTIVE',
@@ -1005,6 +1113,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63194',
         },
         {
+          id: '214792',
           code: 'PASSIVE',
           active: true,
           label: 'PASSIVE',
@@ -1022,6 +1131,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214793',
           code: 'NUMBER - ENTER DETAILS',
           active: true,
           label: 'NUMBER - ENTER DETAILS',
@@ -1039,6 +1149,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214794',
           code: 'PRISONER - ENTER NUMBER OF',
           active: true,
           label: 'PRISONER - ENTER NUMBER OF',
@@ -1047,6 +1158,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63196',
         },
         {
+          id: '214795',
           code: 'VISITOR - ENTER NUMBER OF',
           active: true,
           label: 'VISITOR - ENTER NUMBER OF',
@@ -1055,6 +1167,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63196',
         },
         {
+          id: '214796',
           code: 'OTHER - ENTER NUMBER OF',
           active: true,
           label: 'OTHER - ENTER NUMBER OF',
@@ -1072,6 +1185,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214797',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1080,6 +1194,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63198',
         },
         {
+          id: '214798',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1097,6 +1212,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214799',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1105,6 +1221,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63198',
         },
         {
+          id: '214800',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1122,6 +1239,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214801',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1130,6 +1248,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63199',
         },
         {
+          id: '214802',
           code: 'YES - PLEASE LOG FIND INCIDENT IF WEAPON RECOVERED',
           active: true,
           label: 'YES - PLEASE LOG FIND INCIDENT IF WEAPON RECOVERED',
@@ -1147,6 +1266,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214803',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1155,6 +1275,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63200',
         },
         {
+          id: '214804',
           code: 'YES - PLEASE LOG DAMAGE INCIDENT',
           active: true,
           label: 'YES - PLEASE LOG DAMAGE INCIDENT',
@@ -1172,6 +1293,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214805',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1180,6 +1302,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63209',
         },
         {
+          id: '214806',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1197,6 +1320,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214807',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1205,6 +1329,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63204',
         },
         {
+          id: '214808',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1222,6 +1347,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214809',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -1230,6 +1356,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214810',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -1238,6 +1365,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214811',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -1246,6 +1374,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214812',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -1254,6 +1383,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214813',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -1262,6 +1392,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214814',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -1270,6 +1401,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214815',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -1278,6 +1410,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214816',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -1286,6 +1419,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214817',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -1294,6 +1428,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214818',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -1302,6 +1437,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214819',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -1310,6 +1446,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63203',
         },
         {
+          id: '214820',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -1327,6 +1464,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214821',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -1335,6 +1473,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63204',
         },
         {
+          id: '214822',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -1343,6 +1482,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63204',
         },
         {
+          id: '214823',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -1351,6 +1491,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63204',
         },
         {
+          id: '214824',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1359,6 +1500,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63204',
         },
         {
+          id: '214825',
           code: 'OPERATIONAL STAFF - PRISON OFFICER',
           active: true,
           label: 'OPERATIONAL STAFF - PRISON OFFICER',
@@ -1367,6 +1509,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63204',
         },
         {
+          id: '214826',
           code: 'OPERATIONAL STAFF - OTHER',
           active: true,
           label: 'OPERATIONAL STAFF - OTHER',
@@ -1375,6 +1518,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63204',
         },
         {
+          id: '214827',
           code: 'NON-OPERATIONAL STAFF',
           active: true,
           label: 'NON-OPERATIONAL STAFF',
@@ -1383,6 +1527,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63204',
         },
         {
+          id: '214828',
           code: 'NON-DIRECTLY EMPLOYED STAFF',
           active: true,
           label: 'NON-DIRECTLY EMPLOYED STAFF',
@@ -1391,6 +1536,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63204',
         },
         {
+          id: '214829',
           code: 'OTHER - ENTER DETAILS',
           active: true,
           label: 'OTHER - ENTER DETAILS',
@@ -1408,6 +1554,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214830',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1416,6 +1563,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63207',
         },
         {
+          id: '214831',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1433,6 +1581,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214832',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -1441,6 +1590,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63206',
         },
         {
+          id: '214833',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -1449,6 +1599,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63206',
         },
         {
+          id: '214834',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -1457,6 +1608,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63206',
         },
         {
+          id: '214835',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -1465,6 +1617,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63206',
         },
         {
+          id: '214836',
           code: 'OTHER - ENTER DETAILS',
           active: true,
           label: 'OTHER - ENTER DETAILS',
@@ -1482,6 +1635,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214837',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -1490,6 +1644,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63207',
         },
         {
+          id: '214838',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -1498,6 +1653,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63207',
         },
         {
+          id: '214839',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -1506,6 +1662,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63207',
         },
         {
+          id: '214840',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1514,6 +1671,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63207',
         },
         {
+          id: '214841',
           code: 'OPERATIONAL STAFF - PRISON OFFICER',
           active: true,
           label: 'OPERATIONAL STAFF - PRISON OFFICER',
@@ -1522,6 +1680,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63207',
         },
         {
+          id: '214842',
           code: 'OPERATIONAL STAFF - OTHER',
           active: true,
           label: 'OPERATIONAL STAFF - OTHER',
@@ -1530,6 +1689,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63207',
         },
         {
+          id: '214843',
           code: 'NON-OPERATIONAL STAFF',
           active: true,
           label: 'NON-OPERATIONAL STAFF',
@@ -1538,6 +1698,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63207',
         },
         {
+          id: '214844',
           code: 'NON-DIRECTLY EMPLOYED STAFF',
           active: true,
           label: 'NON-DIRECTLY EMPLOYED STAFF',
@@ -1546,6 +1707,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63207',
         },
         {
+          id: '214845',
           code: 'OTHER - ENTER DETAILS',
           active: false,
           label: 'OTHER - ENTER DETAILS',
@@ -1554,6 +1716,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63207',
         },
         {
+          id: '214846',
           code: 'OTHER - ENTER DETAILS',
           active: true,
           label: 'OTHER - ENTER DETAILS',
@@ -1571,6 +1734,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214847',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1579,6 +1743,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63209',
         },
         {
+          id: '214848',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1596,6 +1761,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214849',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -1604,6 +1770,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63209',
         },
         {
+          id: '214850',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -1612,6 +1779,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63209',
         },
         {
+          id: '214851',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -1620,6 +1788,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63209',
         },
         {
+          id: '214852',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1628,6 +1797,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63209',
         },
         {
+          id: '214853',
           code: 'OPERATIONAL STAFF - PRISON OFFICER',
           active: true,
           label: 'OPERATIONAL STAFF - PRISON OFFICER',
@@ -1636,6 +1806,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63209',
         },
         {
+          id: '214854',
           code: 'OPERATIONAL STAFF - OTHER',
           active: true,
           label: 'OPERATIONAL STAFF - OTHER',
@@ -1644,6 +1815,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63209',
         },
         {
+          id: '214855',
           code: 'NON-OPERATIONAL STAFF',
           active: true,
           label: 'NON-OPERATIONAL STAFF',
@@ -1652,6 +1824,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63209',
         },
         {
+          id: '214856',
           code: 'NON-DIRECTLY EMPLOYED STAFF',
           active: true,
           label: 'NON-DIRECTLY EMPLOYED STAFF',
@@ -1660,6 +1833,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63209',
         },
         {
+          id: '214857',
           code: 'OTHER - ENTER DETAILS',
           active: true,
           label: 'OTHER - ENTER DETAILS',
@@ -1677,6 +1851,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214858',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1685,6 +1860,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63210',
         },
         {
+          id: '214859',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1702,6 +1878,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214860',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1710,6 +1887,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63213',
         },
         {
+          id: '214861',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1727,6 +1905,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214862',
           code: 'CONTRACTORS EQUIPMENT',
           active: true,
           label: 'CONTRACTORS EQUIPMENT',
@@ -1735,6 +1914,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63212',
         },
         {
+          id: '214863',
           code: 'EXTERNAL ACCESS: FENCING',
           active: true,
           label: 'EXTERNAL ACCESS: FENCING',
@@ -1743,6 +1923,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63212',
         },
         {
+          id: '214864',
           code: 'EXTERNAL ACCESS: ROOF',
           active: true,
           label: 'EXTERNAL ACCESS: ROOF',
@@ -1751,6 +1932,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63212',
         },
         {
+          id: '214865',
           code: 'EXTERNAL ACCESS: TREE',
           active: true,
           label: 'EXTERNAL ACCESS: TREE',
@@ -1759,6 +1941,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63212',
         },
         {
+          id: '214866',
           code: 'INTERNAL ACCESS: LANDINGS/RAILINGS',
           active: true,
           label: 'INTERNAL ACCESS: LANDINGS/RAILINGS',
@@ -1767,6 +1950,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63212',
         },
         {
+          id: '214867',
           code: 'INTERNAL ACCESS: NETTING',
           active: true,
           label: 'INTERNAL ACCESS: NETTING',
@@ -1775,6 +1959,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63212',
         },
         {
+          id: '214868',
           code: 'INTERNAL ACCESS: WINDOW/GATE BARS',
           active: true,
           label: 'INTERNAL ACCESS: WINDOW/GATE BARS',
@@ -1783,6 +1968,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63212',
         },
         {
+          id: '214869',
           code: 'OTHER: INTERNAL - ENTER DETAILS',
           active: true,
           label: 'OTHER: INTERNAL - ENTER DETAILS',
@@ -1791,6 +1977,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63212',
         },
         {
+          id: '214870',
           code: 'OTHER: EXTERNAL - ENTER DETAILS',
           active: true,
           label: 'OTHER: EXTERNAL - ENTER DETAILS',
@@ -1808,6 +1995,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214871',
           code: 'BETWEEN 3 FEET AND <1ST FLOOR',
           active: true,
           label: 'BETWEEN 3 FEET AND <1ST FLOOR',
@@ -1816,6 +2004,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63213',
         },
         {
+          id: '214872',
           code: '1ST FLOOR',
           active: true,
           label: '1ST FLOOR',
@@ -1824,6 +2013,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63213',
         },
         {
+          id: '214873',
           code: '2ND FLOOR',
           active: true,
           label: '2ND FLOOR',
@@ -1832,6 +2022,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63213',
         },
         {
+          id: '214874',
           code: '3RD FLOOR OR HIGHER',
           active: true,
           label: '3RD FLOOR OR HIGHER',
@@ -1849,6 +2040,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214875',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1857,6 +2049,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63214',
         },
         {
+          id: '214876',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1874,6 +2067,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214877',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1882,6 +2076,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '214878',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1899,6 +2094,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '214879',
           code: 'CIVILIAN STAFF - STATE NUMBER OF',
           active: true,
           label: 'CIVILIAN STAFF - STATE NUMBER OF',
@@ -1907,6 +2103,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63216',
         },
         {
+          id: '214880',
           code: 'OFFICER - STATE NUMBER OF',
           active: true,
           label: 'OFFICER - STATE NUMBER OF',
@@ -1915,6 +2112,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63216',
         },
         {
+          id: '214881',
           code: 'PRISONER - STATE NUMBER OF',
           active: true,
           label: 'PRISONER - STATE NUMBER OF',
@@ -1923,6 +2121,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63216',
         },
         {
+          id: '214882',
           code: 'STAFF - STATE NUMBER OF',
           active: true,
           label: 'STAFF - STATE NUMBER OF',
@@ -1931,6 +2130,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63216',
         },
         {
+          id: '214883',
           code: 'OTHER - STATE NUMBER OF',
           active: true,
           label: 'OTHER - STATE NUMBER OF',
@@ -1948,6 +2148,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214884',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1956,6 +2157,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63217',
         },
         {
+          id: '214885',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1973,6 +2175,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214886',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1981,6 +2184,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63218',
         },
         {
+          id: '214887',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1998,6 +2202,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214888',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2006,6 +2211,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63219',
         },
         {
+          id: '214889',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2023,6 +2229,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214890',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2031,6 +2238,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '63220',
         },
         {
+          id: '214891',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2048,6 +2256,7 @@ const DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '214892',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2056,6 +2265,7 @@ const DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '214893',
           code: 'YES',
           active: true,
           label: 'YES',

--- a/server/reportConfiguration/types/DRONE_SIGHTING.ts
+++ b/server/reportConfiguration/types/DRONE_SIGHTING.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:59.790Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:26.226Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220684',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -23,6 +24,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69180',
         },
         {
+          id: '220685',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -40,6 +42,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220686',
           code: 'Please Specify',
           active: true,
           label: 'Please Specify',
@@ -57,6 +60,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220687',
           code: 'Please Specify location of each Drone',
           active: true,
           label: 'Please Specify location of each Drone',
@@ -74,6 +78,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220688',
           code: 'Please Specify',
           active: true,
           label: 'Please Specify',
@@ -91,6 +96,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220689',
           code: 'Please Specify',
           active: true,
           label: 'Please Specify',
@@ -108,6 +114,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220690',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -116,6 +123,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69190',
         },
         {
+          id: '220691',
           code: 'YES - PLEASE ADDITIONALLY LOG A SEPRATE FIND INCIDENT',
           active: true,
           label: 'YES - PLEASE ADDITIONALLY LOG A SEPRATE FIND INCIDENT',
@@ -133,6 +141,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220749',
           code: 'Junk',
           active: true,
           label: 'Junk',
@@ -150,6 +159,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220746',
           code: 'Junk',
           active: true,
           label: 'Junk',
@@ -167,6 +177,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220745',
           code: 'Junk',
           active: false,
           label: 'Junk',
@@ -184,6 +195,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220748',
           code: 'junk',
           active: true,
           label: 'junk',
@@ -201,6 +213,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220747',
           code: 'junk',
           active: true,
           label: 'junk',
@@ -218,6 +231,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '220692',
           code: 'FIXED WING / PLANE',
           active: true,
           label: 'FIXED WING / PLANE',
@@ -226,6 +240,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69191',
         },
         {
+          id: '220693',
           code: 'MULTI-COPTER 4 MOTORS',
           active: true,
           label: 'MULTI-COPTER 4 MOTORS',
@@ -234,6 +249,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69191',
         },
         {
+          id: '220694',
           code: 'MULTI-COPTER 6 MOTORS',
           active: true,
           label: 'MULTI-COPTER 6 MOTORS',
@@ -242,6 +258,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69191',
         },
         {
+          id: '220695',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -250,6 +267,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69191',
         },
         {
+          id: '220696',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -267,6 +285,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '220697',
           code: 'Da-Jiang Innovations (DJI) - PHANTHOM',
           active: true,
           label: 'Da-Jiang Innovations (DJI) - PHANTHOM',
@@ -275,6 +294,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69192',
         },
         {
+          id: '220698',
           code: 'Da-Jiang Innovations (DJI) - INSPIRE',
           active: true,
           label: 'Da-Jiang Innovations (DJI) - INSPIRE',
@@ -283,6 +303,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69192',
         },
         {
+          id: '220699',
           code: 'Da-Jiang Innovations (DJI) - MAVIC',
           active: true,
           label: 'Da-Jiang Innovations (DJI) - MAVIC',
@@ -291,6 +312,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69192',
         },
         {
+          id: '220700',
           code: 'Da-Jiang Innovations (DJI) - MINI',
           active: true,
           label: 'Da-Jiang Innovations (DJI) - MINI',
@@ -299,6 +321,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69192',
         },
         {
+          id: '220701',
           code: 'AUTEL EVO',
           active: true,
           label: 'AUTEL EVO',
@@ -307,6 +330,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69192',
         },
         {
+          id: '220702',
           code: 'PARROTT',
           active: true,
           label: 'PARROTT',
@@ -315,6 +339,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69192',
         },
         {
+          id: '220703',
           code: 'SWELLPRO',
           active: true,
           label: 'SWELLPRO',
@@ -323,6 +348,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69192',
         },
         {
+          id: '220704',
           code: 'YUNEEC',
           active: true,
           label: 'YUNEEC',
@@ -331,6 +357,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69192',
         },
         {
+          id: '220705',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -339,6 +366,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69192',
         },
         {
+          id: '220706',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -356,6 +384,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '220707',
           code: '0 TO LESS THAN 0.5M',
           active: true,
           label: '0 TO LESS THAN 0.5M',
@@ -364,6 +393,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69193',
         },
         {
+          id: '220708',
           code: '0.5M TO LESS THAN 1.0M',
           active: true,
           label: '0.5M TO LESS THAN 1.0M',
@@ -372,6 +402,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69193',
         },
         {
+          id: '220709',
           code: '1.0M TO LESS THAN 2.0M',
           active: true,
           label: '1.0M TO LESS THAN 2.0M',
@@ -380,6 +411,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69193',
         },
         {
+          id: '220710',
           code: '2.0M TO LESS THAN 3.0M',
           active: true,
           label: '2.0M TO LESS THAN 3.0M',
@@ -388,6 +420,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69193',
         },
         {
+          id: '220711',
           code: '3.0M OR LONGER',
           active: true,
           label: '3.0M OR LONGER',
@@ -396,6 +429,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69193',
         },
         {
+          id: '220712',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -413,6 +447,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '220713',
           code: 'ADDED HOOK',
           active: true,
           label: 'ADDED HOOK',
@@ -421,6 +456,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69194',
         },
         {
+          id: '220714',
           code: 'COVERED LIGHTS',
           active: true,
           label: 'COVERED LIGHTS',
@@ -429,6 +465,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69194',
         },
         {
+          id: '220715',
           code: 'DROP MECHANISM FITTED',
           active: true,
           label: 'DROP MECHANISM FITTED',
@@ -437,6 +474,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69194',
         },
         {
+          id: '220716',
           code: 'NONE',
           active: true,
           label: 'NONE',
@@ -445,6 +483,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69194',
         },
         {
+          id: '220717',
           code: 'PAINTED BLACK',
           active: true,
           label: 'PAINTED BLACK',
@@ -453,6 +492,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69194',
         },
         {
+          id: '220718',
           code: 'TETHER ATTACHED',
           active: true,
           label: 'TETHER ATTACHED',
@@ -461,6 +501,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69194',
         },
         {
+          id: '220719',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -478,6 +519,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '220720',
           code: 'CRASHED',
           active: true,
           label: 'CRASHED',
@@ -486,6 +528,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69195',
         },
         {
+          id: '220721',
           code: 'INTERCEPTED',
           active: true,
           label: 'INTERCEPTED',
@@ -494,6 +537,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69195',
         },
         {
+          id: '220722',
           code: 'NOT RECOVERED',
           active: true,
           label: 'NOT RECOVERED',
@@ -511,6 +555,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220723',
           code: 'NO PACKAGE OBSERVED/RECOVERED',
           active: true,
           label: 'NO PACKAGE OBSERVED/RECOVERED',
@@ -519,6 +564,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69196',
         },
         {
+          id: '220724',
           code: 'YES - UNKNOWN',
           active: true,
           label: 'YES - UNKNOWN',
@@ -527,6 +573,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69196',
         },
         {
+          id: '220725',
           code: 'YES 0 TO 100G (MORE OPTIONS BELOW)',
           active: true,
           label: 'YES 0 TO 100G (MORE OPTIONS BELOW)',
@@ -535,6 +582,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69196',
         },
         {
+          id: '220726',
           code: 'YES 101G TO 200G',
           active: true,
           label: 'YES 101G TO 200G',
@@ -543,6 +591,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69196',
         },
         {
+          id: '220727',
           code: 'YES 201G TO 300G',
           active: true,
           label: 'YES 201G TO 300G',
@@ -551,6 +600,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69196',
         },
         {
+          id: '220728',
           code: 'YES 301G TO 400G',
           active: true,
           label: 'YES 301G TO 400G',
@@ -559,6 +609,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69196',
         },
         {
+          id: '220729',
           code: 'YES 401G TO 500G',
           active: true,
           label: 'YES 401G TO 500G',
@@ -567,6 +618,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69196',
         },
         {
+          id: '220730',
           code: 'YES 501G TO 1000G',
           active: true,
           label: 'YES 501G TO 1000G',
@@ -575,6 +627,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69196',
         },
         {
+          id: '220731',
           code: 'YES MORE THAN 1001G',
           active: true,
           label: 'YES MORE THAN 1001G',
@@ -592,6 +645,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220732',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -600,6 +654,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69197',
         },
         {
+          id: '220733',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -617,6 +672,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220734',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -625,6 +681,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69199',
         },
         {
+          id: '220735',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -642,6 +699,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220736',
           code: '0 TO LESS THAN 10 METRES',
           active: true,
           label: '0 TO LESS THAN 10 METRES',
@@ -650,6 +708,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69199',
         },
         {
+          id: '220737',
           code: '10 TO LESS THAN 100 METRES',
           active: true,
           label: '10 TO LESS THAN 100 METRES',
@@ -658,6 +717,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69199',
         },
         {
+          id: '220738',
           code: '100 TO LESS THAN 200 METRES',
           active: true,
           label: '100 TO LESS THAN 200 METRES',
@@ -666,6 +726,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69199',
         },
         {
+          id: '220739',
           code: '200 METRES OR MORE',
           active: true,
           label: '200 METRES OR MORE',
@@ -674,6 +735,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69199',
         },
         {
+          id: '220740',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -691,6 +753,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220741',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -699,6 +762,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '69200',
         },
         {
+          id: '220742',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -716,6 +780,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '220743',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -724,6 +789,7 @@ const DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '220744',
           code: 'YES',
           active: true,
           label: 'YES',

--- a/server/reportConfiguration/types/ESCAPE_FROM_CUSTODY.ts
+++ b/server/reportConfiguration/types/ESCAPE_FROM_CUSTODY.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:02.741Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:28.817Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178885',
           code: 'PRISON SERVICE VEHICLE',
           active: true,
           label: 'PRISON SERVICE VEHICLE',
@@ -23,6 +24,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44251',
         },
         {
+          id: '178881',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -31,6 +33,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44251',
         },
         {
+          id: '178882',
           code: 'ESCORT CONTRACTOR',
           active: true,
           label: 'ESCORT CONTRACTOR',
@@ -39,6 +42,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44251',
         },
         {
+          id: '178883',
           code: 'OFFICIAL VEHICLE',
           active: true,
           label: 'OFFICIAL VEHICLE',
@@ -47,6 +51,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44251',
         },
         {
+          id: '178887',
           code: 'STAFF VEHICLE',
           active: true,
           label: 'STAFF VEHICLE',
@@ -55,6 +60,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44251',
         },
         {
+          id: '178886',
           code: 'PRIVATE VEHICLE',
           active: true,
           label: 'PRIVATE VEHICLE',
@@ -63,6 +69,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44251',
         },
         {
+          id: '178888',
           code: 'TAXI',
           active: true,
           label: 'TAXI',
@@ -71,6 +78,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44251',
         },
         {
+          id: '178884',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -88,6 +96,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '178910',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -96,6 +105,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178899',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -104,6 +114,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178900',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -112,6 +123,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178903',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -120,6 +132,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178901',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -128,6 +141,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178902',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -136,6 +150,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178911',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -144,6 +159,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178905',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -152,6 +168,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178904',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -160,6 +177,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178898',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -168,6 +186,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178909',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -176,6 +195,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178908',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -184,6 +204,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178906',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -192,6 +213,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '178907',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -209,6 +231,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178953',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -217,6 +240,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44621',
         },
         {
+          id: '178954',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -234,6 +258,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179046',
           code: 'CUT WINDOW OR BARS',
           active: true,
           label: 'CUT WINDOW OR BARS',
@@ -242,6 +267,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44931',
         },
         {
+          id: '179051',
           code: 'FORCED WINDOW OR BARS',
           active: true,
           label: 'FORCED WINDOW OR BARS',
@@ -250,6 +276,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44931',
         },
         {
+          id: '179045',
           code: 'CUT AND FORCED WINDOW AND BARS',
           active: true,
           label: 'CUT AND FORCED WINDOW AND BARS',
@@ -258,6 +285,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44931',
         },
         {
+          id: '179047',
           code: 'DUG THROUGH EXTERNAL WALL',
           active: true,
           label: 'DUG THROUGH EXTERNAL WALL',
@@ -266,6 +294,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44931',
         },
         {
+          id: '179049',
           code: 'DUG THROUGH INTERNAL WALL',
           active: true,
           label: 'DUG THROUGH INTERNAL WALL',
@@ -274,6 +303,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44931',
         },
         {
+          id: '179048',
           code: 'DUG THROUGH FLOOR',
           active: true,
           label: 'DUG THROUGH FLOOR',
@@ -282,6 +312,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44931',
         },
         {
+          id: '179044',
           code: 'BROKE THROUGH CEILING',
           active: true,
           label: 'BROKE THROUGH CEILING',
@@ -290,6 +321,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44931',
         },
         {
+          id: '179050',
           code: 'FORCED DOOR',
           active: true,
           label: 'FORCED DOOR',
@@ -307,6 +339,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179058',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -315,6 +348,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44633',
         },
         {
+          id: '179059',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -332,6 +366,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179086',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -340,6 +375,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '179085',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -357,6 +393,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179117',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -365,6 +402,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44590',
         },
         {
+          id: '179118',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -382,6 +420,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179198',
           code: 'PRISON HEALTH CARE CENTRE',
           active: true,
           label: 'PRISON HEALTH CARE CENTRE',
@@ -390,6 +429,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44388',
         },
         {
+          id: '179197',
           code: 'OUTSIDE HOSPITAL',
           active: true,
           label: 'OUTSIDE HOSPITAL',
@@ -407,6 +447,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179208',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -415,6 +456,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '179207',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -432,6 +474,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179213',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -440,6 +483,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44406',
         },
         {
+          id: '179214',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -457,6 +501,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179215',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -465,6 +510,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44790',
         },
         {
+          id: '179216',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -482,6 +528,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179260',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -490,6 +537,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179249',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -498,6 +546,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179250',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -506,6 +555,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179253',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -514,6 +564,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179251',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -522,6 +573,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179252',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -530,6 +582,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179261',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -538,6 +591,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179255',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -546,6 +600,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179254',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -554,6 +609,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179248',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -562,6 +618,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179259',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -570,6 +627,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179258',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -578,6 +636,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179256',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -586,6 +645,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44178',
         },
         {
+          id: '179257',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -603,6 +663,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179297',
           code: 'MALE',
           active: true,
           label: 'MALE',
@@ -611,6 +672,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44549',
         },
         {
+          id: '179296',
           code: 'FEMALE',
           active: true,
           label: 'FEMALE',
@@ -628,6 +690,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179307',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -636,6 +699,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44628',
         },
         {
+          id: '179310',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -644,6 +708,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44628',
         },
         {
+          id: '179312',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -652,6 +717,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44628',
         },
         {
+          id: '179304',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -660,6 +726,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44628',
         },
         {
+          id: '179306',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -668,6 +735,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44628',
         },
         {
+          id: '179305',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -676,6 +744,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44628',
         },
         {
+          id: '179308',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -684,6 +753,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44628',
         },
         {
+          id: '179311',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -692,6 +762,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44628',
         },
         {
+          id: '179309',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -709,6 +780,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179326',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -717,6 +789,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44138',
         },
         {
+          id: '179325',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -734,6 +807,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179339',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -742,6 +816,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44485',
         },
         {
+          id: '179340',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -750,6 +825,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44485',
         },
         {
+          id: '179343',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -758,6 +834,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44485',
         },
         {
+          id: '179342',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -766,6 +843,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44485',
         },
         {
+          id: '179341',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -783,6 +861,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179350',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -791,6 +870,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44363',
         },
         {
+          id: '179351',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -799,6 +879,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44363',
         },
         {
+          id: '179349',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -816,6 +897,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179377',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -824,6 +906,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44897',
         },
         {
+          id: '179378',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -841,6 +924,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179420',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -849,6 +933,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44245',
         },
         {
+          id: '179421',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -866,6 +951,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179528',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -874,6 +960,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44241',
         },
         {
+          id: '179529',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -891,6 +978,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179531',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -899,6 +987,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45032',
         },
         {
+          id: '179530',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -916,6 +1005,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179566',
           code: 'UV HAND STAMP',
           active: true,
           label: 'UV HAND STAMP',
@@ -924,6 +1014,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44546',
         },
         {
+          id: '179562',
           code: 'HAND GEOMETRY',
           active: true,
           label: 'HAND GEOMETRY',
@@ -932,6 +1023,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44546',
         },
         {
+          id: '179564',
           code: 'PHOTOGRAPHIC RECORD',
           active: true,
           label: 'PHOTOGRAPHIC RECORD',
@@ -940,6 +1032,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44546',
         },
         {
+          id: '179563',
           code: 'IDENTIFYING CLOTHING',
           active: true,
           label: 'IDENTIFYING CLOTHING',
@@ -948,6 +1041,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44546',
         },
         {
+          id: '179565',
           code: 'STAFF SUPERVISION',
           active: true,
           label: 'STAFF SUPERVISION',
@@ -965,6 +1059,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179605',
           code: 'PRISONER WHO ESCAPED',
           active: true,
           label: 'PRISONER WHO ESCAPED',
@@ -973,6 +1068,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44169',
         },
         {
+          id: '179603',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -981,6 +1077,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44169',
         },
         {
+          id: '179604',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -998,6 +1095,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179614',
           code: 'PURPOSE MADE',
           active: true,
           label: 'PURPOSE MADE',
@@ -1006,6 +1104,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44787',
         },
         {
+          id: '179612',
           code: 'IMPROVISED',
           active: true,
           label: 'IMPROVISED',
@@ -1014,6 +1113,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44787',
         },
         {
+          id: '179613',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1031,6 +1131,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179716',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: true,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -1048,6 +1149,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179737',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1056,6 +1158,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44761',
         },
         {
+          id: '179738',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1073,6 +1176,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179746',
           code: 'WINDOW',
           active: true,
           label: 'WINDOW',
@@ -1081,6 +1185,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44726',
         },
         {
+          id: '179741',
           code: 'EXTERNAL WALL',
           active: true,
           label: 'EXTERNAL WALL',
@@ -1089,6 +1194,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44726',
         },
         {
+          id: '179742',
           code: 'FLOOR',
           active: true,
           label: 'FLOOR',
@@ -1097,6 +1203,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44726',
         },
         {
+          id: '179743',
           code: 'ROOF',
           active: true,
           label: 'ROOF',
@@ -1105,6 +1212,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44726',
         },
         {
+          id: '179740',
           code: 'DOOR/GATE',
           active: true,
           label: 'DOOR/GATE',
@@ -1113,6 +1221,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44726',
         },
         {
+          id: '179744',
           code: 'THROUGH FENCE',
           active: true,
           label: 'THROUGH FENCE',
@@ -1121,6 +1230,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44726',
         },
         {
+          id: '179745',
           code: 'UNDER FENCE',
           active: true,
           label: 'UNDER FENCE',
@@ -1129,6 +1239,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44726',
         },
         {
+          id: '179739',
           code: 'OVER FENCE',
           active: true,
           label: 'OVER FENCE',
@@ -1146,6 +1257,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179756',
           code: 'MURDER/ATTEMPTED MURDER',
           active: true,
           label: 'MURDER/ATTEMPTED MURDER',
@@ -1154,6 +1266,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179755',
           code: 'MANSLAUGHTER',
           active: true,
           label: 'MANSLAUGHTER',
@@ -1162,6 +1275,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179752',
           code: 'ASSAULT',
           active: true,
           label: 'ASSAULT',
@@ -1170,6 +1284,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179760',
           code: 'RAPE/ATTEMPTED RAPE',
           active: true,
           label: 'RAPE/ATTEMPTED RAPE',
@@ -1178,6 +1293,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179758',
           code: 'OTHER SEXUAL OFFENCE',
           active: true,
           label: 'OTHER SEXUAL OFFENCE',
@@ -1186,6 +1302,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179762',
           code: 'THEFT',
           active: true,
           label: 'THEFT',
@@ -1194,6 +1311,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179761',
           code: 'ROBBERY',
           active: true,
           label: 'ROBBERY',
@@ -1202,6 +1320,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179754',
           code: 'FIREARM OFFENCE',
           active: true,
           label: 'FIREARM OFFENCE',
@@ -1210,6 +1329,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179753',
           code: 'DRUG OFFENCE',
           active: true,
           label: 'DRUG OFFENCE',
@@ -1218,6 +1338,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179763',
           code: 'VEHICLE CRIME',
           active: true,
           label: 'VEHICLE CRIME',
@@ -1226,6 +1347,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179759',
           code: 'PUBLIC ORDER OFFENCE',
           active: true,
           label: 'PUBLIC ORDER OFFENCE',
@@ -1234,6 +1356,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44699',
         },
         {
+          id: '179757',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1251,6 +1374,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179769',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1259,6 +1383,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45177',
         },
         {
+          id: '179768',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1276,6 +1401,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179777',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -1284,6 +1410,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179779',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -1292,6 +1419,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179780',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -1300,6 +1428,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179774',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -1308,6 +1437,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179776',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -1316,6 +1446,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179771',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -1324,6 +1455,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179772',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -1332,6 +1464,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179773',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -1340,6 +1473,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179775',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -1348,6 +1482,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179770',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -1356,6 +1491,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179778',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -1364,6 +1500,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44872',
         },
         {
+          id: '179781',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -1381,6 +1518,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179792',
           code: 'SMUGGLED WEAPONS',
           active: true,
           label: 'SMUGGLED WEAPONS',
@@ -1389,6 +1527,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44689',
         },
         {
+          id: '179791',
           code: 'SMUGGLED TOOLS/EQUIPMENT',
           active: true,
           label: 'SMUGGLED TOOLS/EQUIPMENT',
@@ -1397,6 +1536,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44689',
         },
         {
+          id: '179793',
           code: 'SWAPPED IDENTITY',
           active: true,
           label: 'SWAPPED IDENTITY',
@@ -1405,6 +1545,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44689',
         },
         {
+          id: '179788',
           code: 'BREACHED PERIMETER',
           active: true,
           label: 'BREACHED PERIMETER',
@@ -1413,6 +1554,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44689',
         },
         {
+          id: '179790',
           code: 'PROVIDED GET AWAY VEHICLE',
           active: true,
           label: 'PROVIDED GET AWAY VEHICLE',
@@ -1421,6 +1563,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44689',
         },
         {
+          id: '179789',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1438,6 +1581,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179811',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1446,6 +1590,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45147',
         },
         {
+          id: '179812',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1463,6 +1608,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179856',
           code: 'INTENTIONAL',
           active: true,
           label: 'INTENTIONAL',
@@ -1471,6 +1617,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44309',
         },
         {
+          id: '179855',
           code: 'ACCIDENTAL',
           active: true,
           label: 'ACCIDENTAL',
@@ -1488,6 +1635,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179887',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1496,6 +1644,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44373',
         },
         {
+          id: '179888',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1513,6 +1662,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179914',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1521,6 +1671,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44377',
         },
         {
+          id: '179915',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1538,6 +1689,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179936',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1546,6 +1698,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45039',
         },
         {
+          id: '179937',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1563,6 +1716,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179957',
           code: 'PRISON HEALTH CARE CENTRE',
           active: true,
           label: 'PRISON HEALTH CARE CENTRE',
@@ -1571,6 +1725,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45164',
         },
         {
+          id: '179955',
           code: 'OUTSIDE HOSPITAL',
           active: true,
           label: 'OUTSIDE HOSPITAL',
@@ -1579,6 +1734,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45164',
         },
         {
+          id: '179956',
           code: 'OWN GP',
           active: true,
           label: 'OWN GP',
@@ -1596,6 +1752,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180128',
           code: 'CUT',
           active: true,
           label: 'CUT',
@@ -1604,6 +1761,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44192',
         },
         {
+          id: '180129',
           code: 'REMOVED',
           active: true,
           label: 'REMOVED',
@@ -1621,6 +1779,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180158',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1629,6 +1788,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44212',
         },
         {
+          id: '180159',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1646,6 +1806,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180224',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1654,6 +1815,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44310',
         },
         {
+          id: '180223',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1671,6 +1833,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180228',
           code: 'REAL',
           active: true,
           label: 'REAL',
@@ -1679,6 +1842,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44270',
         },
         {
+          id: '180229',
           code: 'REPLICA',
           active: true,
           label: 'REPLICA',
@@ -1687,6 +1851,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44270',
         },
         {
+          id: '180227',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1704,6 +1869,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180335',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1712,6 +1878,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44321',
         },
         {
+          id: '180334',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1729,6 +1896,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180409',
           code: 'SSU',
           active: true,
           label: 'SSU',
@@ -1737,6 +1905,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44558',
         },
         {
+          id: '180410',
           code: 'WING/HOUSEBLOCK',
           active: true,
           label: 'WING/HOUSEBLOCK',
@@ -1745,6 +1914,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44558',
         },
         {
+          id: '180404',
           code: 'CRC',
           active: true,
           label: 'CRC',
@@ -1753,6 +1923,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44558',
         },
         {
+          id: '180405',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -1761,6 +1932,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44558',
         },
         {
+          id: '180408',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -1769,6 +1941,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44558',
         },
         {
+          id: '180407',
           code: 'RULE 45 UNIT (OR)',
           active: true,
           label: 'RULE 45 UNIT (OR)',
@@ -1777,6 +1950,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44558',
         },
         {
+          id: '180406',
           code: 'RULE 45 UNIT (GOAD)',
           active: true,
           label: 'RULE 45 UNIT (GOAD)',
@@ -1794,6 +1968,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180422',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1802,6 +1977,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44651',
         },
         {
+          id: '180423',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1819,6 +1995,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180431',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1827,6 +2004,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44858',
         },
         {
+          id: '180432',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1844,6 +2022,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180460',
           code: 'SINGLE',
           active: true,
           label: 'SINGLE',
@@ -1852,6 +2031,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44221',
         },
         {
+          id: '180459',
           code: 'MULTIPLE OCCUPANCY',
           active: true,
           label: 'MULTIPLE OCCUPANCY',
@@ -1869,6 +2049,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180482',
           code: 'ON FOOT',
           active: true,
           label: 'ON FOOT',
@@ -1877,6 +2058,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '180484',
           code: 'DROVE VEHICLE OUT',
           active: true,
           label: 'DROVE VEHICLE OUT',
@@ -1885,6 +2067,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44121',
         },
         {
+          id: '180483',
           code: 'CONCEALED IN VEHICLE',
           active: true,
           label: 'CONCEALED IN VEHICLE',
@@ -1902,6 +2085,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180514',
           code: 'LADDER',
           active: true,
           label: 'LADDER',
@@ -1910,6 +2094,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45036',
         },
         {
+          id: '180516',
           code: 'ROPE',
           active: true,
           label: 'ROPE',
@@ -1918,6 +2103,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45036',
         },
         {
+          id: '180511',
           code: 'CLIMBING AIDS',
           active: true,
           label: 'CLIMBING AIDS',
@@ -1926,6 +2112,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45036',
         },
         {
+          id: '180512',
           code: 'FURNITURE ITEMS',
           active: true,
           label: 'FURNITURE ITEMS',
@@ -1934,6 +2121,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45036',
         },
         {
+          id: '180517',
           code: 'SPORTS ITEMS',
           active: true,
           label: 'SPORTS ITEMS',
@@ -1942,6 +2130,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45036',
         },
         {
+          id: '180513',
           code: 'GROUNDS ITEMS',
           active: true,
           label: 'GROUNDS ITEMS',
@@ -1950,6 +2139,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45036',
         },
         {
+          id: '180515',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1967,6 +2157,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180550',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -1975,6 +2166,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44126',
         },
         {
+          id: '180553',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -1983,6 +2175,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44126',
         },
         {
+          id: '180555',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -1991,6 +2184,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44126',
         },
         {
+          id: '180547',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -1999,6 +2193,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44126',
         },
         {
+          id: '180549',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -2007,6 +2202,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44126',
         },
         {
+          id: '180548',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -2015,6 +2211,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44126',
         },
         {
+          id: '180551',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -2023,6 +2220,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44126',
         },
         {
+          id: '180554',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -2031,6 +2229,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44126',
         },
         {
+          id: '180552',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2048,6 +2247,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180660',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2056,6 +2256,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44781',
         },
         {
+          id: '180659',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2073,6 +2274,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180689',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -2081,6 +2283,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180678',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -2089,6 +2292,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180679',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -2097,6 +2301,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180682',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -2105,6 +2310,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180680',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -2113,6 +2319,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180681',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -2121,6 +2328,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180690',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -2129,6 +2337,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180684',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -2137,6 +2346,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180683',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -2145,6 +2355,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180677',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -2153,6 +2364,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180688',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -2161,6 +2373,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180687',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -2169,6 +2382,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180685',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2177,6 +2391,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '180686',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -2194,6 +2409,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180699',
           code: 'C.N (CHLORACETOPHEONE)',
           active: true,
           label: 'C.N (CHLORACETOPHEONE)',
@@ -2202,6 +2418,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44848',
         },
         {
+          id: '180700',
           code: 'C.S (ORTHO..NITRILE)',
           active: true,
           label: 'C.S (ORTHO..NITRILE)',
@@ -2210,6 +2427,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44848',
         },
         {
+          id: '180702',
           code: 'O.C (MACE/PEPPER)',
           active: true,
           label: 'O.C (MACE/PEPPER)',
@@ -2218,6 +2436,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44848',
         },
         {
+          id: '180703',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -2226,6 +2445,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44848',
         },
         {
+          id: '180701',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2243,6 +2463,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180729',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2251,6 +2472,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44329',
         },
         {
+          id: '180730',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2268,6 +2490,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180752',
           code: 'ANOTHER PRISONER',
           active: true,
           label: 'ANOTHER PRISONER',
@@ -2276,6 +2499,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '180751',
           code: 'A VISITOR',
           active: true,
           label: 'A VISITOR',
@@ -2293,6 +2517,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180785',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -2301,6 +2526,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45037',
         },
         {
+          id: '180788',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -2309,6 +2535,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45037',
         },
         {
+          id: '180790',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -2317,6 +2544,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45037',
         },
         {
+          id: '180782',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -2325,6 +2553,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45037',
         },
         {
+          id: '180784',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -2333,6 +2562,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45037',
         },
         {
+          id: '180783',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -2341,6 +2571,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45037',
         },
         {
+          id: '180786',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -2349,6 +2580,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45037',
         },
         {
+          id: '180789',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -2357,6 +2589,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45037',
         },
         {
+          id: '180787',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2374,6 +2607,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180795',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2382,6 +2616,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44262',
         },
         {
+          id: '180796',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2399,6 +2634,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180854',
           code: 'PRISONER WHO ESCAPED',
           active: true,
           label: 'PRISONER WHO ESCAPED',
@@ -2407,6 +2643,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44220',
         },
         {
+          id: '180852',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -2415,6 +2652,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44220',
         },
         {
+          id: '180853',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -2432,6 +2670,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180876',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2440,6 +2679,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44501',
         },
         {
+          id: '180877',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2457,6 +2697,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180921',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2465,6 +2706,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44968',
         },
         {
+          id: '180920',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2482,6 +2724,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180968',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2490,6 +2733,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '180967',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2507,6 +2751,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181035',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2515,6 +2760,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44165',
         },
         {
+          id: '181036',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2532,6 +2778,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181134',
           code: 'OTHER SHARP INSTRUMENT',
           active: true,
           label: 'OTHER SHARP INSTRUMENT',
@@ -2540,6 +2787,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44683',
         },
         {
+          id: '181128',
           code: 'BLUNT INSTRUMENT',
           active: true,
           label: 'BLUNT INSTRUMENT',
@@ -2548,6 +2796,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44683',
         },
         {
+          id: '181132',
           code: 'LIGATURE',
           active: true,
           label: 'LIGATURE',
@@ -2556,6 +2805,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44683',
         },
         {
+          id: '181129',
           code: 'DANGEROUS LIQUID',
           active: true,
           label: 'DANGEROUS LIQUID',
@@ -2564,6 +2814,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44683',
         },
         {
+          id: '181130',
           code: 'EXCRETA/URINE',
           active: true,
           label: 'EXCRETA/URINE',
@@ -2572,6 +2823,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44683',
         },
         {
+          id: '181135',
           code: 'SPITTING',
           active: true,
           label: 'SPITTING',
@@ -2580,6 +2832,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44683',
         },
         {
+          id: '181131',
           code: 'FOOD',
           active: true,
           label: 'FOOD',
@@ -2588,6 +2841,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44683',
         },
         {
+          id: '181137',
           code: 'THROWN FURNITURE',
           active: true,
           label: 'THROWN FURNITURE',
@@ -2596,6 +2850,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44683',
         },
         {
+          id: '181136',
           code: 'THROWN EQUIPMENT',
           active: true,
           label: 'THROWN EQUIPMENT',
@@ -2604,6 +2859,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44683',
         },
         {
+          id: '181133',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -2621,6 +2877,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181180',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2629,6 +2886,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44381',
         },
         {
+          id: '181181',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2646,6 +2904,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181204',
           code: 'PRISONER WHO ESCAPED',
           active: true,
           label: 'PRISONER WHO ESCAPED',
@@ -2654,6 +2913,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44369',
         },
         {
+          id: '181202',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -2662,6 +2922,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44369',
         },
         {
+          id: '181203',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -2679,6 +2940,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181225',
           code: 'CUT WINDOW OR BARS',
           active: true,
           label: 'CUT WINDOW OR BARS',
@@ -2687,6 +2949,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181227',
           code: 'FORCED WINDOW OR BARS',
           active: true,
           label: 'FORCED WINDOW OR BARS',
@@ -2695,6 +2958,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181224',
           code: 'CUT AND FORCED WINDOW AND BARS',
           active: true,
           label: 'CUT AND FORCED WINDOW AND BARS',
@@ -2703,6 +2967,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181226',
           code: 'DUG THROUGH EXTERNAL WALL',
           active: true,
           label: 'DUG THROUGH EXTERNAL WALL',
@@ -2711,6 +2976,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181222',
           code: 'DUG THROUGH INTERNAL WALL',
           active: true,
           label: 'DUG THROUGH INTERNAL WALL',
@@ -2719,6 +2985,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45009',
         },
         {
+          id: '181221',
           code: 'DUG THROUGH FLOOR',
           active: true,
           label: 'DUG THROUGH FLOOR',
@@ -2727,6 +2994,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45009',
         },
         {
+          id: '181220',
           code: 'BROKE THROUGH CEILING',
           active: true,
           label: 'BROKE THROUGH CEILING',
@@ -2735,6 +3003,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45009',
         },
         {
+          id: '181223',
           code: 'FORCED DOOR',
           active: true,
           label: 'FORCED DOOR',
@@ -2752,6 +3021,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181254',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2760,6 +3030,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44499',
         },
         {
+          id: '181253',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2777,6 +3048,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181311',
           code: 'INSIDE',
           active: true,
           label: 'INSIDE',
@@ -2785,6 +3057,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45103',
         },
         {
+          id: '181312',
           code: 'OUTSIDE',
           active: true,
           label: 'OUTSIDE',
@@ -2802,6 +3075,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181325',
           code: 'CLAD',
           active: true,
           label: 'CLAD',
@@ -2810,6 +3084,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44903',
         },
         {
+          id: '181326',
           code: 'UNCLAD',
           active: true,
           label: 'UNCLAD',
@@ -2827,6 +3102,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181333',
           code: 'INSIDE',
           active: true,
           label: 'INSIDE',
@@ -2835,6 +3111,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44830',
         },
         {
+          id: '181334',
           code: 'OUTSIDE',
           active: true,
           label: 'OUTSIDE',
@@ -2852,6 +3129,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181366',
           code: 'HACKSAW BLADE',
           active: true,
           label: 'HACKSAW BLADE',
@@ -2860,6 +3138,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44231',
         },
         {
+          id: '181369',
           code: 'OTHER BLADE',
           active: true,
           label: 'OTHER BLADE',
@@ -2868,6 +3147,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44231',
         },
         {
+          id: '181371',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -2876,6 +3156,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44231',
         },
         {
+          id: '181363',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -2884,6 +3165,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44231',
         },
         {
+          id: '181365',
           code: 'DIGGING TOOL',
           active: true,
           label: 'DIGGING TOOL',
@@ -2892,6 +3174,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44231',
         },
         {
+          id: '181364',
           code: 'CROW BAR',
           active: true,
           label: 'CROW BAR',
@@ -2900,6 +3183,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44231',
         },
         {
+          id: '181367',
           code: 'IMPROVISED TOOL',
           active: true,
           label: 'IMPROVISED TOOL',
@@ -2908,6 +3192,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44231',
         },
         {
+          id: '181370',
           code: 'OTHER TOOL',
           active: true,
           label: 'OTHER TOOL',
@@ -2916,6 +3201,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44231',
         },
         {
+          id: '181368',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2933,6 +3219,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181378',
           code: 'PRISONER WHO ESCAPED',
           active: true,
           label: 'PRISONER WHO ESCAPED',
@@ -2941,6 +3228,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44641',
         },
         {
+          id: '181376',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -2949,6 +3237,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44641',
         },
         {
+          id: '181377',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -2966,6 +3255,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181389',
           code: 'MAIN GATE',
           active: true,
           label: 'MAIN GATE',
@@ -2974,6 +3264,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44568',
         },
         {
+          id: '181390',
           code: 'OTHER GATE IN PERIMETER',
           active: true,
           label: 'OTHER GATE IN PERIMETER',
@@ -2982,6 +3273,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44568',
         },
         {
+          id: '181384',
           code: 'OVER WALL',
           active: true,
           label: 'OVER WALL',
@@ -2990,6 +3282,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44852',
         },
         {
+          id: '181383',
           code: 'OVER FENCE',
           active: true,
           label: 'OVER FENCE',
@@ -2998,6 +3291,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44852',
         },
         {
+          id: '181385',
           code: 'THROUGH FENCE',
           active: true,
           label: 'THROUGH FENCE',
@@ -3006,6 +3300,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44834',
         },
         {
+          id: '181387',
           code: 'THROUGH WALL',
           active: true,
           label: 'THROUGH WALL',
@@ -3014,6 +3309,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44824',
         },
         {
+          id: '181386',
           code: 'UNDER FENCE',
           active: true,
           label: 'UNDER FENCE',
@@ -3022,6 +3318,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44834',
         },
         {
+          id: '181388',
           code: 'UNDER WALL',
           active: true,
           label: 'UNDER WALL',
@@ -3039,6 +3336,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181394',
           code: 'LADDER',
           active: true,
           label: 'LADDER',
@@ -3047,6 +3345,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45052',
         },
         {
+          id: '181396',
           code: 'ROPE',
           active: true,
           label: 'ROPE',
@@ -3055,6 +3354,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45052',
         },
         {
+          id: '181391',
           code: 'CLIMBING AIDS',
           active: true,
           label: 'CLIMBING AIDS',
@@ -3063,6 +3363,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45052',
         },
         {
+          id: '181392',
           code: 'FURNITURE ITEMS',
           active: true,
           label: 'FURNITURE ITEMS',
@@ -3071,6 +3372,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45052',
         },
         {
+          id: '181397',
           code: 'SPORTS ITEMS',
           active: true,
           label: 'SPORTS ITEMS',
@@ -3079,6 +3381,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45052',
         },
         {
+          id: '181393',
           code: 'GROUNDS ITEMS',
           active: true,
           label: 'GROUNDS ITEMS',
@@ -3087,6 +3390,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45052',
         },
         {
+          id: '181395',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -3104,6 +3408,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181425',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -3112,6 +3417,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181427',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -3120,6 +3426,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181428',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -3128,6 +3435,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181422',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -3136,6 +3444,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181424',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -3144,6 +3453,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181419',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -3152,6 +3462,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181420',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -3160,6 +3471,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181421',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -3168,6 +3480,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181423',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -3176,6 +3489,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181418',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -3184,6 +3498,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181426',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -3192,6 +3507,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44981',
         },
         {
+          id: '181429',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -3209,6 +3525,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181490',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3217,6 +3534,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44258',
         },
         {
+          id: '181491',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3234,6 +3552,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181573',
           code: 'LIVE',
           active: true,
           label: 'LIVE',
@@ -3242,6 +3561,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44325',
         },
         {
+          id: '181572',
           code: 'BLANK',
           active: true,
           label: 'BLANK',
@@ -3250,6 +3570,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44325',
         },
         {
+          id: '181574',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -3267,6 +3588,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181585',
           code: 'THROUGH THE CLADDING',
           active: true,
           label: 'THROUGH THE CLADDING',
@@ -3275,6 +3597,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44476',
         },
         {
+          id: '181586',
           code: 'ABOVE THE CLADDING',
           active: true,
           label: 'ABOVE THE CLADDING',
@@ -3283,6 +3606,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44192',
         },
         {
+          id: '181587',
           code: 'BELOW THE CLADDING',
           active: true,
           label: 'BELOW THE CLADDING',
@@ -3300,6 +3624,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181725',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3308,6 +3633,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44844',
         },
         {
+          id: '181726',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3325,6 +3651,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181745',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3333,6 +3660,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44657',
         },
         {
+          id: '181746',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3350,6 +3678,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181824',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -3358,6 +3687,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45132',
         },
         {
+          id: '181825',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -3366,6 +3696,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45132',
         },
         {
+          id: '181828',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -3374,6 +3705,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45132',
         },
         {
+          id: '181827',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -3382,6 +3714,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45132',
         },
         {
+          id: '181826',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -3399,6 +3732,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181845',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3407,6 +3741,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44659',
         },
         {
+          id: '181844',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3424,6 +3759,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181906',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3432,6 +3768,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44961',
         },
         {
+          id: '181907',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3449,6 +3786,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181978',
           code: 'ANOTHER CELL',
           active: true,
           label: 'ANOTHER CELL',
@@ -3457,6 +3795,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181984',
           code: 'RECESS/SHOWERS',
           active: true,
           label: 'RECESS/SHOWERS',
@@ -3465,6 +3804,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181986',
           code: 'STORE ROOM',
           active: true,
           label: 'STORE ROOM',
@@ -3473,6 +3813,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181979',
           code: 'ASSOCIATION AREA',
           active: true,
           label: 'ASSOCIATION AREA',
@@ -3481,6 +3822,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181983',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -3489,6 +3831,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181981',
           code: 'CANTEEN',
           active: true,
           label: 'CANTEEN',
@@ -3497,6 +3840,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181982',
           code: 'KITCHEN/SERVERY',
           active: true,
           label: 'KITCHEN/SERVERY',
@@ -3505,6 +3849,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181985',
           code: 'ROOF SPACE',
           active: true,
           label: 'ROOF SPACE',
@@ -3513,6 +3858,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44936',
         },
         {
+          id: '181980',
           code: 'BASEMENT',
           active: true,
           label: 'BASEMENT',
@@ -3530,6 +3876,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182064',
           code: 'SPORTS FIELD',
           active: true,
           label: 'SPORTS FIELD',
@@ -3538,6 +3885,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44705',
         },
         {
+          id: '182065',
           code: 'CELL',
           active: true,
           label: 'CELL',
@@ -3546,6 +3894,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44540',
         },
         {
+          id: '182066',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -3554,6 +3903,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44527',
         },
         {
+          id: '182079',
           code: 'WING/HOUSEBLOCK',
           active: true,
           label: 'WING/HOUSEBLOCK',
@@ -3562,6 +3912,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182069',
           code: 'DORMITORY',
           active: true,
           label: 'DORMITORY',
@@ -3570,6 +3921,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182074',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -3578,6 +3930,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182068',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -3586,6 +3939,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182075',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -3594,6 +3948,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182070',
           code: 'EDUCATION/LIBRARY',
           active: true,
           label: 'EDUCATION/LIBRARY',
@@ -3602,6 +3957,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182081',
           code: 'WORKSHOP',
           active: true,
           label: 'WORKSHOP',
@@ -3610,6 +3966,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182078',
           code: 'STORES',
           active: true,
           label: 'STORES',
@@ -3618,6 +3975,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182067',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -3626,6 +3984,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182073',
           code: 'GYMNASIUM',
           active: true,
           label: 'GYMNASIUM',
@@ -3634,6 +3993,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182077',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -3642,6 +4002,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182080',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -3650,6 +4011,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182071',
           code: 'EXERCISE YARD',
           active: true,
           label: 'EXERCISE YARD',
@@ -3658,6 +4020,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182076',
           code: 'OTHER SECURE AREA',
           active: true,
           label: 'OTHER SECURE AREA',
@@ -3666,6 +4029,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182072',
           code: 'GROUNDS WITH NO ACCESS TO EXTERNAL PERIMITER',
           active: true,
           label: 'GROUNDS WITH NO ACCESS TO EXTERNAL PERIMITER',
@@ -3674,6 +4038,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44370',
         },
         {
+          id: '182082',
           code: 'GROUNDS WITH ACCESS TO EXTERNAL PERIMITER',
           active: true,
           label: 'GROUNDS WITH ACCESS TO EXTERNAL PERIMITER',
@@ -3691,6 +4056,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182110',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -3699,6 +4065,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182100',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -3707,6 +4074,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182101',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -3715,6 +4083,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182104',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -3723,6 +4092,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182102',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -3731,6 +4101,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182103',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -3739,6 +4110,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182111',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -3747,6 +4119,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182106',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -3755,6 +4128,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182105',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -3763,6 +4137,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182099',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -3771,6 +4146,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182109',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -3779,6 +4155,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182108',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -3787,6 +4164,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44851',
         },
         {
+          id: '182107',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -3804,6 +4182,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182124',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -3812,6 +4191,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182113',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -3820,6 +4200,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182114',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -3828,6 +4209,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182117',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -3836,6 +4218,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182115',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -3844,6 +4227,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182116',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -3852,6 +4236,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182125',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -3860,6 +4245,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182119',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -3868,6 +4254,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182118',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -3876,6 +4263,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182112',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -3884,6 +4272,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182123',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -3892,6 +4281,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182122',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -3900,6 +4290,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182120',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -3908,6 +4299,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44217',
         },
         {
+          id: '182121',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -3925,6 +4317,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182131',
           code: 'GANDER',
           active: true,
           label: 'GANDER',
@@ -3933,6 +4326,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182137',
           code: 'PIPE',
           active: true,
           label: 'PIPE',
@@ -3941,6 +4335,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182128',
           code: "'S' WIRE",
           active: true,
           label: "'S' WIRE",
@@ -3949,6 +4344,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182139',
           code: 'SCARE STRIP',
           active: true,
           label: 'SCARE STRIP',
@@ -3957,6 +4353,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182140',
           code: 'TAUT WIRE',
           active: true,
           label: 'TAUT WIRE',
@@ -3965,6 +4362,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182132',
           code: 'GEOPHONES',
           active: true,
           label: 'GEOPHONES',
@@ -3973,6 +4371,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182133',
           code: 'INFRA RED DETECTORS',
           active: true,
           label: 'INFRA RED DETECTORS',
@@ -3981,6 +4380,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182135',
           code: 'MICROPHONIC CABLE',
           active: true,
           label: 'MICROPHONIC CABLE',
@@ -3989,6 +4389,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182130',
           code: 'FIBRE OPTIC SYSTEM',
           active: true,
           label: 'FIBRE OPTIC SYSTEM',
@@ -3997,6 +4398,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182134',
           code: 'LEAKY CO-AXIL CABLE',
           active: true,
           label: 'LEAKY CO-AXIL CABLE',
@@ -4005,6 +4407,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182138',
           code: 'PRESSURE SENSORS',
           active: true,
           label: 'PRESSURE SENSORS',
@@ -4013,6 +4416,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182129',
           code: 'CCTV',
           active: true,
           label: 'CCTV',
@@ -4021,6 +4425,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '45048',
         },
         {
+          id: '182136',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -4038,6 +4443,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182168',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4046,6 +4452,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44121',
         },
         {
+          id: '182169',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4063,6 +4470,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182195',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -4071,6 +4479,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182185',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -4079,6 +4488,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182186',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -4087,6 +4497,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182189',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -4095,6 +4506,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182187',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -4103,6 +4515,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182188',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: true,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -4111,6 +4524,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182196',
           code: 'WORKSHOPS',
           active: true,
           label: 'WORKSHOPS',
@@ -4119,6 +4533,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182191',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -4127,6 +4542,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182190',
           code: 'HOBBIES',
           active: true,
           label: 'HOBBIES',
@@ -4135,6 +4551,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182184',
           code: 'CELL FURNISHINGS',
           active: true,
           label: 'CELL FURNISHINGS',
@@ -4143,6 +4560,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182194',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: true,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -4151,6 +4569,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182193',
           code: 'SMUGGLED',
           active: true,
           label: 'SMUGGLED',
@@ -4159,6 +4578,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44436',
         },
         {
+          id: '182192',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -4176,6 +4596,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182356',
           code: 'DUG THROUGH',
           active: true,
           label: 'DUG THROUGH',
@@ -4184,6 +4605,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44291',
         },
         {
+          id: '182357',
           code: 'DUG UNDER',
           active: true,
           label: 'DUG UNDER',
@@ -4192,6 +4614,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44291',
         },
         {
+          id: '182358',
           code: 'EXPLOSION',
           active: true,
           label: 'EXPLOSION',
@@ -4200,6 +4623,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44291',
         },
         {
+          id: '182361',
           code: 'RAMMED BY VEHICLE',
           active: true,
           label: 'RAMMED BY VEHICLE',
@@ -4208,6 +4632,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44291',
         },
         {
+          id: '182360',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -4216,6 +4641,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44291',
         },
         {
+          id: '182359',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -4233,6 +4659,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182471',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4241,6 +4668,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44442',
         },
         {
+          id: '182472',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4258,6 +4686,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182550',
           code: 'POLICE ARREST',
           active: true,
           label: 'POLICE ARREST',
@@ -4266,6 +4695,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44415',
         },
         {
+          id: '182551',
           code: 'PRISON STAFF ARREST',
           active: true,
           label: 'PRISON STAFF ARREST',
@@ -4274,6 +4704,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44415',
         },
         {
+          id: '182552',
           code: 'SURRENDER',
           active: true,
           label: 'SURRENDER',
@@ -4282,6 +4713,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44415',
         },
         {
+          id: '182549',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -4299,6 +4731,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182606',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -4307,6 +4740,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44428',
         },
         {
+          id: '182607',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -4324,6 +4758,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182648',
           code: 'INVESTIGATION BY POLICE',
           active: true,
           label: 'INVESTIGATION BY POLICE',
@@ -4332,6 +4767,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44798',
         },
         {
+          id: '182649',
           code: 'INVESTIGATION INTERNALLY',
           active: true,
           label: 'INVESTIGATION INTERNALLY',
@@ -4340,6 +4776,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44798',
         },
         {
+          id: '182647',
           code: "GOVERNOR'S ADJUDICATION",
           active: true,
           label: "GOVERNOR'S ADJUDICATION",
@@ -4348,6 +4785,7 @@ const ESCAPE_FROM_CUSTODY: IncidentTypeConfiguration = {
           nextQuestionId: '44798',
         },
         {
+          id: '182650',
           code: 'NO INVESTIGATION',
           active: true,
           label: 'NO INVESTIGATION',

--- a/server/reportConfiguration/types/ESCAPE_FROM_ESCORT.ts
+++ b/server/reportConfiguration/types/ESCAPE_FROM_ESCORT.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:01.839Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:27.909Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178932',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45118',
         },
         {
+          id: '178933',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '178974',
           code: 'CATEGORY A',
           active: true,
           label: 'CATEGORY A',
@@ -48,6 +51,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45156',
         },
         {
+          id: '178975',
           code: 'CATEGORY B',
           active: true,
           label: 'CATEGORY B',
@@ -56,6 +60,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45156',
         },
         {
+          id: '178976',
           code: 'CATEGORY C',
           active: true,
           label: 'CATEGORY C',
@@ -64,6 +69,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45156',
         },
         {
+          id: '178973',
           code: 'CATEGORISED YO',
           active: true,
           label: 'CATEGORISED YO',
@@ -72,6 +78,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45156',
         },
         {
+          id: '178977',
           code: 'CATEGORY D',
           active: true,
           label: 'CATEGORY D',
@@ -80,6 +87,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45156',
         },
         {
+          id: '178980',
           code: 'UNCATEGORISED YO',
           active: true,
           label: 'UNCATEGORISED YO',
@@ -88,6 +96,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45156',
         },
         {
+          id: '178972',
           code: 'CATEGORISED FEMALE',
           active: true,
           label: 'CATEGORISED FEMALE',
@@ -96,6 +105,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45156',
         },
         {
+          id: '178979',
           code: 'UNCATEGORISED FEMALE',
           active: true,
           label: 'UNCATEGORISED FEMALE',
@@ -104,6 +114,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45156',
         },
         {
+          id: '178978',
           code: 'UNCATEGORISED ADULT MALE',
           active: true,
           label: 'UNCATEGORISED ADULT MALE',
@@ -121,6 +132,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179039',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -129,6 +141,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44571',
         },
         {
+          id: '179040',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -137,6 +150,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44571',
         },
         {
+          id: '179043',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -145,6 +159,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44571',
         },
         {
+          id: '179042',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -153,6 +168,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44571',
         },
         {
+          id: '179041',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -170,6 +186,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179106',
           code: 'COACH',
           active: true,
           label: 'COACH',
@@ -178,6 +195,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '179107',
           code: 'MINIBUS',
           active: true,
           label: 'MINIBUS',
@@ -186,6 +204,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '179110',
           code: 'TAXI',
           active: true,
           label: 'TAXI',
@@ -194,6 +213,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '179105',
           code: 'CELLULAR VEHICLE',
           active: true,
           label: 'CELLULAR VEHICLE',
@@ -202,6 +222,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '179109',
           code: 'SECURE TRANSIT',
           active: true,
           label: 'SECURE TRANSIT',
@@ -210,6 +231,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '179108',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -227,6 +249,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179195',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -235,6 +258,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44859',
         },
         {
+          id: '179196',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -252,6 +276,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179203',
           code: 'LIVE',
           active: true,
           label: 'LIVE',
@@ -260,6 +285,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44994',
         },
         {
+          id: '179202',
           code: 'BLANK',
           active: true,
           label: 'BLANK',
@@ -268,6 +294,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44994',
         },
         {
+          id: '179204',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -285,6 +312,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179314',
           code: 'REAL',
           active: true,
           label: 'REAL',
@@ -293,6 +321,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44998',
         },
         {
+          id: '179315',
           code: 'REPLICA',
           active: true,
           label: 'REPLICA',
@@ -301,6 +330,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44998',
         },
         {
+          id: '179313',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -318,6 +348,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179397',
           code: 'A CO-DEFENDANT',
           active: true,
           label: 'A CO-DEFENDANT',
@@ -326,6 +357,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44211',
         },
         {
+          id: '179399',
           code: 'A RELATIVE',
           active: true,
           label: 'A RELATIVE',
@@ -334,6 +366,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44211',
         },
         {
+          id: '179398',
           code: 'A KNOWN ASSOCIATE',
           active: true,
           label: 'A KNOWN ASSOCIATE',
@@ -342,6 +375,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44211',
         },
         {
+          id: '179400',
           code: 'AN E LIST PRISONER',
           active: true,
           label: 'AN E LIST PRISONER',
@@ -350,6 +384,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44211',
         },
         {
+          id: '179401',
           code: 'NONE OF THE ABOVE',
           active: true,
           label: 'NONE OF THE ABOVE',
@@ -367,6 +402,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179447',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -375,6 +411,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44970',
         },
         {
+          id: '179448',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -392,6 +429,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179709',
           code: 'INVESTIGATION BY POLICE',
           active: true,
           label: 'INVESTIGATION BY POLICE',
@@ -400,6 +438,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45066',
         },
         {
+          id: '179710',
           code: 'INVESTIGATION INTERNALLY',
           active: true,
           label: 'INVESTIGATION INTERNALLY',
@@ -408,6 +447,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45066',
         },
         {
+          id: '179708',
           code: "GOVERNOR'S ADJUDICATION",
           active: true,
           label: "GOVERNOR'S ADJUDICATION",
@@ -416,6 +456,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45066',
         },
         {
+          id: '179711',
           code: 'NO INVESTIGATION',
           active: true,
           label: 'NO INVESTIGATION',
@@ -433,6 +474,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179878',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -441,6 +483,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45112',
         },
         {
+          id: '179877',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -458,6 +501,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179895',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -466,6 +510,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44966',
         },
         {
+          id: '179896',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -483,6 +528,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179911',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: true,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -500,6 +546,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179959',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -508,6 +555,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45136',
         },
         {
+          id: '179958',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -525,6 +573,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179980',
           code: 'MALE',
           active: true,
           label: 'MALE',
@@ -533,6 +582,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44757',
         },
         {
+          id: '179979',
           code: 'FEMALE',
           active: true,
           label: 'FEMALE',
@@ -550,6 +600,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180172',
           code: 'HOSPITAL OUTPATIENT',
           active: true,
           label: 'HOSPITAL OUTPATIENT',
@@ -558,6 +609,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44409',
         },
         {
+          id: '180171',
           code: 'HOSPITAL INPATIENT',
           active: true,
           label: 'HOSPITAL INPATIENT',
@@ -566,6 +618,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44409',
         },
         {
+          id: '180178',
           code: 'INTER PRISON TRANSFER',
           active: true,
           label: 'INTER PRISON TRANSFER',
@@ -574,6 +627,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45112',
         },
         {
+          id: '180179',
           code: 'MAGISTRATES COURT',
           active: true,
           label: 'MAGISTRATES COURT',
@@ -582,6 +636,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45112',
         },
         {
+          id: '180174',
           code: 'CROWN COURT',
           active: true,
           label: 'CROWN COURT',
@@ -590,6 +645,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45112',
         },
         {
+          id: '180173',
           code: 'COUNTY COURT',
           active: true,
           label: 'COUNTY COURT',
@@ -598,6 +654,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45112',
         },
         {
+          id: '180175',
           code: 'FUNERAL',
           active: true,
           label: 'FUNERAL',
@@ -606,6 +663,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45112',
         },
         {
+          id: '180181',
           code: 'WEDDING',
           active: true,
           label: 'WEDDING',
@@ -614,6 +672,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45112',
         },
         {
+          id: '180176',
           code: 'HOME VISIT',
           active: true,
           label: 'HOME VISIT',
@@ -622,6 +681,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45112',
         },
         {
+          id: '180177',
           code: 'HOSP VISIT (DYING RELATIVE)',
           active: true,
           label: 'HOSP VISIT (DYING RELATIVE)',
@@ -630,6 +690,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45112',
         },
         {
+          id: '180180',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -647,6 +708,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180246',
           code: 'SECRETED ON PRISONER',
           active: true,
           label: 'SECRETED ON PRISONER',
@@ -655,6 +717,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45151',
         },
         {
+          id: '180244',
           code: 'FOUND IN VEHICLE/AREA',
           active: true,
           label: 'FOUND IN VEHICLE/AREA',
@@ -663,6 +726,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45151',
         },
         {
+          id: '180243',
           code: 'BROUGHT BY OUTSIDE ACCOMPLICE',
           active: true,
           label: 'BROUGHT BY OUTSIDE ACCOMPLICE',
@@ -671,6 +735,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45151',
         },
         {
+          id: '180245',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -688,6 +753,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180275',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -696,6 +762,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44164',
         },
         {
+          id: '180276',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -713,6 +780,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180280',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -721,6 +789,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44904',
         },
         {
+          id: '180281',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -738,6 +807,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180401',
           code: 'PRISON HEALTH CARE CENTRE',
           active: true,
           label: 'PRISON HEALTH CARE CENTRE',
@@ -746,6 +816,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44134',
         },
         {
+          id: '180399',
           code: 'OUTSIDE HOSPITAL',
           active: true,
           label: 'OUTSIDE HOSPITAL',
@@ -754,6 +825,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44134',
         },
         {
+          id: '180400',
           code: 'OWN GP',
           active: true,
           label: 'OWN GP',
@@ -771,6 +843,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180402',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -779,6 +852,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45154',
         },
         {
+          id: '180403',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -796,6 +870,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180489',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -804,6 +879,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44706',
         },
         {
+          id: '180490',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -821,6 +897,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180522',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -829,6 +906,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44650',
         },
         {
+          id: '180523',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -846,6 +924,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180615',
           code: 'PRISONER WHO ESCAPED',
           active: true,
           label: 'PRISONER WHO ESCAPED',
@@ -854,6 +933,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44507',
         },
         {
+          id: '180613',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -862,6 +942,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44507',
         },
         {
+          id: '180614',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -879,6 +960,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180736',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -887,6 +969,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '180735',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -904,6 +987,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180749',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -912,6 +996,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44426',
         },
         {
+          id: '180750',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -920,6 +1005,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44426',
         },
         {
+          id: '180748',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -937,6 +1023,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180832',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -945,6 +1032,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '180831',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -962,6 +1050,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180837',
           code: 'REAL',
           active: true,
           label: 'REAL',
@@ -970,6 +1059,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44644',
         },
         {
+          id: '180835',
           code: 'IMPROVISED',
           active: true,
           label: 'IMPROVISED',
@@ -978,6 +1068,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44644',
         },
         {
+          id: '180836',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -995,6 +1086,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180913',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1003,6 +1095,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44581',
         },
         {
+          id: '180912',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1020,6 +1113,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180970',
           code: 'PRISON HEALTH CARE CENTRE',
           active: true,
           label: 'PRISON HEALTH CARE CENTRE',
@@ -1028,6 +1122,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44908',
         },
         {
+          id: '180969',
           code: 'OUTSIDE HOSPITAL',
           active: true,
           label: 'OUTSIDE HOSPITAL',
@@ -1045,6 +1140,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180990',
           code: 'PRISONER WHO ESCAPED',
           active: true,
           label: 'PRISONER WHO ESCAPED',
@@ -1053,6 +1149,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44838',
         },
         {
+          id: '180988',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -1061,6 +1158,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44838',
         },
         {
+          id: '180989',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -1078,6 +1176,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181039',
           code: 'GOVERNORS INSTRUCTION',
           active: true,
           label: 'GOVERNORS INSTRUCTION',
@@ -1086,6 +1185,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181046',
           code: 'PREVENTED BY DISABILITY',
           active: true,
           label: 'PREVENTED BY DISABILITY',
@@ -1094,6 +1194,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181047',
           code: 'PREVENTED BY INJURY',
           active: true,
           label: 'PREVENTED BY INJURY',
@@ -1102,6 +1203,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181043',
           code: 'MEDICAL TREATMENT/REQUEST',
           active: true,
           label: 'MEDICAL TREATMENT/REQUEST',
@@ -1110,6 +1212,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181041',
           code: 'IN COURT ROOM',
           active: true,
           label: 'IN COURT ROOM',
@@ -1118,6 +1221,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181042',
           code: 'LOCATED IN SECURE AREA',
           active: true,
           label: 'LOCATED IN SECURE AREA',
@@ -1126,6 +1230,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181040',
           code: 'IN CELL OF CELLULAR VEHICLE',
           active: true,
           label: 'IN CELL OF CELLULAR VEHICLE',
@@ -1134,6 +1239,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181048',
           code: 'TRANSFER TO MENTAL HOSPITAL',
           active: true,
           label: 'TRANSFER TO MENTAL HOSPITAL',
@@ -1142,6 +1248,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181037',
           code: 'DURING MARRIAGE CEREMONY',
           active: true,
           label: 'DURING MARRIAGE CEREMONY',
@@ -1150,6 +1257,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181044',
           code: 'NONE AVAILABLE',
           active: true,
           label: 'NONE AVAILABLE',
@@ -1158,6 +1266,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181038',
           code: 'FAILURE TO USE',
           active: true,
           label: 'FAILURE TO USE',
@@ -1166,6 +1275,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181045',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1183,6 +1293,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181051',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1191,6 +1302,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45068',
         },
         {
+          id: '181052',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1208,6 +1320,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181114',
           code: 'PRISONER WHO ESCAPED',
           active: true,
           label: 'PRISONER WHO ESCAPED',
@@ -1216,6 +1329,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45080',
         },
         {
+          id: '181112',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -1224,6 +1338,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45080',
         },
         {
+          id: '181113',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -1241,6 +1356,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181120',
           code: 'MALE',
           active: true,
           label: 'MALE',
@@ -1249,6 +1365,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44143',
         },
         {
+          id: '181119',
           code: 'FEMALE',
           active: true,
           label: 'FEMALE',
@@ -1266,6 +1383,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181322',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1274,6 +1392,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45089',
         },
         {
+          id: '181321',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1291,6 +1410,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181345',
           code: 'SECRETED ON THE PRISONER',
           active: true,
           label: 'SECRETED ON THE PRISONER',
@@ -1299,6 +1419,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44729',
         },
         {
+          id: '181343',
           code: 'FOUND IN VEHICLE/AREA',
           active: true,
           label: 'FOUND IN VEHICLE/AREA',
@@ -1307,6 +1428,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44729',
         },
         {
+          id: '181342',
           code: 'BROUGHT BY ACCOMPLICE',
           active: true,
           label: 'BROUGHT BY ACCOMPLICE',
@@ -1315,6 +1437,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44729',
         },
         {
+          id: '181344',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1332,6 +1455,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181372',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1340,6 +1464,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44882',
         },
         {
+          id: '181373',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1357,6 +1482,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181382',
           code: 'PRISON SERVICE',
           active: true,
           label: 'PRISON SERVICE',
@@ -1365,6 +1491,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44490',
         },
         {
+          id: '181381',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -1382,6 +1509,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181430',
           code: 'PRISONER USED KEY',
           active: true,
           label: 'PRISONER USED KEY',
@@ -1390,6 +1518,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44675',
         },
         {
+          id: '181431',
           code: 'SLIPPED RESTRAINT',
           active: true,
           label: 'SLIPPED RESTRAINT',
@@ -1398,6 +1527,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44673',
         },
         {
+          id: '181435',
           code: 'PICKED LOCK',
           active: true,
           label: 'PICKED LOCK',
@@ -1406,6 +1536,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181436',
           code: 'STAFF UNLOCKED UNDER THREAT',
           active: true,
           label: 'STAFF UNLOCKED UNDER THREAT',
@@ -1414,6 +1545,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181432',
           code: 'IMPROPER APPLICATION',
           active: true,
           label: 'IMPROPER APPLICATION',
@@ -1422,6 +1554,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181434',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1430,6 +1563,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44443',
         },
         {
+          id: '181433',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1447,6 +1581,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181526',
           code: 'OTHER SHARP INSTRUMENT',
           active: true,
           label: 'OTHER SHARP INSTRUMENT',
@@ -1455,6 +1590,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44605',
         },
         {
+          id: '181520',
           code: 'BLUNT INSTRUMENT',
           active: true,
           label: 'BLUNT INSTRUMENT',
@@ -1463,6 +1599,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44605',
         },
         {
+          id: '181524',
           code: 'LIGATURE',
           active: true,
           label: 'LIGATURE',
@@ -1471,6 +1608,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44605',
         },
         {
+          id: '181521',
           code: 'DANGEROUS LIQUID',
           active: true,
           label: 'DANGEROUS LIQUID',
@@ -1479,6 +1617,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44605',
         },
         {
+          id: '181522',
           code: 'EXCRETA/URINE',
           active: true,
           label: 'EXCRETA/URINE',
@@ -1487,6 +1626,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44605',
         },
         {
+          id: '181527',
           code: 'SPITTING',
           active: true,
           label: 'SPITTING',
@@ -1495,6 +1635,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44605',
         },
         {
+          id: '181523',
           code: 'FOOD',
           active: true,
           label: 'FOOD',
@@ -1503,6 +1644,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44605',
         },
         {
+          id: '181529',
           code: 'THROWN FURNITURE',
           active: true,
           label: 'THROWN FURNITURE',
@@ -1511,6 +1653,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44605',
         },
         {
+          id: '181528',
           code: 'THROWN EQUIPMENT',
           active: true,
           label: 'THROWN EQUIPMENT',
@@ -1519,6 +1662,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44605',
         },
         {
+          id: '181525',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1536,6 +1680,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181588',
           code: 'C.N (CHLORACETOPHEONE)',
           active: true,
           label: 'C.N (CHLORACETOPHEONE)',
@@ -1544,6 +1689,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44715',
         },
         {
+          id: '181589',
           code: 'C.S (ORTHO..NITRILE)',
           active: true,
           label: 'C.S (ORTHO..NITRILE)',
@@ -1552,6 +1698,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44715',
         },
         {
+          id: '181591',
           code: 'O.C (MACE/PEPPER)',
           active: true,
           label: 'O.C (MACE/PEPPER)',
@@ -1560,6 +1707,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44715',
         },
         {
+          id: '181592',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1568,6 +1716,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44715',
         },
         {
+          id: '181590',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -1585,6 +1734,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181611',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1593,6 +1743,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45025',
         },
         {
+          id: '181612',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1610,6 +1761,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181724',
           code: 'OFFICER',
           active: true,
           label: 'OFFICER',
@@ -1618,6 +1770,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44859',
         },
         {
+          id: '181723',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -1635,6 +1788,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181837',
           code: 'HANDCUFFS',
           active: true,
           label: 'HANDCUFFS',
@@ -1643,6 +1797,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45149',
         },
         {
+          id: '181839',
           code: 'ESCORT CHAIN',
           active: true,
           label: 'ESCORT CHAIN',
@@ -1651,6 +1806,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44211',
         },
         {
+          id: '181838',
           code: 'CLOSETING CHAIN',
           active: true,
           label: 'CLOSETING CHAIN',
@@ -1659,6 +1815,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44211',
         },
         {
+          id: '181840',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1676,6 +1833,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181856',
           code: 'MURDER/ATTEMPTED MURDER',
           active: true,
           label: 'MURDER/ATTEMPTED MURDER',
@@ -1684,6 +1842,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181855',
           code: 'MANSLAUGHTER',
           active: true,
           label: 'MANSLAUGHTER',
@@ -1692,6 +1851,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181852',
           code: 'ASSAULT',
           active: true,
           label: 'ASSAULT',
@@ -1700,6 +1860,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181860',
           code: 'RAPE/ATTEMPTED RAPE',
           active: true,
           label: 'RAPE/ATTEMPTED RAPE',
@@ -1708,6 +1869,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181858',
           code: 'OTHER SEXUAL OFFENCE',
           active: true,
           label: 'OTHER SEXUAL OFFENCE',
@@ -1716,6 +1878,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181862',
           code: 'THEFT',
           active: true,
           label: 'THEFT',
@@ -1724,6 +1887,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181861',
           code: 'ROBBERY',
           active: true,
           label: 'ROBBERY',
@@ -1732,6 +1896,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181854',
           code: 'FIREARM OFFENCE',
           active: true,
           label: 'FIREARM OFFENCE',
@@ -1740,6 +1905,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181853',
           code: 'DRUG OFFENCE',
           active: true,
           label: 'DRUG OFFENCE',
@@ -1748,6 +1914,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181863',
           code: 'VEHICLE CRIME',
           active: true,
           label: 'VEHICLE CRIME',
@@ -1756,6 +1923,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181859',
           code: 'PUBLIC ORDER OFFENCE',
           active: true,
           label: 'PUBLIC ORDER OFFENCE',
@@ -1764,6 +1932,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45145',
         },
         {
+          id: '181857',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1781,6 +1950,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181891',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1789,6 +1959,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44360',
         },
         {
+          id: '181890',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1806,6 +1977,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181944',
           code: 'PRISONER WHO ESCAPED',
           active: true,
           label: 'PRISONER WHO ESCAPED',
@@ -1814,6 +1986,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45104',
         },
         {
+          id: '181942',
           code: 'OTHER PRISONER',
           active: true,
           label: 'OTHER PRISONER',
@@ -1822,6 +1995,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45104',
         },
         {
+          id: '181943',
           code: 'OUTSIDE ACCOMPLICE',
           active: true,
           label: 'OUTSIDE ACCOMPLICE',
@@ -1839,6 +2013,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181953',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1847,6 +2022,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44215',
         },
         {
+          id: '181954',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1864,6 +2040,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182034',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1872,6 +2049,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44538',
         },
         {
+          id: '182035',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1889,6 +2067,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182037',
           code: 'POLICE ARREST',
           active: true,
           label: 'POLICE ARREST',
@@ -1897,6 +2076,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44298',
         },
         {
+          id: '182038',
           code: 'PRISON STAFF ARREST',
           active: true,
           label: 'PRISON STAFF ARREST',
@@ -1905,6 +2085,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44298',
         },
         {
+          id: '182039',
           code: 'SURRENDER',
           active: true,
           label: 'SURRENDER',
@@ -1913,6 +2094,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44298',
         },
         {
+          id: '182036',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1930,6 +2112,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182057',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -1938,6 +2121,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182059',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -1946,6 +2130,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182060',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -1954,6 +2139,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182054',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -1962,6 +2148,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182056',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -1970,6 +2157,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182051',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -1978,6 +2166,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182052',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -1986,6 +2175,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182053',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -1994,6 +2184,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182055',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -2002,6 +2193,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182050',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -2010,6 +2202,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182058',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -2018,6 +2211,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44539',
         },
         {
+          id: '182061',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -2035,6 +2229,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182094',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -2043,6 +2238,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182096',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -2051,6 +2247,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182097',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -2059,6 +2256,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182091',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -2067,6 +2265,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182093',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -2075,6 +2274,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182088',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -2083,6 +2283,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182089',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -2091,6 +2292,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182090',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -2099,6 +2301,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182092',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -2107,6 +2310,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182087',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -2115,6 +2319,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182095',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -2123,6 +2328,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44519',
         },
         {
+          id: '182098',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -2140,6 +2346,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182248',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2148,6 +2355,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44828',
         },
         {
+          id: '182247',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2165,6 +2373,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182253',
           code: 'PURPOSE MADE',
           active: true,
           label: 'PURPOSE MADE',
@@ -2173,6 +2382,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44754',
         },
         {
+          id: '182251',
           code: 'IMPROVISED',
           active: true,
           label: 'IMPROVISED',
@@ -2181,6 +2391,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44754',
         },
         {
+          id: '182252',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2198,6 +2409,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182257',
           code: 'MALE',
           active: true,
           label: 'MALE',
@@ -2206,6 +2418,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45157',
         },
         {
+          id: '182256',
           code: 'FEMALE',
           active: true,
           label: 'FEMALE',
@@ -2223,6 +2436,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182283',
           code: 'SECRETED ON THE PRISONER',
           active: true,
           label: 'SECRETED ON THE PRISONER',
@@ -2231,6 +2445,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44845',
         },
         {
+          id: '182281',
           code: 'FOUND IN VEHICLE/AREA',
           active: true,
           label: 'FOUND IN VEHICLE/AREA',
@@ -2239,6 +2454,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44845',
         },
         {
+          id: '182280',
           code: 'BROUGHT BY ACCOMPLICE',
           active: true,
           label: 'BROUGHT BY ACCOMPLICE',
@@ -2247,6 +2463,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44845',
         },
         {
+          id: '182282',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2264,6 +2481,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182302',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2272,6 +2490,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45110',
         },
         {
+          id: '182301',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2289,6 +2508,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182365',
           code: 'SECRETED ON THE PRISONER',
           active: true,
           label: 'SECRETED ON THE PRISONER',
@@ -2297,6 +2517,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44521',
         },
         {
+          id: '182363',
           code: 'FOUND IN VEHICLE/AREA',
           active: true,
           label: 'FOUND IN VEHICLE/AREA',
@@ -2305,6 +2526,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44521',
         },
         {
+          id: '182362',
           code: 'BROUGHT BY ACCOMPLICE',
           active: true,
           label: 'BROUGHT BY ACCOMPLICE',
@@ -2313,6 +2535,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44521',
         },
         {
+          id: '182364',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -2330,6 +2553,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182377',
           code: 'PUBLIC SECTOR',
           active: true,
           label: 'PUBLIC SECTOR',
@@ -2338,6 +2562,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44490',
         },
         {
+          id: '182376',
           code: 'PRIVATE SECTOR',
           active: true,
           label: 'PRIVATE SECTOR',
@@ -2355,6 +2580,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182389',
           code: 'VEHICLE EN ROUTE TO VENUE',
           active: true,
           label: 'VEHICLE EN ROUTE TO VENUE',
@@ -2363,6 +2589,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44188',
         },
         {
+          id: '182388',
           code: 'VEHICLE EN ROUTE FROM VENUE',
           active: true,
           label: 'VEHICLE EN ROUTE FROM VENUE',
@@ -2371,6 +2598,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44188',
         },
         {
+          id: '182387',
           code: 'LEAVING VEHICLE (DEBUSSING)',
           active: true,
           label: 'LEAVING VEHICLE (DEBUSSING)',
@@ -2379,6 +2607,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44188',
         },
         {
+          id: '182386',
           code: 'ENTERING VEHICLE (EMBUSSING)',
           active: true,
           label: 'ENTERING VEHICLE (EMBUSSING)',
@@ -2387,6 +2616,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44188',
         },
         {
+          id: '182398',
           code: 'UNSCHEDULED STOP',
           active: true,
           label: 'UNSCHEDULED STOP',
@@ -2395,6 +2625,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '182390',
           code: 'CELL AT COURT',
           active: true,
           label: 'CELL AT COURT',
@@ -2403,6 +2634,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '182391',
           code: 'COURT CELLS AREA',
           active: true,
           label: 'COURT CELLS AREA',
@@ -2411,6 +2643,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '182393',
           code: 'COURT VISITS AREA',
           active: true,
           label: 'COURT VISITS AREA',
@@ -2419,6 +2652,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '182392',
           code: 'COURT DOCK',
           active: true,
           label: 'COURT DOCK',
@@ -2427,6 +2661,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '182396',
           code: 'HOSPITAL WARD/ROOM',
           active: true,
           label: 'HOSPITAL WARD/ROOM',
@@ -2435,6 +2670,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '182394',
           code: 'HOSPITAL TREATMENT ROOM',
           active: true,
           label: 'HOSPITAL TREATMENT ROOM',
@@ -2443,6 +2679,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '182395',
           code: 'HOSPITAL WAITING AREA',
           active: true,
           label: 'HOSPITAL WAITING AREA',
@@ -2451,6 +2688,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44448',
         },
         {
+          id: '182397',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -2468,6 +2706,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182421',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2476,6 +2715,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45035',
         },
         {
+          id: '182422',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2493,6 +2733,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182512',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2501,6 +2742,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44246',
         },
         {
+          id: '182513',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2518,6 +2760,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182546',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2526,6 +2769,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44696',
         },
         {
+          id: '182545',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2543,6 +2787,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182556',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2551,6 +2796,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44930',
         },
         {
+          id: '182555',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2568,6 +2814,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182559',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2576,6 +2823,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45070',
         },
         {
+          id: '182560',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2593,6 +2841,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182571',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -2601,6 +2850,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45024',
         },
         {
+          id: '182572',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -2609,6 +2859,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45024',
         },
         {
+          id: '182575',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -2617,6 +2868,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45024',
         },
         {
+          id: '182574',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -2625,6 +2877,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45024',
         },
         {
+          id: '182573',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -2642,6 +2895,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182589',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2650,6 +2904,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '44419',
         },
         {
+          id: '182588',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2667,6 +2922,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182590',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2675,6 +2931,7 @@ const ESCAPE_FROM_ESCORT: IncidentTypeConfiguration = {
           nextQuestionId: '45030',
         },
         {
+          id: '182591',
           code: 'NO',
           active: true,
           label: 'NO',

--- a/server/reportConfiguration/types/FINDS.ts
+++ b/server/reportConfiguration/types/FINDS.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:05.467Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:31.729Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '218684',
           code: 'AMNESTY',
           active: true,
           label: 'AMNESTY',
@@ -23,6 +24,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218685',
           code: 'ARCHWAY METAL DETECTOR (amd)',
           active: true,
           label: 'ARCHWAY METAL DETECTOR (amd)',
@@ -31,6 +33,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218686',
           code: 'BOSS CHAIR',
           active: true,
           label: 'BOSS CHAIR',
@@ -39,6 +42,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218687',
           code: 'CELL SEARCH',
           active: true,
           label: 'CELL SEARCH',
@@ -47,6 +51,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218688',
           code: 'DOG SEARCH',
           active: true,
           label: 'DOG SEARCH',
@@ -55,6 +60,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218689',
           code: 'DRONE RECOVERY',
           active: true,
           label: 'DRONE RECOVERY',
@@ -63,6 +69,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218690',
           code: 'DRUG TRACE DETECTION MACHINE',
           active: true,
           label: 'DRUG TRACE DETECTION MACHINE',
@@ -71,6 +78,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218691',
           code: 'GATE SEARCH - ENHANCED GATE SECURITY (EGS)',
           active: true,
           label: 'GATE SEARCH - ENHANCED GATE SECURITY (EGS)',
@@ -79,6 +87,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218692',
           code: 'GATE SEARCH - FRONT END SEARCH (FES), HIGH SECURITY ONLY (HSE)',
           active: true,
           label: 'GATE SEARCH - FRONT END SEARCH (FES), HIGH SECURITY ONLY (HSE)',
@@ -87,6 +96,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218693',
           code: 'GATE SEARCH - OTHER',
           active: true,
           label: 'GATE SEARCH - OTHER',
@@ -95,6 +105,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218694',
           code: 'HANDHELD METAL DETECTOR (HMD) WAND',
           active: true,
           label: 'HANDHELD METAL DETECTOR (HMD) WAND',
@@ -103,6 +114,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218695',
           code: 'INFORMATION RECEIVED',
           active: true,
           label: 'INFORMATION RECEIVED',
@@ -111,6 +123,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218696',
           code: 'INTELLIGENCE LED SEARCH',
           active: true,
           label: 'INTELLIGENCE LED SEARCH',
@@ -119,6 +132,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218697',
           code: 'ITEM HANDED OVER',
           active: true,
           label: 'ITEM HANDED OVER',
@@ -127,6 +141,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218698',
           code: 'ITEM OBSERVED & RECOVERED',
           active: true,
           label: 'ITEM OBSERVED & RECOVERED',
@@ -135,6 +150,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218699',
           code: 'MOBILE PHONE SIGNAL DETECTOR',
           active: true,
           label: 'MOBILE PHONE SIGNAL DETECTOR',
@@ -143,6 +159,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218700',
           code: 'PHONE DETECTION POLE',
           active: true,
           label: 'PHONE DETECTION POLE',
@@ -151,6 +168,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218701',
           code: 'PRE-OCCUPATION SEARCH',
           active: true,
           label: 'PRE-OCCUPATION SEARCH',
@@ -159,6 +177,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218702',
           code: 'UNUSUAL BEHAVIOUR',
           active: true,
           label: 'UNUSUAL BEHAVIOUR',
@@ -167,6 +186,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218703',
           code: 'X-RAY BAGGAGE SCANNER',
           active: true,
           label: 'X-RAY BAGGAGE SCANNER',
@@ -175,6 +195,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218704',
           code: 'X-RAY BODY SCANNER',
           active: true,
           label: 'X-RAY BODY SCANNER',
@@ -183,6 +204,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218705',
           code: 'OTHER SEARCH (PRISONER)',
           active: true,
           label: 'OTHER SEARCH (PRISONER)',
@@ -191,6 +213,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218706',
           code: 'OTHER SEARCH (PREMISES)',
           active: true,
           label: 'OTHER SEARCH (PREMISES)',
@@ -199,6 +222,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218707',
           code: 'OTHER SEARCH (STAFF)',
           active: true,
           label: 'OTHER SEARCH (STAFF)',
@@ -207,6 +231,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218708',
           code: 'OTHER SEARCH (VISITOR)',
           active: true,
           label: 'OTHER SEARCH (VISITOR)',
@@ -215,6 +240,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67180',
         },
         {
+          id: '218709',
           code: 'OTHER - (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER - (PLEASE SPECIFY)',
@@ -232,6 +258,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218710',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -240,6 +267,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218711',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -257,6 +285,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218712',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -265,6 +294,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218713',
           code: 'ASSOCIATION AREA (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'ASSOCIATION AREA (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -273,6 +303,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218714',
           code: 'CELL - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'CELL - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -281,6 +312,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218715',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -289,6 +321,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218716',
           code: 'COURT',
           active: true,
           label: 'COURT',
@@ -297,6 +330,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218717',
           code: 'DINING ROOM - (PLEASE STATE LOCATION DETAILS IN COMMENTS)',
           active: true,
           label: 'DINING ROOM - (PLEASE STATE LOCATION DETAILS IN COMMENTS)',
@@ -305,6 +339,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218718',
           code: 'DORMITORY - (PLEASE STATE LOCATION DETAILS IN COMMENTS)',
           active: true,
           label: 'DORMITORY - (PLEASE STATE LOCATION DETAILS IN COMMENTS)',
@@ -313,6 +348,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218719',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -321,6 +357,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218720',
           code: 'EXERCISE YARD - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'EXERCISE YARD - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -329,6 +366,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218721',
           code: 'GATE/GATE LODGE',
           active: true,
           label: 'GATE/GATE LODGE',
@@ -337,6 +375,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218722',
           code: 'GYM',
           active: true,
           label: 'GYM',
@@ -345,6 +384,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218723',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -353,6 +393,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218724',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: true,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -361,6 +402,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218725',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: true,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -369,6 +411,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218726',
           code: 'INDUCTION/FIRST NIGHT CENTRE',
           active: true,
           label: 'INDUCTION/FIRST NIGHT CENTRE',
@@ -377,6 +420,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218727',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -385,6 +429,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218728',
           code: 'MAIL ROOM',
           active: true,
           label: 'MAIL ROOM',
@@ -393,6 +438,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218729',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -401,6 +447,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218730',
           code: 'OUTSIDE WORKING PARTY',
           active: true,
           label: 'OUTSIDE WORKING PARTY',
@@ -409,6 +456,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218731',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -417,6 +465,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218732',
           code: 'RECESS/ ROOF VOID',
           active: true,
           label: 'RECESS/ ROOF VOID',
@@ -425,6 +474,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218733',
           code: 'SEGREGATION UNIT - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'SEGREGATION UNIT - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -433,6 +483,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218734',
           code: 'SHOWERS/CHANGING ROOM (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'SHOWERS/CHANGING ROOM (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -441,6 +492,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218735',
           code: 'VEHICLE USED FOR COURT/TRANSFER',
           active: true,
           label: 'VEHICLE USED FOR COURT/TRANSFER',
@@ -449,6 +501,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218736',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -457,6 +510,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218737',
           code: 'VULNERABLE PRISONERS UNIT (VPU) - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'VULNERABLE PRISONERS UNIT (VPU) - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -465,6 +519,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218738',
           code: 'WING - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'WING - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -473,6 +528,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218739',
           code: 'WORKSHOP - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'WORKSHOP - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -481,6 +537,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67182',
         },
         {
+          id: '218740',
           code: 'OTHER - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'OTHER - (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -498,6 +555,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218741',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -506,6 +564,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218742',
           code: 'CONTRACTOR',
           active: true,
           label: 'CONTRACTOR',
@@ -514,6 +573,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218743',
           code: 'DRONE/UAV',
           active: true,
           label: 'DRONE/UAV',
@@ -522,6 +582,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218744',
           code: 'POST - RULE 39 (CHECK RULE 39 MAIL, BARCODED)',
           active: true,
           label: 'POST - RULE 39 (CHECK RULE 39 MAIL, BARCODED)',
@@ -530,6 +591,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67183',
         },
         {
+          id: '218745',
           code: 'POST - RULE 39 (NOT CHECK RULE 39 MAIL, NO BARCODE)',
           active: true,
           label: 'POST - RULE 39 (NOT CHECK RULE 39 MAIL, NO BARCODE)',
@@ -538,6 +600,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218746',
           code: 'POST - OTHER',
           active: true,
           label: 'POST - OTHER',
@@ -546,6 +609,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218747',
           code: 'PRISONER',
           active: true,
           label: 'PRISONER',
@@ -554,6 +618,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218748',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -562,6 +627,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218749',
           code: 'THROWN IN',
           active: true,
           label: 'THROWN IN',
@@ -570,6 +636,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218750',
           code: 'VISITOR - DOMESTIC',
           active: true,
           label: 'VISITOR - DOMESTIC',
@@ -578,6 +645,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218751',
           code: 'VISITOR - SOCIAL',
           active: true,
           label: 'VISITOR - SOCIAL',
@@ -586,6 +654,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218752',
           code: 'VISITOR - OTHER (PLEASE ENTER COMMENT TO EXPLAIN)',
           active: true,
           label: 'VISITOR - OTHER (PLEASE ENTER COMMENT TO EXPLAIN)',
@@ -594,6 +663,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218753',
           code: 'OTHER - (PLEASE ENTER COMMENT TO EXPLAIN)',
           active: true,
           label: 'OTHER - (PLEASE ENTER COMMENT TO EXPLAIN)',
@@ -611,6 +681,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218754',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -619,6 +690,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67184',
         },
         {
+          id: '218755',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -636,6 +708,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218756',
           code: 'NOT APPLICABLE',
           active: true,
           label: 'NOT APPLICABLE',
@@ -644,6 +717,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67186',
         },
         {
+          id: '218757',
           code: 'CONTRACTOR',
           active: true,
           label: 'CONTRACTOR',
@@ -652,6 +726,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67185',
         },
         {
+          id: '218758',
           code: 'PRISONER',
           active: true,
           label: 'PRISONER',
@@ -660,6 +735,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67185',
         },
         {
+          id: '218759',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -668,6 +744,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67185',
         },
         {
+          id: '218760',
           code: 'VISITOR - DOMESTIC',
           active: true,
           label: 'VISITOR - DOMESTIC',
@@ -676,6 +753,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67185',
         },
         {
+          id: '218761',
           code: 'VISITOR - SOCIAL',
           active: true,
           label: 'VISITOR - SOCIAL',
@@ -684,6 +762,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67185',
         },
         {
+          id: '218762',
           code: 'VISITOR - OTHER (PLEASE ENTER COMMENT TO EXPLAIN)',
           active: true,
           label: 'VISITOR - OTHER (PLEASE ENTER COMMENT TO EXPLAIN)',
@@ -692,6 +771,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67185',
         },
         {
+          id: '218763',
           code: 'OTHER - (PLEASE SPECIFY IN COMMENTS)',
           active: true,
           label: 'OTHER - (PLEASE SPECIFY IN COMMENTS)',
@@ -709,6 +789,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218764',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -717,6 +798,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67186',
         },
         {
+          id: '218765',
           code: 'YES (e.g. ITEM RETURN TO STAFF AT END OF SHIFT/VISIT)',
           active: true,
           label: 'YES (e.g. ITEM RETURN TO STAFF AT END OF SHIFT/VISIT)',
@@ -725,6 +807,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67186',
         },
         {
+          id: '218766',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -742,6 +825,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '218767',
           code: 'NOT CONCEALED',
           active: true,
           label: 'NOT CONCEALED',
@@ -750,6 +834,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218768',
           code: 'BED/BEDDING',
           active: true,
           label: 'BED/BEDDING',
@@ -758,6 +843,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218769',
           code: 'BOOK/PAPERS',
           active: true,
           label: 'BOOK/PAPERS',
@@ -766,6 +852,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218770',
           code: 'CELL/BUILDING FABRIC',
           active: true,
           label: 'CELL/BUILDING FABRIC',
@@ -774,6 +861,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218771',
           code: 'FOOD/CONTAINER',
           active: true,
           label: 'FOOD/CONTAINER',
@@ -782,6 +870,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218772',
           code: 'IN BAG (i.e. BACKPACK/BRIEFCASE/HANDBAG)',
           active: true,
           label: 'IN BAG (i.e. BACKPACK/BRIEFCASE/HANDBAG)',
@@ -790,6 +879,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218773',
           code: 'IN CLOTHING',
           active: true,
           label: 'IN CLOTHING',
@@ -798,6 +888,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218774',
           code: 'IN HAND',
           active: true,
           label: 'IN HAND',
@@ -806,6 +897,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218775',
           code: 'IN MOUTH',
           active: true,
           label: 'IN MOUTH',
@@ -814,6 +906,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218776',
           code: 'INTERNALLY CONCEALED',
           active: true,
           label: 'INTERNALLY CONCEALED',
@@ -822,6 +915,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218777',
           code: 'LETTER/PARCEL',
           active: true,
           label: 'LETTER/PARCEL',
@@ -830,6 +924,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218778',
           code: 'LIGHT FITTINGS',
           active: true,
           label: 'LIGHT FITTINGS',
@@ -838,6 +933,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218779',
           code: 'PIPEWORK',
           active: true,
           label: 'PIPEWORK',
@@ -846,6 +942,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218780',
           code: 'RULE 39/LEGAL PAPERS',
           active: true,
           label: 'RULE 39/LEGAL PAPERS',
@@ -854,6 +951,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218781',
           code: 'TV/RADIO/DVD/CONSOLES ETC',
           active: true,
           label: 'TV/RADIO/DVD/CONSOLES ETC',
@@ -862,6 +960,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67187',
         },
         {
+          id: '218782',
           code: 'OTHER - (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER - (PLEASE SPECIFY)',
@@ -879,6 +978,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218783',
           code: 'MULTIPLE TYPES (SEE FULL BELOW LIST BEFORE SELECTING)',
           active: true,
           label: 'MULTIPLE TYPES (SEE FULL BELOW LIST BEFORE SELECTING)',
@@ -887,6 +987,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67205',
         },
         {
+          id: '218784',
           code: 'ALCOHOL / HOOCH / DISTILLING EQUIPMENT',
           active: true,
           label: 'ALCOHOL / HOOCH / DISTILLING EQUIPMENT',
@@ -895,6 +996,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67188',
         },
         {
+          id: '218785',
           code: 'DRUG / DRUG EQUIPMENT',
           active: true,
           label: 'DRUG / DRUG EQUIPMENT',
@@ -903,6 +1005,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67190',
         },
         {
+          id: '218786',
           code: 'MOBILE PHONE / MOBILE RELATED ITEM',
           active: true,
           label: 'MOBILE PHONE / MOBILE RELATED ITEM',
@@ -911,6 +1014,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67194',
         },
         {
+          id: '218787',
           code: 'DIGITAL FIND (EXCLUDING  MOBILE PHONES)',
           active: true,
           label: 'DIGITAL FIND (EXCLUDING  MOBILE PHONES)',
@@ -919,6 +1023,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67200',
         },
         {
+          id: '218788',
           code: 'TOBACCO / TOBACCO RELATED ITEMS',
           active: true,
           label: 'TOBACCO / TOBACCO RELATED ITEMS',
@@ -927,6 +1032,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67201',
         },
         {
+          id: '218789',
           code: 'WEAPON',
           active: true,
           label: 'WEAPON',
@@ -935,6 +1041,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67203',
         },
         {
+          id: '218790',
           code: 'OTHER REPORTABLE ITEMS (BY NATIONAL OR LOCAL POLICY)',
           active: true,
           label: 'OTHER REPORTABLE ITEMS (BY NATIONAL OR LOCAL POLICY)',
@@ -952,6 +1059,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218791',
           code: 'NIL',
           active: true,
           label: 'NIL',
@@ -960,6 +1068,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67189',
         },
         {
+          id: '218792',
           code: 'LESS THAN 1 LITRE - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'LESS THAN 1 LITRE - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -968,6 +1077,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67189',
         },
         {
+          id: '218793',
           code: '1 LITRE TO LESS THAN 2 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '1 LITRE TO LESS THAN 2 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -976,6 +1086,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67189',
         },
         {
+          id: '218794',
           code: '2 LITRES TO LESS THAN 3 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '2 LITRES TO LESS THAN 3 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -984,6 +1095,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67189',
         },
         {
+          id: '218795',
           code: '3 LITRES TO LESS THAN 4 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '3 LITRES TO LESS THAN 4 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -992,6 +1104,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67189',
         },
         {
+          id: '218796',
           code: '4 LITRES TO LESS THAN 5 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '4 LITRES TO LESS THAN 5 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -1000,6 +1113,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67189',
         },
         {
+          id: '218797',
           code: '5 LITRES TO LESS THAN 10 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '5 LITRES TO LESS THAN 10 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -1008,6 +1122,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67189',
         },
         {
+          id: '218798',
           code: '10 LITRES TO LESS THAN 20 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '10 LITRES TO LESS THAN 20 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -1016,6 +1131,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67189',
         },
         {
+          id: '218799',
           code: '20 LITRES OR MORE - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '20 LITRES OR MORE - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -1033,6 +1149,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218800',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1041,6 +1158,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218801',
           code: 'YES - (PLEASE SPECIFY IN COMMENTS)',
           active: true,
           label: 'YES - (PLEASE SPECIFY IN COMMENTS)',
@@ -1058,6 +1176,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '218802',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1066,6 +1185,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218803',
           code: 'NONE FOUND',
           active: true,
           label: 'NONE FOUND',
@@ -1074,6 +1194,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218804',
           code: 'AMPHETAMINES',
           active: true,
           label: 'AMPHETAMINES',
@@ -1082,6 +1203,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218805',
           code: 'BARBITURATES',
           active: true,
           label: 'BARBITURATES',
@@ -1090,6 +1212,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218806',
           code: 'BENZODIAZEPINES',
           active: true,
           label: 'BENZODIAZEPINES',
@@ -1098,6 +1221,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218807',
           code: 'BUPRENORPHINE/SUBUTEX',
           active: true,
           label: 'BUPRENORPHINE/SUBUTEX',
@@ -1106,6 +1230,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218808',
           code: 'CANNABIS',
           active: true,
           label: 'CANNABIS',
@@ -1114,6 +1239,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218809',
           code: 'CANNABIS PLANT',
           active: true,
           label: 'CANNABIS PLANT',
@@ -1122,6 +1248,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218810',
           code: 'COCAINE',
           active: true,
           label: 'COCAINE',
@@ -1130,6 +1257,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218811',
           code: 'CRACK',
           active: true,
           label: 'CRACK',
@@ -1138,6 +1266,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218812',
           code: 'GABAPENTIN',
           active: true,
           label: 'GABAPENTIN',
@@ -1146,6 +1275,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218813',
           code: 'HEROIN',
           active: true,
           label: 'HEROIN',
@@ -1154,6 +1284,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218814',
           code: 'KETAMINE',
           active: true,
           label: 'KETAMINE',
@@ -1162,6 +1293,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218815',
           code: 'LSD',
           active: true,
           label: 'LSD',
@@ -1170,6 +1302,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218816',
           code: 'METHADONE',
           active: true,
           label: 'METHADONE',
@@ -1178,6 +1311,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218817',
           code: 'NPS (NEW PSYCHOACTIVE SUBSTANCES)',
           active: true,
           label: 'NPS (NEW PSYCHOACTIVE SUBSTANCES)',
@@ -1186,6 +1320,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218818',
           code: 'PREGABALIN',
           active: true,
           label: 'PREGABALIN',
@@ -1194,6 +1329,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218819',
           code: 'STEROIDS',
           active: true,
           label: 'STEROIDS',
@@ -1202,6 +1338,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218820',
           code: 'TRAMADOL',
           active: true,
           label: 'TRAMADOL',
@@ -1210,6 +1347,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218821',
           code: 'TRANQUILISERS',
           active: true,
           label: 'TRANQUILISERS',
@@ -1218,6 +1356,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67191',
         },
         {
+          id: '218822',
           code: 'OTHER - (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER - (PLEASE SPECIFY)',
@@ -1235,6 +1374,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218823',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1243,6 +1383,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218824',
           code: 'LESS THAN OR EQUAL TO 1G',
           active: true,
           label: 'LESS THAN OR EQUAL TO 1G',
@@ -1251,6 +1392,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218825',
           code: '2G TO 5G',
           active: true,
           label: '2G TO 5G',
@@ -1259,6 +1401,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218826',
           code: '6G TO 10G',
           active: true,
           label: '6G TO 10G',
@@ -1267,6 +1410,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218827',
           code: '11G TO 20G',
           active: true,
           label: '11G TO 20G',
@@ -1275,6 +1419,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218828',
           code: '21G TO 30G',
           active: true,
           label: '21G TO 30G',
@@ -1283,6 +1428,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218829',
           code: '31G TO 40G',
           active: true,
           label: '31G TO 40G',
@@ -1291,6 +1437,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218830',
           code: '41G TO 50G',
           active: true,
           label: '41G TO 50G',
@@ -1299,6 +1446,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218831',
           code: '50G TO 100G',
           active: true,
           label: '50G TO 100G',
@@ -1307,6 +1455,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218832',
           code: '101G TO 200G',
           active: true,
           label: '101G TO 200G',
@@ -1315,6 +1464,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218833',
           code: '201G TO 300G',
           active: true,
           label: '201G TO 300G',
@@ -1323,6 +1473,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218834',
           code: '301G TO 400G',
           active: true,
           label: '301G TO 400G',
@@ -1331,6 +1482,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218835',
           code: '401G TO 500G',
           active: true,
           label: '401G TO 500G',
@@ -1339,6 +1491,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218836',
           code: '501G TO 1000G',
           active: true,
           label: '501G TO 1000G',
@@ -1347,6 +1500,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67192',
         },
         {
+          id: '218837',
           code: 'MORE THAN 1KG',
           active: true,
           label: 'MORE THAN 1KG',
@@ -1364,6 +1518,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218838',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1372,6 +1527,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67193',
         },
         {
+          id: '218839',
           code: 'YES - FORENSIC LABORATORY',
           active: true,
           label: 'YES - FORENSIC LABORATORY',
@@ -1380,6 +1536,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67193',
         },
         {
+          id: '218840',
           code: 'YES - LOCAL WITH BDH KIT OR SIMILAR',
           active: true,
           label: 'YES - LOCAL WITH BDH KIT OR SIMILAR',
@@ -1397,6 +1554,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '218841',
           code: 'NONE FOUND',
           active: true,
           label: 'NONE FOUND',
@@ -1405,6 +1563,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218842',
           code: 'AUTHENTIC NEEDLE',
           active: true,
           label: 'AUTHENTIC NEEDLE',
@@ -1413,6 +1572,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218843',
           code: 'AUTHENTIC SYRINGE',
           active: true,
           label: 'AUTHENTIC SYRINGE',
@@ -1421,6 +1581,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218844',
           code: 'IMPROVISED NEEDLE',
           active: true,
           label: 'IMPROVISED NEEDLE',
@@ -1429,6 +1590,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218845',
           code: 'IMPROVISED SYRINGE',
           active: true,
           label: 'IMPROVISED SYRINGE',
@@ -1437,6 +1599,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218846',
           code: 'PIPE(S)',
           active: true,
           label: 'PIPE(S)',
@@ -1445,6 +1608,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218847',
           code: 'ROACH',
           active: true,
           label: 'ROACH',
@@ -1453,6 +1617,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218848',
           code: 'OTHER - (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER - (PLEASE SPECIFY)',
@@ -1470,6 +1635,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218849',
           code: 'NO MOBILE PHONE FOUND',
           active: true,
           label: 'NO MOBILE PHONE FOUND',
@@ -1478,6 +1644,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218850',
           code: '1',
           active: true,
           label: '1',
@@ -1486,6 +1653,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218851',
           code: '2',
           active: true,
           label: '2',
@@ -1494,6 +1662,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218852',
           code: '3',
           active: true,
           label: '3',
@@ -1502,6 +1671,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218853',
           code: '4',
           active: true,
           label: '4',
@@ -1510,6 +1680,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218854',
           code: '5',
           active: true,
           label: '5',
@@ -1518,6 +1689,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218855',
           code: '6',
           active: true,
           label: '6',
@@ -1526,6 +1698,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218856',
           code: '7',
           active: true,
           label: '7',
@@ -1534,6 +1707,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218857',
           code: '8',
           active: true,
           label: '8',
@@ -1542,6 +1716,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218858',
           code: '9',
           active: true,
           label: '9',
@@ -1550,6 +1725,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218859',
           code: '10',
           active: true,
           label: '10',
@@ -1558,6 +1734,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218860',
           code: '11',
           active: true,
           label: '11',
@@ -1566,6 +1743,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218861',
           code: '12',
           active: true,
           label: '12',
@@ -1574,6 +1752,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218862',
           code: '13',
           active: true,
           label: '13',
@@ -1582,6 +1761,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218863',
           code: '14',
           active: true,
           label: '14',
@@ -1590,6 +1770,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218864',
           code: '15',
           active: true,
           label: '15',
@@ -1598,6 +1779,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218865',
           code: '16',
           active: true,
           label: '16',
@@ -1606,6 +1788,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218866',
           code: '17',
           active: true,
           label: '17',
@@ -1614,6 +1797,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218867',
           code: '18',
           active: true,
           label: '18',
@@ -1622,6 +1806,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218868',
           code: '19',
           active: true,
           label: '19',
@@ -1630,6 +1815,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218869',
           code: '20',
           active: true,
           label: '20',
@@ -1638,6 +1824,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218870',
           code: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
@@ -1646,6 +1833,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67195',
         },
         {
+          id: '218871',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1663,6 +1851,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218872',
           code: 'NO SIM CARDS FOUND',
           active: true,
           label: 'NO SIM CARDS FOUND',
@@ -1671,6 +1860,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218873',
           code: '1',
           active: true,
           label: '1',
@@ -1679,6 +1869,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218874',
           code: '2',
           active: true,
           label: '2',
@@ -1687,6 +1878,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218875',
           code: '3',
           active: true,
           label: '3',
@@ -1695,6 +1887,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218876',
           code: '4',
           active: true,
           label: '4',
@@ -1703,6 +1896,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218877',
           code: '5',
           active: true,
           label: '5',
@@ -1711,6 +1905,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218878',
           code: '6',
           active: true,
           label: '6',
@@ -1719,6 +1914,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218879',
           code: '7',
           active: true,
           label: '7',
@@ -1727,6 +1923,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218880',
           code: '8',
           active: true,
           label: '8',
@@ -1735,6 +1932,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218881',
           code: '9',
           active: true,
           label: '9',
@@ -1743,6 +1941,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218882',
           code: '10',
           active: true,
           label: '10',
@@ -1751,6 +1950,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218883',
           code: '11',
           active: true,
           label: '11',
@@ -1759,6 +1959,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218884',
           code: '12',
           active: true,
           label: '12',
@@ -1767,6 +1968,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218885',
           code: '13',
           active: true,
           label: '13',
@@ -1775,6 +1977,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218886',
           code: '14',
           active: true,
           label: '14',
@@ -1783,6 +1986,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218887',
           code: '15',
           active: true,
           label: '15',
@@ -1791,6 +1995,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218888',
           code: '16',
           active: true,
           label: '16',
@@ -1799,6 +2004,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218889',
           code: '17',
           active: true,
           label: '17',
@@ -1807,6 +2013,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218890',
           code: '18',
           active: true,
           label: '18',
@@ -1815,6 +2022,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218891',
           code: '19',
           active: true,
           label: '19',
@@ -1823,6 +2031,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218892',
           code: '20',
           active: true,
           label: '20',
@@ -1831,6 +2040,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218893',
           code: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
@@ -1839,6 +2049,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67196',
         },
         {
+          id: '218894',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1856,6 +2067,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218895',
           code: 'NO MEMORY CARD FOUND',
           active: true,
           label: 'NO MEMORY CARD FOUND',
@@ -1864,6 +2076,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218896',
           code: '1',
           active: true,
           label: '1',
@@ -1872,6 +2085,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218897',
           code: '2',
           active: true,
           label: '2',
@@ -1880,6 +2094,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218898',
           code: '3',
           active: true,
           label: '3',
@@ -1888,6 +2103,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218899',
           code: '4',
           active: true,
           label: '4',
@@ -1896,6 +2112,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218900',
           code: '5',
           active: true,
           label: '5',
@@ -1904,6 +2121,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218901',
           code: '6',
           active: true,
           label: '6',
@@ -1912,6 +2130,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218902',
           code: '7',
           active: true,
           label: '7',
@@ -1920,6 +2139,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218903',
           code: '8',
           active: true,
           label: '8',
@@ -1928,6 +2148,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218904',
           code: '9',
           active: true,
           label: '9',
@@ -1936,6 +2157,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218905',
           code: '10',
           active: true,
           label: '10',
@@ -1944,6 +2166,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218906',
           code: '11',
           active: true,
           label: '11',
@@ -1952,6 +2175,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218907',
           code: '12',
           active: true,
           label: '12',
@@ -1960,6 +2184,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218908',
           code: '13',
           active: true,
           label: '13',
@@ -1968,6 +2193,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218909',
           code: '14',
           active: true,
           label: '14',
@@ -1976,6 +2202,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218910',
           code: '15',
           active: true,
           label: '15',
@@ -1984,6 +2211,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218911',
           code: '16',
           active: true,
           label: '16',
@@ -1992,6 +2220,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218912',
           code: '17',
           active: true,
           label: '17',
@@ -2000,6 +2229,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218913',
           code: '18',
           active: true,
           label: '18',
@@ -2008,6 +2238,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218914',
           code: '19',
           active: true,
           label: '19',
@@ -2016,6 +2247,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218915',
           code: '20',
           active: true,
           label: '20',
@@ -2024,6 +2256,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218916',
           code: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
@@ -2032,6 +2265,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67197',
         },
         {
+          id: '218917',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2049,6 +2283,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218918',
           code: 'NO - (ENTER REASON IN COMMENT)',
           active: true,
           label: 'NO - (ENTER REASON IN COMMENT)',
@@ -2057,6 +2292,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67198',
         },
         {
+          id: '218919',
           code: 'YES - ENTER DATE AND COMMENT WITH BAG NUMBER)',
           active: true,
           label: 'YES - ENTER DATE AND COMMENT WITH BAG NUMBER)',
@@ -2074,6 +2310,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218920',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2082,6 +2319,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67199',
         },
         {
+          id: '218921',
           code: 'YES - HOMEMADE/ADAPTED',
           active: true,
           label: 'YES - HOMEMADE/ADAPTED',
@@ -2090,6 +2328,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67199',
         },
         {
+          id: '218922',
           code: 'YES - FACTORY MADE/MANUFACTURED',
           active: true,
           label: 'YES - FACTORY MADE/MANUFACTURED',
@@ -2107,6 +2346,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218923',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2115,6 +2355,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218924',
           code: 'YES - (SPECIFY IN COMMENTS)',
           active: true,
           label: 'YES - (SPECIFY IN COMMENTS)',
@@ -2132,6 +2373,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '218925',
           code: 'DESKTOP',
           active: true,
           label: 'DESKTOP',
@@ -2140,6 +2382,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218926',
           code: 'DVD PLAYER',
           active: true,
           label: 'DVD PLAYER',
@@ -2148,6 +2391,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218927',
           code: 'EXTERNAL STORAGE, E.G. EXTERNAL HARD DRIVE',
           active: true,
           label: 'EXTERNAL STORAGE, E.G. EXTERNAL HARD DRIVE',
@@ -2156,6 +2400,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218928',
           code: 'GAMES CONSOLE',
           active: true,
           label: 'GAMES CONSOLE',
@@ -2164,6 +2409,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218929',
           code: 'LAPTOP',
           active: true,
           label: 'LAPTOP',
@@ -2172,6 +2418,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218930',
           code: 'MEDIA STREAMING DEVICE, E.G. AMAZON FIRE STICK',
           active: true,
           label: 'MEDIA STREAMING DEVICE, E.G. AMAZON FIRE STICK',
@@ -2180,6 +2427,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218931',
           code: 'MOBILE HOT SPOT (MIFI DEVICE)',
           active: true,
           label: 'MOBILE HOT SPOT (MIFI DEVICE)',
@@ -2188,6 +2436,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218932',
           code: 'SMART WATCH',
           active: true,
           label: 'SMART WATCH',
@@ -2196,6 +2445,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218933',
           code: 'STEREO / RADIO',
           active: true,
           label: 'STEREO / RADIO',
@@ -2204,6 +2454,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218934',
           code: 'TABLET, E.G. IPAD',
           active: true,
           label: 'TABLET, E.G. IPAD',
@@ -2212,6 +2463,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218935',
           code: 'USB MEMORY STICK',
           active: true,
           label: 'USB MEMORY STICK',
@@ -2220,6 +2472,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218936',
           code: 'WIRELESS HEADSET . HEADPHONE, E.G. APPLE AIRPODS',
           active: true,
           label: 'WIRELESS HEADSET . HEADPHONE, E.G. APPLE AIRPODS',
@@ -2228,6 +2481,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218937',
           code: 'OTHER - (PLEASE STATE IN COMMENTS)',
           active: true,
           label: 'OTHER - (PLEASE STATE IN COMMENTS)',
@@ -2245,6 +2499,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '218938',
           code: 'CIGARETTES/CIGARS',
           active: true,
           label: 'CIGARETTES/CIGARS',
@@ -2253,6 +2508,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67202',
         },
         {
+          id: '218939',
           code: 'LOOSE TOBACCO',
           active: true,
           label: 'LOOSE TOBACCO',
@@ -2261,6 +2517,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67202',
         },
         {
+          id: '218940',
           code: 'OTHER - INCLUDING PACKAGING AND ROACHES - (PLEASE STATE IN COMMENTS)',
           active: true,
           label: 'OTHER - INCLUDING PACKAGING AND ROACHES - (PLEASE STATE IN COMMENTS)',
@@ -2278,6 +2535,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218941',
           code: 'N/A',
           active: true,
           label: 'N/A',
@@ -2286,6 +2544,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218942',
           code: 'LESS THAN OR EQUAL TO 1G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'LESS THAN OR EQUAL TO 1G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2294,6 +2553,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218943',
           code: '2G TO 5G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '2G TO 5G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2302,6 +2562,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218944',
           code: '6G TO 10G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '6G TO 10G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2310,6 +2571,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218945',
           code: '11G TO 20G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '11G TO 20G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2318,6 +2580,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218946',
           code: 'GREATER THAN 20G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'GREATER THAN 20G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2335,6 +2598,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '218947',
           code: 'YES - BLUNT INSTRUMENT (COSH, ITEM IN SOCK, ETC)',
           active: true,
           label: 'YES - BLUNT INSTRUMENT (COSH, ITEM IN SOCK, ETC)',
@@ -2343,6 +2607,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218948',
           code: 'YES - FIREARM (FAKE GUNS, AMMUNITION, CHEMICAL INCAPACITANT ETC)',
           active: true,
           label: 'YES - FIREARM (FAKE GUNS, AMMUNITION, CHEMICAL INCAPACITANT ETC)',
@@ -2351,6 +2616,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218949',
           code: 'YES - KNIFE/BLADED ARTICLE',
           active: true,
           label: 'YES - KNIFE/BLADED ARTICLE',
@@ -2359,6 +2625,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218950',
           code: 'YES - OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'YES - OTHER (PLEASE SPECIFY)',
@@ -2376,6 +2643,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '218951',
           code: 'YES (NOOSE / LIGATURE)',
           active: true,
           label: 'YES (NOOSE / LIGATURE)',
@@ -2384,6 +2652,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '218952',
           code: 'YES - (PLEASE SPECIFY IN COMMENTS)',
           active: true,
           label: 'YES - (PLEASE SPECIFY IN COMMENTS)',
@@ -2401,6 +2670,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218953',
           code: 'NIL',
           active: true,
           label: 'NIL',
@@ -2409,6 +2679,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67206',
         },
         {
+          id: '218954',
           code: 'LESS THAN 1 LITRE - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'LESS THAN 1 LITRE - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2417,6 +2688,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67206',
         },
         {
+          id: '218955',
           code: '1 LITRE TO LESS THAN 2 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '1 LITRE TO LESS THAN 2 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2425,6 +2697,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67206',
         },
         {
+          id: '218956',
           code: '2 LITRES TO LESS THAN 3 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '2 LITRES TO LESS THAN 3 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2433,6 +2706,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67206',
         },
         {
+          id: '218957',
           code: '3 LITRES TO LESS THAN 4 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '3 LITRES TO LESS THAN 4 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2441,6 +2715,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67206',
         },
         {
+          id: '218958',
           code: '4 LITRES TO LESS THAN 5 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '4 LITRES TO LESS THAN 5 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2449,6 +2724,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67206',
         },
         {
+          id: '218959',
           code: '5 LITRES TO LESS THAN 10 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '5 LITRES TO LESS THAN 10 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2457,6 +2733,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67206',
         },
         {
+          id: '218960',
           code: '10 LITRES TO LESS THAN 20 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '10 LITRES TO LESS THAN 20 LITRES - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2465,6 +2742,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67206',
         },
         {
+          id: '218961',
           code: '20 LITRES OR MORE - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '20 LITRES OR MORE - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2482,6 +2760,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218962',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2490,6 +2769,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67207',
         },
         {
+          id: '218963',
           code: 'YES - (PLEASE SPECIFY)',
           active: true,
           label: 'YES - (PLEASE SPECIFY)',
@@ -2507,6 +2787,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218964',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2515,6 +2796,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67211',
         },
         {
+          id: '218965',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2532,6 +2814,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '218966',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2540,6 +2823,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218967',
           code: 'AMPHETAMINES',
           active: true,
           label: 'AMPHETAMINES',
@@ -2548,6 +2832,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218968',
           code: 'BARBITURATES',
           active: true,
           label: 'BARBITURATES',
@@ -2556,6 +2841,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218969',
           code: 'BENZODIAZEPINES',
           active: true,
           label: 'BENZODIAZEPINES',
@@ -2564,6 +2850,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218970',
           code: 'BUPRENORPHINE/SUBUTEX',
           active: true,
           label: 'BUPRENORPHINE/SUBUTEX',
@@ -2572,6 +2859,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218971',
           code: 'CANNABIS',
           active: true,
           label: 'CANNABIS',
@@ -2580,6 +2868,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218972',
           code: 'CANNABIS PLANT',
           active: true,
           label: 'CANNABIS PLANT',
@@ -2588,6 +2877,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218973',
           code: 'COCAINE',
           active: true,
           label: 'COCAINE',
@@ -2596,6 +2886,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218974',
           code: 'CRACK',
           active: true,
           label: 'CRACK',
@@ -2604,6 +2895,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218975',
           code: 'GABAPENTIN',
           active: true,
           label: 'GABAPENTIN',
@@ -2612,6 +2904,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218976',
           code: 'HEROIN',
           active: true,
           label: 'HEROIN',
@@ -2620,6 +2913,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218977',
           code: 'KETAMINE',
           active: true,
           label: 'KETAMINE',
@@ -2628,6 +2922,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218978',
           code: 'LSD',
           active: true,
           label: 'LSD',
@@ -2636,6 +2931,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218979',
           code: 'METHADONE',
           active: true,
           label: 'METHADONE',
@@ -2644,6 +2940,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218980',
           code: 'NPS (NEW pSYCHOACTIVE SUBSTANCES)',
           active: true,
           label: 'NPS (NEW pSYCHOACTIVE SUBSTANCES)',
@@ -2652,6 +2949,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218981',
           code: 'PREGABLIN',
           active: true,
           label: 'PREGABLIN',
@@ -2660,6 +2958,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218982',
           code: 'STEROIDS',
           active: true,
           label: 'STEROIDS',
@@ -2668,6 +2967,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218983',
           code: 'TRAMADOL',
           active: true,
           label: 'TRAMADOL',
@@ -2676,6 +2976,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218984',
           code: 'TRANQUILISERS',
           active: true,
           label: 'TRANQUILISERS',
@@ -2684,6 +2985,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67209',
         },
         {
+          id: '218985',
           code: 'OTHER - (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER - (PLEASE SPECIFY)',
@@ -2701,6 +3003,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '218986',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2709,6 +3012,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218987',
           code: 'LESS THAN OR EQUAL TO 1G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'LESS THAN OR EQUAL TO 1G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2717,6 +3021,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218988',
           code: '2G TO 5G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '2G TO 5G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2725,6 +3030,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218989',
           code: '6G TO 10G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '6G TO 10G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2733,6 +3039,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218990',
           code: '11G TO 20G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '11G TO 20G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2741,6 +3048,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218991',
           code: '21G TO 30G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '21G TO 30G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2749,6 +3057,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218992',
           code: '31G TO 40G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '31G TO 40G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2757,6 +3066,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218993',
           code: '41G TO 50G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '41G TO 50G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2765,6 +3075,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218994',
           code: '50G TO 100G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '50G TO 100G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2773,6 +3084,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218995',
           code: '101G TO 200G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '101G TO 200G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2781,6 +3093,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218996',
           code: '201G TO 300G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '201G TO 300G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2789,6 +3102,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218997',
           code: '301G TO 400G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '301G TO 400G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2797,6 +3111,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218998',
           code: '401G TO 500G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '401G TO 500G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2805,6 +3120,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '218999',
           code: '501G TO 1,000G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '501G TO 1,000G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2813,6 +3129,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67210',
         },
         {
+          id: '219000',
           code: 'MORE THAN 1KG - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'MORE THAN 1KG - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2830,6 +3147,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219001',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2838,6 +3156,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67211',
         },
         {
+          id: '219002',
           code: 'YES - FORENSIC LABORATORY',
           active: true,
           label: 'YES - FORENSIC LABORATORY',
@@ -2846,6 +3165,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67211',
         },
         {
+          id: '219003',
           code: 'YES - LOCAL WITH BDH KIT OR SIMILAR',
           active: true,
           label: 'YES - LOCAL WITH BDH KIT OR SIMILAR',
@@ -2863,6 +3183,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219004',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2871,6 +3192,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67213',
         },
         {
+          id: '219005',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2888,6 +3210,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '219006',
           code: 'AUTHENTIC NEEDLE',
           active: true,
           label: 'AUTHENTIC NEEDLE',
@@ -2896,6 +3219,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67213',
         },
         {
+          id: '219007',
           code: 'AUTHENTIC SYRINGE',
           active: true,
           label: 'AUTHENTIC SYRINGE',
@@ -2904,6 +3228,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67213',
         },
         {
+          id: '219008',
           code: 'IMPROVISED NEEDLE',
           active: true,
           label: 'IMPROVISED NEEDLE',
@@ -2912,6 +3237,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67213',
         },
         {
+          id: '219009',
           code: 'IMPROVISED SYRINGE',
           active: true,
           label: 'IMPROVISED SYRINGE',
@@ -2920,6 +3246,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67213',
         },
         {
+          id: '219010',
           code: 'PIPE(S)',
           active: true,
           label: 'PIPE(S)',
@@ -2928,6 +3255,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67213',
         },
         {
+          id: '219011',
           code: 'ROACH',
           active: true,
           label: 'ROACH',
@@ -2936,6 +3264,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67214',
         },
         {
+          id: '219012',
           code: 'OTHER - (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER - (PLEASE SPECIFY)',
@@ -2953,6 +3282,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219013',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2961,6 +3291,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67220',
         },
         {
+          id: '219014',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2978,6 +3309,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219015',
           code: 'NO MOBILE PHONE FOUND',
           active: true,
           label: 'NO MOBILE PHONE FOUND',
@@ -2986,6 +3318,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219016',
           code: '1',
           active: true,
           label: '1',
@@ -2994,6 +3327,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219017',
           code: '2',
           active: true,
           label: '2',
@@ -3002,6 +3336,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219018',
           code: '3',
           active: true,
           label: '3',
@@ -3010,6 +3345,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219019',
           code: '4',
           active: true,
           label: '4',
@@ -3018,6 +3354,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219020',
           code: '5',
           active: true,
           label: '5',
@@ -3026,6 +3363,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219021',
           code: '6',
           active: true,
           label: '6',
@@ -3034,6 +3372,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219022',
           code: '7',
           active: true,
           label: '7',
@@ -3042,6 +3381,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219023',
           code: '8',
           active: true,
           label: '8',
@@ -3050,6 +3390,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219024',
           code: '9',
           active: true,
           label: '9',
@@ -3058,6 +3399,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219025',
           code: '10',
           active: true,
           label: '10',
@@ -3066,6 +3408,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219026',
           code: '11',
           active: true,
           label: '11',
@@ -3074,6 +3417,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219027',
           code: '12',
           active: true,
           label: '12',
@@ -3082,6 +3426,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219028',
           code: '13',
           active: true,
           label: '13',
@@ -3090,6 +3435,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219029',
           code: '14',
           active: true,
           label: '14',
@@ -3098,6 +3444,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219030',
           code: '15',
           active: true,
           label: '15',
@@ -3106,6 +3453,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219031',
           code: '16',
           active: true,
           label: '16',
@@ -3114,6 +3462,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219032',
           code: '17',
           active: true,
           label: '17',
@@ -3122,6 +3471,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219033',
           code: '18',
           active: true,
           label: '18',
@@ -3130,6 +3480,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219034',
           code: '19',
           active: true,
           label: '19',
@@ -3138,6 +3489,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219035',
           code: '20',
           active: true,
           label: '20',
@@ -3146,6 +3498,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219036',
           code: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
@@ -3154,6 +3507,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67215',
         },
         {
+          id: '219037',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -3171,6 +3525,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219038',
           code: 'NO SIM CARDS FOUND',
           active: true,
           label: 'NO SIM CARDS FOUND',
@@ -3179,6 +3534,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219039',
           code: '1',
           active: true,
           label: '1',
@@ -3187,6 +3543,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219040',
           code: '2',
           active: true,
           label: '2',
@@ -3195,6 +3552,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219041',
           code: '3',
           active: true,
           label: '3',
@@ -3203,6 +3561,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219042',
           code: '4',
           active: true,
           label: '4',
@@ -3211,6 +3570,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219043',
           code: '5',
           active: true,
           label: '5',
@@ -3219,6 +3579,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219044',
           code: '6',
           active: true,
           label: '6',
@@ -3227,6 +3588,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219045',
           code: '7',
           active: true,
           label: '7',
@@ -3235,6 +3597,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219046',
           code: '8',
           active: true,
           label: '8',
@@ -3243,6 +3606,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219047',
           code: '9',
           active: true,
           label: '9',
@@ -3251,6 +3615,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219048',
           code: '10',
           active: true,
           label: '10',
@@ -3259,6 +3624,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219049',
           code: '11',
           active: true,
           label: '11',
@@ -3267,6 +3633,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219050',
           code: '12',
           active: true,
           label: '12',
@@ -3275,6 +3642,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219051',
           code: '13',
           active: true,
           label: '13',
@@ -3283,6 +3651,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219052',
           code: '14',
           active: true,
           label: '14',
@@ -3291,6 +3660,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219053',
           code: '15',
           active: true,
           label: '15',
@@ -3299,6 +3669,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219054',
           code: '16',
           active: true,
           label: '16',
@@ -3307,6 +3678,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219055',
           code: '17',
           active: true,
           label: '17',
@@ -3315,6 +3687,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219056',
           code: '18',
           active: true,
           label: '18',
@@ -3323,6 +3696,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219057',
           code: '19',
           active: true,
           label: '19',
@@ -3331,6 +3705,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219058',
           code: '20',
           active: true,
           label: '20',
@@ -3339,6 +3714,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219059',
           code: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
@@ -3347,6 +3723,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67216',
         },
         {
+          id: '219060',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -3364,6 +3741,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219061',
           code: 'NO MEMORY CARD FOUND',
           active: true,
           label: 'NO MEMORY CARD FOUND',
@@ -3372,6 +3750,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219062',
           code: '1',
           active: true,
           label: '1',
@@ -3380,6 +3759,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219063',
           code: '2',
           active: true,
           label: '2',
@@ -3388,6 +3768,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219064',
           code: '3',
           active: true,
           label: '3',
@@ -3396,6 +3777,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219065',
           code: '4',
           active: true,
           label: '4',
@@ -3404,6 +3786,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219066',
           code: '5',
           active: true,
           label: '5',
@@ -3412,6 +3795,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219067',
           code: '6',
           active: true,
           label: '6',
@@ -3420,6 +3804,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219068',
           code: '7',
           active: true,
           label: '7',
@@ -3428,6 +3813,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219069',
           code: '8',
           active: true,
           label: '8',
@@ -3436,6 +3822,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219070',
           code: '9',
           active: true,
           label: '9',
@@ -3444,6 +3831,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219071',
           code: '10',
           active: true,
           label: '10',
@@ -3452,6 +3840,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219072',
           code: '11',
           active: true,
           label: '11',
@@ -3460,6 +3849,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219073',
           code: '12',
           active: true,
           label: '12',
@@ -3468,6 +3858,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219074',
           code: '13',
           active: true,
           label: '13',
@@ -3476,6 +3867,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219075',
           code: '14',
           active: true,
           label: '14',
@@ -3484,6 +3876,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219076',
           code: '15',
           active: true,
           label: '15',
@@ -3492,6 +3885,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219077',
           code: '16',
           active: true,
           label: '16',
@@ -3500,6 +3894,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219078',
           code: '17',
           active: true,
           label: '17',
@@ -3508,6 +3903,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219079',
           code: '18',
           active: true,
           label: '18',
@@ -3516,6 +3912,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219080',
           code: '19',
           active: true,
           label: '19',
@@ -3524,6 +3921,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219081',
           code: '20',
           active: true,
           label: '20',
@@ -3532,6 +3930,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219082',
           code: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 - (STATE NUMBER IN COMMENT)',
@@ -3540,6 +3939,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67217',
         },
         {
+          id: '219083',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -3557,6 +3957,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219084',
           code: 'NO - NONE FOUND',
           active: true,
           label: 'NO - NONE FOUND',
@@ -3565,6 +3966,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67218',
         },
         {
+          id: '219085',
           code: 'YES - HOMEMADE/ADAPTED',
           active: true,
           label: 'YES - HOMEMADE/ADAPTED',
@@ -3573,6 +3975,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67218',
         },
         {
+          id: '219086',
           code: 'YES - FACTORY MADE/MANUFACTURED',
           active: true,
           label: 'YES - FACTORY MADE/MANUFACTURED',
@@ -3590,6 +3993,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219087',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3598,6 +4002,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67219',
         },
         {
+          id: '219088',
           code: 'YES - (SPECIFY IN COMMENTS)',
           active: true,
           label: 'YES - (SPECIFY IN COMMENTS)',
@@ -3615,6 +4020,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219089',
           code: 'NO - (ENTER REASON IN COMMENT)',
           active: true,
           label: 'NO - (ENTER REASON IN COMMENT)',
@@ -3623,6 +4029,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67220',
         },
         {
+          id: '219090',
           code: 'YES - (ENTER DATE AND COMMENT WITH BAG NUMBER)',
           active: true,
           label: 'YES - (ENTER DATE AND COMMENT WITH BAG NUMBER)',
@@ -3640,6 +4047,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '219091',
           code: 'NO OTHER DIGITAL FINDS',
           active: true,
           label: 'NO OTHER DIGITAL FINDS',
@@ -3648,6 +4056,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219092',
           code: 'DESKTOP',
           active: true,
           label: 'DESKTOP',
@@ -3656,6 +4065,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219093',
           code: 'DVD PLAYER',
           active: true,
           label: 'DVD PLAYER',
@@ -3664,6 +4074,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219094',
           code: 'EXTERNAL STORAGE, E.G. EXTERNAL HARD DRIVE',
           active: true,
           label: 'EXTERNAL STORAGE, E.G. EXTERNAL HARD DRIVE',
@@ -3672,6 +4083,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219095',
           code: 'GAMES CONSOLE',
           active: true,
           label: 'GAMES CONSOLE',
@@ -3680,6 +4092,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219096',
           code: 'LAPTOP',
           active: true,
           label: 'LAPTOP',
@@ -3688,6 +4101,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219097',
           code: 'MEDIA STREAMING DEVICE, E.G. AMAZON FIRE STICK',
           active: true,
           label: 'MEDIA STREAMING DEVICE, E.G. AMAZON FIRE STICK',
@@ -3696,6 +4110,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219098',
           code: 'MOBILE HOT SPOT (MIFI DEVICE)',
           active: true,
           label: 'MOBILE HOT SPOT (MIFI DEVICE)',
@@ -3704,6 +4119,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219099',
           code: 'SMART WATCH',
           active: true,
           label: 'SMART WATCH',
@@ -3712,6 +4128,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219100',
           code: 'STEREO / RADIO',
           active: true,
           label: 'STEREO / RADIO',
@@ -3720,6 +4137,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219101',
           code: 'TABLET, E.G. IPAD',
           active: true,
           label: 'TABLET, E.G. IPAD',
@@ -3728,6 +4146,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219102',
           code: 'USB MEMORY STICK',
           active: true,
           label: 'USB MEMORY STICK',
@@ -3736,6 +4155,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219103',
           code: 'WIRELESS HEADSET / HEADPHONE, E.G. APPLE AIRPODS',
           active: true,
           label: 'WIRELESS HEADSET / HEADPHONE, E.G. APPLE AIRPODS',
@@ -3744,6 +4164,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67221',
         },
         {
+          id: '219104',
           code: 'OTHER - (PLEASE STATE)',
           active: true,
           label: 'OTHER - (PLEASE STATE)',
@@ -3761,6 +4182,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219105',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3769,6 +4191,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67224',
         },
         {
+          id: '219106',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3786,6 +4209,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '219107',
           code: 'CIGARETTES/CIGARS',
           active: true,
           label: 'CIGARETTES/CIGARS',
@@ -3794,6 +4218,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67223',
         },
         {
+          id: '219108',
           code: 'LOOSE TOBACO',
           active: true,
           label: 'LOOSE TOBACO',
@@ -3802,6 +4227,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67223',
         },
         {
+          id: '219109',
           code: 'OTHER (INCLUDING PACKAGING AND ROACHES)',
           active: true,
           label: 'OTHER (INCLUDING PACKAGING AND ROACHES)',
@@ -3819,6 +4245,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219110',
           code: 'LESS THAN OR EQUAL TO 1G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'LESS THAN OR EQUAL TO 1G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -3827,6 +4254,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67224',
         },
         {
+          id: '219111',
           code: '2G TO 5G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '2G TO 5G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -3835,6 +4263,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67224',
         },
         {
+          id: '219112',
           code: '6G TO 10G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '6G TO 10G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -3843,6 +4272,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67224',
         },
         {
+          id: '219113',
           code: '11G TO 20G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '11G TO 20G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -3851,6 +4281,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67224',
         },
         {
+          id: '219114',
           code: 'GREATER THAN 20G - (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'GREATER THAN 20G - (PLEASE STATE NUMBER IN COMMENTS)',
@@ -3868,6 +4299,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '219115',
           code: 'NO - NONE FOUND',
           active: true,
           label: 'NO - NONE FOUND',
@@ -3876,6 +4308,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67225',
         },
         {
+          id: '219116',
           code: 'YES - BLUNT INSTRUMENT (COSH, ITEM IN SOCK ETC)',
           active: true,
           label: 'YES - BLUNT INSTRUMENT (COSH, ITEM IN SOCK ETC)',
@@ -3884,6 +4317,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67225',
         },
         {
+          id: '219117',
           code: 'YES - FIREARM (FAKE GUNS, AMMUNITION, CHEMICAL INCAPACITANT ETC)',
           active: true,
           label: 'YES - FIREARM (FAKE GUNS, AMMUNITION, CHEMICAL INCAPACITANT ETC)',
@@ -3892,6 +4326,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67225',
         },
         {
+          id: '219118',
           code: 'YES - KNIFE/BLADED ARTICLE',
           active: true,
           label: 'YES - KNIFE/BLADED ARTICLE',
@@ -3900,6 +4335,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67225',
         },
         {
+          id: '219119',
           code: 'YES - OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'YES - OTHER (PLEASE SPECIFY)',
@@ -3917,6 +4353,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '219120',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3925,6 +4362,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '219121',
           code: 'YES (NOOSE / LIGATURE)',
           active: true,
           label: 'YES (NOOSE / LIGATURE)',
@@ -3933,6 +4371,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '67226',
         },
         {
+          id: '219122',
           code: 'YES - (PLEASE SPECIFY IN COMMENTS)',
           active: true,
           label: 'YES - (PLEASE SPECIFY IN COMMENTS)',
@@ -3950,6 +4389,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '219123',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3958,6 +4398,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '219124',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -3966,6 +4407,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '219125',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3983,6 +4425,7 @@ const FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '219126',
           code: 'COMMUNITY VISIT',
           active: true,
           label: 'COMMUNITY VISIT',
@@ -3991,6 +4434,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '219127',
           code: 'COMPASSIONATE',
           active: true,
           label: 'COMPASSIONATE',
@@ -3999,6 +4443,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '219128',
           code: 'FACILITY',
           active: true,
           label: 'FACILITY',
@@ -4007,6 +4452,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '219129',
           code: 'RESETTLEMENT',
           active: true,
           label: 'RESETTLEMENT',
@@ -4015,6 +4461,7 @@ const FINDS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '219130',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',

--- a/server/reportConfiguration/types/FIRE.ts
+++ b/server/reportConfiguration/types/FIRE.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:12.211Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:38.479Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178927',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45084',
         },
         {
+          id: '178926',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179010',
           code: 'NUMBER',
           active: true,
           label: 'NUMBER',
@@ -57,6 +60,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179021',
           code: '5 MINUTES AND LESS',
           active: true,
           label: '5 MINUTES AND LESS',
@@ -65,6 +69,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45064',
         },
         {
+          id: '179020',
           code: '5 - 10 MINUTES',
           active: true,
           label: '5 - 10 MINUTES',
@@ -73,6 +78,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45064',
         },
         {
+          id: '179019',
           code: '10 - 15 MINUTES',
           active: true,
           label: '10 - 15 MINUTES',
@@ -81,6 +87,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45064',
         },
         {
+          id: '179022',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -98,6 +105,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179083',
           code: 'ENTER COMMENT AND DATE',
           active: true,
           label: 'ENTER COMMENT AND DATE',
@@ -115,6 +123,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179092',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -123,6 +132,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44520',
         },
         {
+          id: '179093',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -140,6 +150,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179121',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -148,6 +159,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179122',
           code: 'ASSOCIATION AREA',
           active: true,
           label: 'ASSOCIATION AREA',
@@ -156,6 +168,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179123',
           code: 'CELL',
           active: true,
           label: 'CELL',
@@ -164,6 +177,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179124',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -172,6 +186,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179126',
           code: 'DINING ROOM',
           active: true,
           label: 'DINING ROOM',
@@ -180,6 +195,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179127',
           code: 'DORMITORY',
           active: true,
           label: 'DORMITORY',
@@ -188,6 +204,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179128',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -196,6 +213,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179130',
           code: 'EXERCISE YARD',
           active: true,
           label: 'EXERCISE YARD',
@@ -204,6 +222,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179132',
           code: 'GATE',
           active: true,
           label: 'GATE',
@@ -212,6 +231,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179133',
           code: 'GYM',
           active: true,
           label: 'GYM',
@@ -220,6 +240,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179134',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -228,6 +249,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179137',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -236,6 +258,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179139',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -244,6 +267,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179141',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -252,6 +276,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179142',
           code: 'RECESS',
           active: true,
           label: 'RECESS',
@@ -260,6 +285,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179143',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -268,6 +294,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179145',
           code: 'SPECIAL UNIT',
           active: true,
           label: 'SPECIAL UNIT',
@@ -276,6 +303,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179144',
           code: 'SHOWERS/CHANGING ROOM',
           active: true,
           label: 'SHOWERS/CHANGING ROOM',
@@ -284,6 +312,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179148',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -292,6 +321,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179150',
           code: 'WING',
           active: true,
           label: 'WING',
@@ -300,6 +330,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179152',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -308,6 +339,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179153',
           code: 'WORKSHOP',
           active: true,
           label: 'WORKSHOP',
@@ -316,6 +348,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179151',
           code: 'WITHIN PERIMETER',
           active: true,
           label: 'WITHIN PERIMETER',
@@ -324,6 +357,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179129',
           code: 'ELSEWHERE',
           active: true,
           label: 'ELSEWHERE',
@@ -332,6 +366,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179131',
           code: 'FUNERAL',
           active: true,
           label: 'FUNERAL',
@@ -340,6 +375,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179135',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: true,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -348,6 +384,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179136',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: true,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -356,6 +393,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179140',
           code: 'OUTSIDE WORKING PARTY',
           active: true,
           label: 'OUTSIDE WORKING PARTY',
@@ -364,6 +402,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179146',
           code: 'SPORTS FIELD',
           active: true,
           label: 'SPORTS FIELD',
@@ -372,6 +411,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179147',
           code: 'VEHICLE',
           active: true,
           label: 'VEHICLE',
@@ -380,6 +420,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179149',
           code: 'WEDDINGS',
           active: true,
           label: 'WEDDINGS',
@@ -388,6 +429,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179138',
           code: 'MAGISTRATES COURT',
           active: true,
           label: 'MAGISTRATES COURT',
@@ -396,6 +438,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44732',
         },
         {
+          id: '179125',
           code: 'CROWN COURT',
           active: true,
           label: 'CROWN COURT',
@@ -413,6 +456,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179169',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -421,6 +465,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44131',
         },
         {
+          id: '179170',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -438,6 +483,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179263',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -446,6 +492,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44314',
         },
         {
+          id: '179262',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -463,6 +510,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179355',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -471,6 +519,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45058',
         },
         {
+          id: '179354',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -488,6 +537,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179364',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -496,6 +546,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44342',
         },
         {
+          id: '179363',
           code: 'PRISONER',
           active: true,
           label: 'PRISONER',
@@ -504,6 +555,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44342',
         },
         {
+          id: '179362',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -521,6 +573,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179381',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -529,6 +582,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44194',
         },
         {
+          id: '179382',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -546,6 +600,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179412',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -554,6 +609,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45069',
         },
         {
+          id: '179411',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -571,6 +627,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179539',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -579,6 +636,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44287',
         },
         {
+          id: '179538',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -596,6 +654,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179653',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -604,6 +663,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44454',
         },
         {
+          id: '179654',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -621,6 +681,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179697',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: true,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -638,6 +699,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179879',
           code: 'DESCRIPTION',
           active: true,
           label: 'DESCRIPTION',
@@ -655,6 +717,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179905',
           code: 'LOCAL',
           active: true,
           label: 'LOCAL',
@@ -663,6 +726,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179906',
           code: 'SERVICE SUPPLIER',
           active: true,
           label: 'SERVICE SUPPLIER',
@@ -680,6 +744,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179997',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -688,6 +753,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45116',
         },
         {
+          id: '179996',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -696,6 +762,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45116',
         },
         {
+          id: '179994',
           code: 'FIRE BRIGADE',
           active: true,
           label: 'FIRE BRIGADE',
@@ -704,6 +771,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45116',
         },
         {
+          id: '179995',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -721,6 +789,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180134',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -729,6 +798,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44865',
         },
         {
+          id: '180135',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -746,6 +816,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180160',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -754,6 +825,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44740',
         },
         {
+          id: '180161',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -771,6 +843,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180188',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -779,6 +852,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44410',
         },
         {
+          id: '180189',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -796,6 +870,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180279',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -804,6 +879,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45055',
         },
         {
+          id: '180278',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -812,6 +888,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45055',
         },
         {
+          id: '180277',
           code: 'OTHERS',
           active: true,
           label: 'OTHERS',
@@ -829,6 +906,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180456',
           code: 'LOCAL',
           active: true,
           label: 'LOCAL',
@@ -837,6 +915,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45084',
         },
         {
+          id: '180455',
           code: 'SERVICE SUPPLIER',
           active: true,
           label: 'SERVICE SUPPLIER',
@@ -854,6 +933,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180478',
           code: 'MALICIOUS IGNITION',
           active: true,
           label: 'MALICIOUS IGNITION',
@@ -862,6 +942,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44895',
         },
         {
+          id: '180477',
           code: 'ELECTRICAL FAULT',
           active: true,
           label: 'ELECTRICAL FAULT',
@@ -870,6 +951,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44895',
         },
         {
+          id: '180481',
           code: 'SMOKING MATERIAL',
           active: true,
           label: 'SMOKING MATERIAL',
@@ -878,6 +960,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44895',
         },
         {
+          id: '180480',
           code: 'OVERHEATING',
           active: true,
           label: 'OVERHEATING',
@@ -886,6 +969,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44895',
         },
         {
+          id: '180479',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -903,6 +987,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180819',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -911,6 +996,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44949',
         },
         {
+          id: '180820',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -928,6 +1014,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180910',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -936,6 +1023,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44813',
         },
         {
+          id: '180911',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -953,6 +1041,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181060',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -961,6 +1050,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44158',
         },
         {
+          id: '181061',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -978,6 +1068,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181082',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -986,6 +1077,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44181',
         },
         {
+          id: '181081',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -994,6 +1086,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44181',
         },
         {
+          id: '181080',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1011,6 +1104,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181084',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1019,6 +1113,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44829',
         },
         {
+          id: '181083',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1036,6 +1131,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181092',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1044,6 +1140,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44556',
         },
         {
+          id: '181093',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1061,6 +1158,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181100',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -1069,6 +1167,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44741',
         },
         {
+          id: '181099',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1077,6 +1176,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44741',
         },
         {
+          id: '181098',
           code: 'OTHERS',
           active: true,
           label: 'OTHERS',
@@ -1094,6 +1194,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181138',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1102,6 +1203,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44837',
         },
         {
+          id: '181139',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1119,6 +1221,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181291',
           code: 'WOOD',
           active: true,
           label: 'WOOD',
@@ -1127,6 +1230,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45017',
         },
         {
+          id: '181290',
           code: 'PAPER',
           active: true,
           label: 'PAPER',
@@ -1135,6 +1239,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45017',
         },
         {
+          id: '181288',
           code: 'OIL',
           active: true,
           label: 'OIL',
@@ -1143,6 +1248,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45017',
         },
         {
+          id: '181287',
           code: 'FLAMMABLE LIQUID',
           active: true,
           label: 'FLAMMABLE LIQUID',
@@ -1151,6 +1257,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45017',
         },
         {
+          id: '181289',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1168,6 +1275,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181323',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1176,6 +1284,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44898',
         },
         {
+          id: '181324',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1193,6 +1302,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181331',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1201,6 +1311,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45046',
         },
         {
+          id: '181332',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1218,6 +1329,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181341',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -1226,6 +1338,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45131',
         },
         {
+          id: '181340',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1234,6 +1347,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45131',
         },
         {
+          id: '181339',
           code: 'OTHERS',
           active: true,
           label: 'OTHERS',
@@ -1251,6 +1365,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181449',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -1259,6 +1374,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44762',
         },
         {
+          id: '181448',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1267,6 +1383,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44762',
         },
         {
+          id: '181447',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1284,6 +1401,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181514',
           code: 'SPRINKLERS',
           active: true,
           label: 'SPRINKLERS',
@@ -1292,6 +1410,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44996',
         },
         {
+          id: '181512',
           code: 'KITCHEN SUPPRESSION SYSTEM',
           active: true,
           label: 'KITCHEN SUPPRESSION SYSTEM',
@@ -1300,6 +1419,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44996',
         },
         {
+          id: '181513',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1317,6 +1437,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181566',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1325,6 +1446,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44264',
         },
         {
+          id: '181565',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1342,6 +1464,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181576',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -1350,6 +1473,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44354',
         },
         {
+          id: '181577',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -1358,6 +1482,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44354',
         },
         {
+          id: '181575',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -1375,6 +1500,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181775',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1383,6 +1509,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44878',
         },
         {
+          id: '181776',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1400,6 +1527,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181785',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1408,6 +1536,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45146',
         },
         {
+          id: '181786',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1425,6 +1554,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181817',
           code: 'ENTER TIME',
           active: true,
           label: 'ENTER TIME',
@@ -1442,6 +1572,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181948',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1450,6 +1581,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44695',
         },
         {
+          id: '181947',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1467,6 +1599,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181957',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -1475,6 +1608,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44833',
         },
         {
+          id: '181956',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1483,6 +1617,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44833',
         },
         {
+          id: '181955',
           code: 'OTHERS',
           active: true,
           label: 'OTHERS',
@@ -1500,6 +1635,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182008',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1508,6 +1644,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45053',
         },
         {
+          id: '182009',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1525,6 +1662,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182042',
           code: 'FULL',
           active: true,
           label: 'FULL',
@@ -1533,6 +1671,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45173',
         },
         {
+          id: '182043',
           code: 'PARTIAL',
           active: true,
           label: 'PARTIAL',
@@ -1550,6 +1689,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182164',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1558,6 +1698,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45085',
         },
         {
+          id: '182165',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1575,6 +1716,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182200',
           code: 'FURNISHINGS',
           active: true,
           label: 'FURNISHINGS',
@@ -1583,6 +1725,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45133',
         },
         {
+          id: '182197',
           code: 'BEDDING',
           active: true,
           label: 'BEDDING',
@@ -1591,6 +1734,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45133',
         },
         {
+          id: '182198',
           code: 'CLOTHING',
           active: true,
           label: 'CLOTHING',
@@ -1599,6 +1743,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45133',
         },
         {
+          id: '182199',
           code: 'EQUIPMENT',
           active: true,
           label: 'EQUIPMENT',
@@ -1607,6 +1752,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45133',
         },
         {
+          id: '182202',
           code: 'RUBBISH/REFUSE',
           active: true,
           label: 'RUBBISH/REFUSE',
@@ -1615,6 +1761,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45133',
         },
         {
+          id: '182203',
           code: 'VEHICLE/PLANT',
           active: true,
           label: 'VEHICLE/PLANT',
@@ -1623,6 +1770,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45133',
         },
         {
+          id: '182201',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1640,6 +1788,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182206',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1648,6 +1797,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44747',
         },
         {
+          id: '182207',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1665,6 +1815,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182214',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1673,6 +1824,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44999',
         },
         {
+          id: '182215',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1690,6 +1842,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182241',
           code: 'FIRE ALARM',
           active: true,
           label: 'FIRE ALARM',
@@ -1698,6 +1851,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44268',
         },
         {
+          id: '182244',
           code: 'TELEPHONE',
           active: true,
           label: 'TELEPHONE',
@@ -1706,6 +1860,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44268',
         },
         {
+          id: '182243',
           code: 'RADIO',
           active: true,
           label: 'RADIO',
@@ -1714,6 +1869,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44268',
         },
         {
+          id: '182240',
           code: 'AUTOMATIC FIRE ALARM',
           active: true,
           label: 'AUTOMATIC FIRE ALARM',
@@ -1722,6 +1878,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44268',
         },
         {
+          id: '182242',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1739,6 +1896,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182255',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1747,6 +1905,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44272',
         },
         {
+          id: '182254',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1764,6 +1923,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182291',
           code: 'TELEPHONY',
           active: true,
           label: 'TELEPHONY',
@@ -1772,6 +1932,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44957',
         },
         {
+          id: '182290',
           code: 'IT',
           active: true,
           label: 'IT',
@@ -1789,6 +1950,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182294',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -1797,6 +1959,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44478',
         },
         {
+          id: '182293',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1805,6 +1968,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44478',
         },
         {
+          id: '182292',
           code: 'OTHERS',
           active: true,
           label: 'OTHERS',
@@ -1822,6 +1986,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182318',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -1830,6 +1995,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44486',
         },
         {
+          id: '182317',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -1838,6 +2004,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44486',
         },
         {
+          id: '182316',
           code: 'OTHERS',
           active: true,
           label: 'OTHERS',
@@ -1855,6 +2022,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182418',
           code: 'WATER EXTINGUISHER',
           active: true,
           label: 'WATER EXTINGUISHER',
@@ -1863,6 +2031,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44945',
         },
         {
+          id: '182415',
           code: 'FOAM EXTINGUISHERS',
           active: true,
           label: 'FOAM EXTINGUISHERS',
@@ -1871,6 +2040,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44945',
         },
         {
+          id: '182413',
           code: 'DRY POWDER EXTINGUISHER',
           active: true,
           label: 'DRY POWDER EXTINGUISHER',
@@ -1879,6 +2049,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44945',
         },
         {
+          id: '182410',
           code: 'AFFF EXTINGUISHER',
           active: true,
           label: 'AFFF EXTINGUISHER',
@@ -1887,6 +2058,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44945',
         },
         {
+          id: '182416',
           code: 'HOSE REEL',
           active: true,
           label: 'HOSE REEL',
@@ -1895,6 +2067,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44945',
         },
         {
+          id: '182414',
           code: 'FIRE BLANKET',
           active: true,
           label: 'FIRE BLANKET',
@@ -1903,6 +2076,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44945',
         },
         {
+          id: '182411',
           code: 'CELL SPRAY NOZZLE',
           active: true,
           label: 'CELL SPRAY NOZZLE',
@@ -1911,6 +2085,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44945',
         },
         {
+          id: '182412',
           code: 'CO2 EXTINGUISHER',
           active: true,
           label: 'CO2 EXTINGUISHER',
@@ -1919,6 +2094,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44945',
         },
         {
+          id: '182417',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1936,6 +2112,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182469',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1944,6 +2121,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '45091',
         },
         {
+          id: '182470',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1961,6 +2139,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182473',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1969,6 +2148,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44567',
         },
         {
+          id: '182474',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1986,6 +2166,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182548',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1994,6 +2175,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44232',
         },
         {
+          id: '182547',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2011,6 +2193,7 @@ const FIRE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182639',
           code: 'GOVERNOR',
           active: true,
           label: 'GOVERNOR',
@@ -2019,6 +2202,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44493',
         },
         {
+          id: '182637',
           code: 'DEPUTY GOVERNOR',
           active: true,
           label: 'DEPUTY GOVERNOR',
@@ -2027,6 +2211,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44493',
         },
         {
+          id: '182638',
           code: 'DUTY GOVERNOR',
           active: true,
           label: 'DUTY GOVERNOR',
@@ -2035,6 +2220,7 @@ const FIRE: IncidentTypeConfiguration = {
           nextQuestionId: '44493',
         },
         {
+          id: '182640',
           code: 'OTHER',
           active: true,
           label: 'OTHER',

--- a/server/reportConfiguration/types/FOOD_REFUSAL.ts
+++ b/server/reportConfiguration/types/FOOD_REFUSAL.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:13.755Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:40.098Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179164',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44427',
         },
         {
+          id: '179163',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179556',
           code: 'NORMAL LOCATION',
           active: true,
           label: 'NORMAL LOCATION',
@@ -48,6 +51,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44399',
         },
         {
+          id: '179559',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -56,6 +60,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44399',
         },
         {
+          id: '179555',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -64,6 +69,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44399',
         },
         {
+          id: '179558',
           code: 'OUTSIDE HOSPITAL',
           active: true,
           label: 'OUTSIDE HOSPITAL',
@@ -72,6 +78,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44399',
         },
         {
+          id: '179557',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -89,6 +96,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179841',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -97,6 +105,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44688',
         },
         {
+          id: '179840',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -114,6 +123,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179913',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -122,6 +132,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179912',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -139,6 +150,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180503',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -147,6 +159,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44887',
         },
         {
+          id: '180502',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -164,6 +177,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180875',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -172,6 +186,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44989',
         },
         {
+          id: '180874',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -189,6 +204,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181149',
           code: 'ALL FOOD AND LIQUIDS',
           active: true,
           label: 'ALL FOOD AND LIQUIDS',
@@ -197,6 +213,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44319',
         },
         {
+          id: '181151',
           code: 'FOOD ONLY',
           active: true,
           label: 'FOOD ONLY',
@@ -205,6 +222,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44319',
         },
         {
+          id: '181150',
           code: 'FLUIDS ONLY',
           active: true,
           label: 'FLUIDS ONLY',
@@ -213,6 +231,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44319',
         },
         {
+          id: '181152',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -230,6 +249,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181539',
           code: 'FACILITIES',
           active: true,
           label: 'FACILITIES',
@@ -238,6 +258,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44768',
         },
         {
+          id: '181540',
           code: 'FOOD',
           active: true,
           label: 'FOOD',
@@ -246,6 +267,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44768',
         },
         {
+          id: '181543',
           code: 'PAY',
           active: true,
           label: 'PAY',
@@ -254,6 +276,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44768',
         },
         {
+          id: '181546',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -262,6 +285,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44768',
         },
         {
+          id: '181544',
           code: 'TIME OUT OF CELL',
           active: true,
           label: 'TIME OUT OF CELL',
@@ -270,6 +294,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44768',
         },
         {
+          id: '181541',
           code: 'LOCATION',
           active: true,
           label: 'LOCATION',
@@ -278,6 +303,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44768',
         },
         {
+          id: '181545',
           code: 'TRANSFER',
           active: true,
           label: 'TRANSFER',
@@ -286,6 +312,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44768',
         },
         {
+          id: '181538',
           code: 'CHARGES/CONVICTIONS',
           active: true,
           label: 'CHARGES/CONVICTIONS',
@@ -294,6 +321,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44768',
         },
         {
+          id: '181542',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -311,6 +339,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181926',
           code: 'ENTER HOURS',
           active: true,
           label: 'ENTER HOURS',
@@ -328,6 +357,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181928',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -336,6 +366,7 @@ const FOOD_REFUSAL: IncidentTypeConfiguration = {
           nextQuestionId: '44575',
         },
         {
+          id: '181927',
           code: 'NO',
           active: true,
           label: 'NO',

--- a/server/reportConfiguration/types/FULL_CLOSE_DOWN_SEARCH.ts
+++ b/server/reportConfiguration/types/FULL_CLOSE_DOWN_SEARCH.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:14.422Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:40.875Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178989',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44677',
         },
         {
+          id: '178988',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179804',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -48,6 +51,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44969',
         },
         {
+          id: '179805',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -65,6 +69,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179926',
           code: 'FIREARM',
           active: true,
           label: 'FIREARM',
@@ -73,6 +78,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44385',
         },
         {
+          id: '179921',
           code: 'AMMUNITION',
           active: true,
           label: 'AMMUNITION',
@@ -81,6 +87,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44385',
         },
         {
+          id: '179922',
           code: 'C.I SPRAY',
           active: true,
           label: 'C.I SPRAY',
@@ -89,6 +96,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44385',
         },
         {
+          id: '179929',
           code: 'OTHER WEAPON',
           active: true,
           label: 'OTHER WEAPON',
@@ -97,6 +105,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44385',
         },
         {
+          id: '179925',
           code: 'EXPLOSIVES',
           active: true,
           label: 'EXPLOSIVES',
@@ -105,6 +114,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44385',
         },
         {
+          id: '179923',
           code: 'DRUGS',
           active: true,
           label: 'DRUGS',
@@ -113,6 +123,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44385',
         },
         {
+          id: '179924',
           code: 'ESCAPE EQUIPMENT',
           active: true,
           label: 'ESCAPE EQUIPMENT',
@@ -121,6 +132,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44385',
         },
         {
+          id: '179927',
           code: 'GATHER EVIDENCE',
           active: true,
           label: 'GATHER EVIDENCE',
@@ -129,6 +141,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44385',
         },
         {
+          id: '179928',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -146,6 +159,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180488',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -154,6 +168,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '180487',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -171,6 +186,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180841',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -179,6 +195,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '45062',
         },
         {
+          id: '180840',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -196,6 +213,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181020',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -204,6 +222,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '45018',
         },
         {
+          id: '181019',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -221,6 +240,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181265',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -229,6 +249,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44570',
         },
         {
+          id: '181264',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -246,6 +267,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181851',
           code: 'WEAPONS',
           active: true,
           label: 'WEAPONS',
@@ -254,6 +276,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44803',
         },
         {
+          id: '181847',
           code: 'HOOCH/ALCOHOL',
           active: true,
           label: 'HOOCH/ALCOHOL',
@@ -262,6 +285,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44803',
         },
         {
+          id: '181846',
           code: 'CASH',
           active: true,
           label: 'CASH',
@@ -270,6 +294,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44803',
         },
         {
+          id: '181849',
           code: 'MOBILE PHONE',
           active: true,
           label: 'MOBILE PHONE',
@@ -278,6 +303,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44803',
         },
         {
+          id: '181848',
           code: 'INCENDIARY DEVICE',
           active: true,
           label: 'INCENDIARY DEVICE',
@@ -286,6 +312,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44803',
         },
         {
+          id: '181850',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -303,6 +330,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182011',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -311,6 +339,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44146',
         },
         {
+          id: '182010',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -328,6 +357,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182234',
           code: 'INFORMATION/INTELLIGENCE',
           active: true,
           label: 'INFORMATION/INTELLIGENCE',
@@ -336,6 +366,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44432',
         },
         {
+          id: '182237',
           code: 'SPECIFIC FIND',
           active: true,
           label: 'SPECIFIC FIND',
@@ -344,6 +375,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44432',
         },
         {
+          id: '182233',
           code: 'HEADQUARTERS INSTRUCTIONS',
           active: true,
           label: 'HEADQUARTERS INSTRUCTIONS',
@@ -352,6 +384,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44432',
         },
         {
+          id: '182236',
           code: 'ROUTINE REQUIREMENT',
           active: true,
           label: 'ROUTINE REQUIREMENT',
@@ -360,6 +393,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44432',
         },
         {
+          id: '182235',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -377,6 +411,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182249',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -385,6 +420,7 @@ const FULL_CLOSE_DOWN_SEARCH: IncidentTypeConfiguration = {
           nextQuestionId: '44723',
         },
         {
+          id: '182250',
           code: 'NO',
           active: true,
           label: 'NO',

--- a/server/reportConfiguration/types/KEY_LOCK_INCIDENT.ts
+++ b/server/reportConfiguration/types/KEY_LOCK_INCIDENT.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:15.830Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:42.544Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182748',
           code: 'Keys taken out of the establishment',
           active: false,
           label: 'Keys taken out of the establishment',
@@ -23,6 +24,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182749',
           code: 'Keys lost',
           active: false,
           label: 'Keys lost',
@@ -31,6 +33,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182750',
           code: 'Key left unattended in prison',
           active: false,
           label: 'Key left unattended in prison',
@@ -39,6 +42,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182751',
           code: 'Key issued to wrong person',
           active: false,
           label: 'Key issued to wrong person',
@@ -47,6 +51,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182752',
           code: 'Doors/Gates/Cell door left unlocked',
           active: false,
           label: 'Doors/Gates/Cell door left unlocked',
@@ -55,6 +60,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182753',
           code: 'Loss of handcuffs',
           active: false,
           label: 'Loss of handcuffs',
@@ -63,6 +69,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182754',
           code: 'Loss of escort chain',
           active: false,
           label: 'Loss of escort chain',
@@ -71,6 +78,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182755',
           code: 'Other handcuff key/lock issues',
           active: false,
           label: 'Other handcuff key/lock issues',
@@ -79,6 +87,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182756',
           code: 'Broken/Damaged keys',
           active: false,
           label: 'Broken/Damaged keys',
@@ -87,6 +96,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182757',
           code: 'Worn locks (not malicious)',
           active: false,
           label: 'Worn locks (not malicious)',
@@ -95,6 +105,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182758',
           code: 'Malicious damage to/blockage of locks',
           active: false,
           label: 'Malicious damage to/blockage of locks',
@@ -103,6 +114,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182759',
           code: 'Lock picked',
           active: false,
           label: 'Lock picked',
@@ -111,6 +123,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182760',
           code: 'Part of lock removed',
           active: false,
           label: 'Part of lock removed',
@@ -119,6 +132,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182761',
           code: 'Complete lock removed',
           active: false,
           label: 'Complete lock removed',
@@ -127,6 +141,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182762',
           code: 'Electronics overcome (electronic door)',
           active: false,
           label: 'Electronics overcome (electronic door)',
@@ -135,6 +150,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182763',
           code: 'Electronics failure (electronic door)',
           active: false,
           label: 'Electronics failure (electronic door)',
@@ -143,6 +159,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182764',
           code: 'Replica key found/used',
           active: false,
           label: 'Replica key found/used',
@@ -151,6 +168,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182765',
           code: 'Key viewed by prisoner',
           active: false,
           label: 'Key viewed by prisoner',
@@ -159,6 +177,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182766',
           code: 'Other: (anything else including prisoner grabbing key chain, etc)',
           active: false,
           label: 'Other: (anything else including prisoner grabbing key chain, etc)',
@@ -167,6 +186,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182945',
           code: 'Keys taken out of the establishment',
           active: true,
           label: 'Keys taken out of the establishment',
@@ -175,6 +195,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182946',
           code: 'Keys lost',
           active: true,
           label: 'Keys lost',
@@ -183,6 +204,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182947',
           code: 'Key left unattended in prison',
           active: true,
           label: 'Key left unattended in prison',
@@ -191,6 +213,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182948',
           code: 'Key issued to wrong person',
           active: true,
           label: 'Key issued to wrong person',
@@ -199,6 +222,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182949',
           code: 'Doors/Gates/cell door left unlocked',
           active: true,
           label: 'Doors/Gates/cell door left unlocked',
@@ -207,6 +231,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182950',
           code: 'Loss of handcuffs',
           active: true,
           label: 'Loss of handcuffs',
@@ -215,6 +240,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182951',
           code: 'Loss of escort chain',
           active: true,
           label: 'Loss of escort chain',
@@ -223,6 +249,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182952',
           code: 'Other handcuff key/lock issues',
           active: true,
           label: 'Other handcuff key/lock issues',
@@ -231,6 +258,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182953',
           code: 'Broken/Damaged keys',
           active: true,
           label: 'Broken/Damaged keys',
@@ -239,6 +267,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182954',
           code: 'Worn locks (not malicious)',
           active: true,
           label: 'Worn locks (not malicious)',
@@ -247,6 +276,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182955',
           code: 'Malicious damage to/blockage of locks',
           active: true,
           label: 'Malicious damage to/blockage of locks',
@@ -255,6 +285,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182956',
           code: 'Lock picked',
           active: true,
           label: 'Lock picked',
@@ -263,6 +294,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182957',
           code: 'Part of lock removed',
           active: true,
           label: 'Part of lock removed',
@@ -271,6 +303,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182958',
           code: 'Complete lock removed',
           active: true,
           label: 'Complete lock removed',
@@ -279,6 +312,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182959',
           code: 'Electronics overcome (electronic door)',
           active: true,
           label: 'Electronics overcome (electronic door)',
@@ -287,6 +321,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182960',
           code: 'Electronics failure (electronic door)',
           active: true,
           label: 'Electronics failure (electronic door)',
@@ -295,6 +330,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182961',
           code: 'Replica key found/used',
           active: true,
           label: 'Replica key found/used',
@@ -303,6 +339,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182962',
           code: 'Key viewed by prisoner',
           active: true,
           label: 'Key viewed by prisoner',
@@ -311,6 +348,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45197',
         },
         {
+          id: '182963',
           code: 'Other  (anything else including prisoner grabbing key chain, etc)',
           active: true,
           label: 'Other  (anything else including prisoner grabbing key chain, etc)',
@@ -328,6 +366,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182767',
           code: 'Class 1 pass key',
           active: false,
           label: 'Class 1 pass key',
@@ -336,6 +375,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182768',
           code: 'Class 2 pass key',
           active: false,
           label: 'Class 2 pass key',
@@ -344,6 +384,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182769',
           code: 'Cell key',
           active: false,
           label: 'Cell key',
@@ -352,6 +393,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182770',
           code: 'Class 3 A1 Suite key',
           active: false,
           label: 'Class 3 A1 Suite key',
@@ -360,6 +402,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182771',
           code: 'Class 3 Accountable key',
           active: false,
           label: 'Class 3 Accountable key',
@@ -368,6 +411,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182772',
           code: 'Handcuff key',
           active: false,
           label: 'Handcuff key',
@@ -376,6 +420,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182773',
           code: 'Escort Chain key',
           active: false,
           label: 'Escort Chain key',
@@ -384,6 +429,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182774',
           code: 'Class 1 Lock',
           active: false,
           label: 'Class 1 Lock',
@@ -392,6 +438,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182775',
           code: 'Class 2 Lock',
           active: false,
           label: 'Class 2 Lock',
@@ -400,6 +447,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182776',
           code: 'Cell Lock',
           active: false,
           label: 'Cell Lock',
@@ -408,6 +456,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182777',
           code: 'Class 3 A1 Suite Lock',
           active: false,
           label: 'Class 3 A1 Suite Lock',
@@ -416,6 +465,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182778',
           code: 'Class 3 Accountable Lock',
           active: false,
           label: 'Class 3 Accountable Lock',
@@ -424,6 +474,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182779',
           code: 'Handcuffs',
           active: false,
           label: 'Handcuffs',
@@ -432,6 +483,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182780',
           code: 'Escort chain',
           active: false,
           label: 'Escort chain',
@@ -440,6 +492,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182781',
           code: 'Electronic Lock System',
           active: false,
           label: 'Electronic Lock System',
@@ -448,6 +501,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182782',
           code: 'Magnetic Keys',
           active: false,
           label: 'Magnetic Keys',
@@ -456,6 +510,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182783',
           code: 'Magnetic Lock',
           active: false,
           label: 'Magnetic Lock',
@@ -464,6 +519,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182784',
           code: 'Cell Door',
           active: false,
           label: 'Cell Door',
@@ -472,6 +528,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182785',
           code: 'Brent Keys',
           active: false,
           label: 'Brent Keys',
@@ -480,6 +537,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182786',
           code: 'Other: Specify',
           active: false,
           label: 'Other: Specify',
@@ -488,6 +546,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182964',
           code: 'Class 1 pass key',
           active: true,
           label: 'Class 1 pass key',
@@ -496,6 +555,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182965',
           code: 'Class 2 pass key',
           active: true,
           label: 'Class 2 pass key',
@@ -504,6 +564,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182966',
           code: 'Cell key',
           active: true,
           label: 'Cell key',
@@ -512,6 +573,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182967',
           code: 'Class 3 A1 Suite key',
           active: true,
           label: 'Class 3 A1 Suite key',
@@ -520,6 +582,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182968',
           code: 'Class 3 Accountable key',
           active: true,
           label: 'Class 3 Accountable key',
@@ -528,6 +591,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182969',
           code: 'Handcuff key',
           active: true,
           label: 'Handcuff key',
@@ -536,6 +600,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182970',
           code: 'Escort Chain key',
           active: true,
           label: 'Escort Chain key',
@@ -544,6 +609,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182971',
           code: 'Class 1 Lock',
           active: true,
           label: 'Class 1 Lock',
@@ -552,6 +618,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182972',
           code: 'Class 2 Lock',
           active: true,
           label: 'Class 2 Lock',
@@ -560,6 +627,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182973',
           code: 'Cell Lock',
           active: true,
           label: 'Cell Lock',
@@ -568,6 +636,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182974',
           code: 'Class 3 A1 Suite Lock',
           active: true,
           label: 'Class 3 A1 Suite Lock',
@@ -576,6 +645,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182975',
           code: 'Class 3 Accountable Lock',
           active: true,
           label: 'Class 3 Accountable Lock',
@@ -584,6 +654,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182976',
           code: 'Handcuffs',
           active: true,
           label: 'Handcuffs',
@@ -592,6 +663,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182977',
           code: 'Escort chain',
           active: true,
           label: 'Escort chain',
@@ -600,6 +672,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182978',
           code: 'Electronic Lock System',
           active: true,
           label: 'Electronic Lock System',
@@ -608,6 +681,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182979',
           code: 'Magnetic Keys',
           active: true,
           label: 'Magnetic Keys',
@@ -616,6 +690,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182980',
           code: 'Magnetic Lock',
           active: true,
           label: 'Magnetic Lock',
@@ -624,6 +699,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182981',
           code: 'Cell Door',
           active: true,
           label: 'Cell Door',
@@ -632,6 +708,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182982',
           code: 'Brent Keys',
           active: true,
           label: 'Brent Keys',
@@ -640,6 +717,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45198',
         },
         {
+          id: '182983',
           code: 'Other :  Specify',
           active: true,
           label: 'Other :  Specify',
@@ -657,6 +735,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182787',
           code: 'Enter Value:',
           active: false,
           label: 'Enter Value:',
@@ -665,6 +744,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182984',
           code: 'Enter Value:',
           active: true,
           label: 'Enter Value:',
@@ -682,6 +762,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182788',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -690,6 +771,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182789',
           code: 'No',
           active: false,
           label: 'No',
@@ -698,6 +780,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182985',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -706,6 +789,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45200',
         },
         {
+          id: '182986',
           code: 'No',
           active: false,
           label: 'No',
@@ -714,6 +798,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45200',
         },
         {
+          id: '184687',
           code: 'No',
           active: false,
           label: 'No',
@@ -722,6 +807,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45202',
         },
         {
+          id: '188684',
           code: 'No',
           active: false,
           label: 'No',
@@ -730,6 +816,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45208',
         },
         {
+          id: '190684',
           code: 'No',
           active: true,
           label: 'No',
@@ -747,6 +834,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182790',
           code: 'Complete relock',
           active: false,
           label: 'Complete relock',
@@ -755,6 +843,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182791',
           code: 'Partial relock',
           active: false,
           label: 'Partial relock',
@@ -763,6 +852,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182792',
           code: 'Complete replacement',
           active: false,
           label: 'Complete replacement',
@@ -771,6 +861,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182793',
           code: 'Partial replacement',
           active: false,
           label: 'Partial replacement',
@@ -779,6 +870,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182794',
           code: 'Forensic testing',
           active: false,
           label: 'Forensic testing',
@@ -787,6 +879,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182987',
           code: 'Complete relock',
           active: true,
           label: 'Complete relock',
@@ -795,6 +888,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45201',
         },
         {
+          id: '182988',
           code: 'Partial relock',
           active: true,
           label: 'Partial relock',
@@ -803,6 +897,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45201',
         },
         {
+          id: '182989',
           code: 'Complete replacement',
           active: true,
           label: 'Complete replacement',
@@ -811,6 +906,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45201',
         },
         {
+          id: '182990',
           code: 'Partial replacement',
           active: true,
           label: 'Partial replacement',
@@ -819,6 +915,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45201',
         },
         {
+          id: '182991',
           code: 'Forensic testing',
           active: true,
           label: 'Forensic testing',
@@ -827,6 +924,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45201',
         },
         {
+          id: '188685',
           code: 'Other',
           active: true,
           label: 'Other',
@@ -844,6 +942,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182795',
           code: '£',
           active: false,
           label: '£',
@@ -852,6 +951,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182992',
           code: '£',
           active: true,
           label: '£',
@@ -860,6 +960,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45202',
         },
         {
+          id: '190687',
           code: 'N/A',
           active: true,
           label: 'N/A',
@@ -877,6 +978,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182796',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -885,6 +987,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182797',
           code: 'No',
           active: false,
           label: 'No',
@@ -893,6 +996,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182993',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -901,6 +1005,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45203',
         },
         {
+          id: '182994',
           code: 'No',
           active: true,
           label: 'No',
@@ -909,6 +1014,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45203',
         },
         {
+          id: '190686',
           code: 'N/A',
           active: true,
           label: 'N/A',
@@ -926,6 +1032,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182798',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -934,6 +1041,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182799',
           code: 'No',
           active: false,
           label: 'No',
@@ -942,6 +1050,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182995',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -950,6 +1059,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45204',
         },
         {
+          id: '182996',
           code: 'No',
           active: false,
           label: 'No',
@@ -958,6 +1068,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45204',
         },
         {
+          id: '184688',
           code: 'No',
           active: true,
           label: 'No',
@@ -966,6 +1077,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45205',
         },
         {
+          id: '190688',
           code: 'N/A',
           active: true,
           label: 'N/A',
@@ -983,6 +1095,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182800',
           code: 'Full close down search',
           active: false,
           label: 'Full close down search',
@@ -991,6 +1104,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182801',
           code: 'Partial search',
           active: false,
           label: 'Partial search',
@@ -999,6 +1113,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182802',
           code: 'Other: Specify',
           active: false,
           label: 'Other: Specify',
@@ -1007,6 +1122,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182997',
           code: 'Full close down search',
           active: true,
           label: 'Full close down search',
@@ -1015,6 +1131,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45205',
         },
         {
+          id: '182998',
           code: 'Partial search',
           active: true,
           label: 'Partial search',
@@ -1023,6 +1140,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45205',
         },
         {
+          id: '182999',
           code: 'Other: Please specify',
           active: true,
           label: 'Other: Please specify',
@@ -1040,6 +1158,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182803',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1048,6 +1167,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182804',
           code: 'No',
           active: false,
           label: 'No',
@@ -1056,6 +1176,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183000',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -1064,6 +1185,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45206',
         },
         {
+          id: '183001',
           code: 'No',
           active: false,
           label: 'No',
@@ -1072,6 +1194,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45206',
         },
         {
+          id: '190685',
           code: 'No',
           active: true,
           label: 'No',
@@ -1089,6 +1212,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182805',
           code: 'Hacksaw blade',
           active: false,
           label: 'Hacksaw blade',
@@ -1097,6 +1221,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182806',
           code: 'Other Blade',
           active: false,
           label: 'Other Blade',
@@ -1105,6 +1230,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182807',
           code: 'Wire cutters',
           active: false,
           label: 'Wire cutters',
@@ -1113,6 +1239,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182808',
           code: 'Bolt cutters',
           active: false,
           label: 'Bolt cutters',
@@ -1121,6 +1248,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182809',
           code: 'Digging tool',
           active: false,
           label: 'Digging tool',
@@ -1129,6 +1257,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182810',
           code: 'Crow bar',
           active: false,
           label: 'Crow bar',
@@ -1137,6 +1266,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182811',
           code: 'Improvised tool',
           active: false,
           label: 'Improvised tool',
@@ -1145,6 +1275,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182812',
           code: 'Other: Specify',
           active: false,
           label: 'Other: Specify',
@@ -1153,6 +1284,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182813',
           code: 'Not Known',
           active: false,
           label: 'Not Known',
@@ -1161,6 +1293,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183002',
           code: 'Hacksaw blade',
           active: true,
           label: 'Hacksaw blade',
@@ -1169,6 +1302,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45207',
         },
         {
+          id: '183003',
           code: 'Other blade',
           active: true,
           label: 'Other blade',
@@ -1177,6 +1311,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45207',
         },
         {
+          id: '183004',
           code: 'Wire cutters',
           active: true,
           label: 'Wire cutters',
@@ -1185,6 +1320,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45207',
         },
         {
+          id: '183005',
           code: 'Bolt cutters',
           active: true,
           label: 'Bolt cutters',
@@ -1193,6 +1329,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45207',
         },
         {
+          id: '183006',
           code: 'Digging tool',
           active: true,
           label: 'Digging tool',
@@ -1201,6 +1338,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45207',
         },
         {
+          id: '183007',
           code: 'Crow bar',
           active: true,
           label: 'Crow bar',
@@ -1209,6 +1347,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45207',
         },
         {
+          id: '183008',
           code: 'Improvised tool',
           active: true,
           label: 'Improvised tool',
@@ -1217,6 +1356,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45207',
         },
         {
+          id: '183009',
           code: 'Other: Please specify',
           active: true,
           label: 'Other: Please specify',
@@ -1225,6 +1365,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45207',
         },
         {
+          id: '183010',
           code: 'Not Known',
           active: true,
           label: 'Not Known',
@@ -1242,6 +1383,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182814',
           code: 'Works Department',
           active: false,
           label: 'Works Department',
@@ -1250,6 +1392,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182815',
           code: 'Contractors',
           active: false,
           label: 'Contractors',
@@ -1258,6 +1401,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182816',
           code: 'Education',
           active: false,
           label: 'Education',
@@ -1266,6 +1410,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182817',
           code: 'Heathcare Centre',
           active: false,
           label: 'Heathcare Centre',
@@ -1274,6 +1419,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182818',
           code: 'Farms and Gardens',
           active: false,
           label: 'Farms and Gardens',
@@ -1282,6 +1428,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182819',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -1290,6 +1437,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182820',
           code: 'Visitor',
           active: false,
           label: 'Visitor',
@@ -1298,6 +1446,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182821',
           code: 'Other: Specify',
           active: false,
           label: 'Other: Specify',
@@ -1306,6 +1455,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182822',
           code: 'Not Known',
           active: false,
           label: 'Not Known',
@@ -1314,6 +1464,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183011',
           code: 'Works Department',
           active: true,
           label: 'Works Department',
@@ -1322,6 +1473,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45208',
         },
         {
+          id: '183012',
           code: 'Contractors',
           active: true,
           label: 'Contractors',
@@ -1330,6 +1482,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45208',
         },
         {
+          id: '183013',
           code: 'Education',
           active: true,
           label: 'Education',
@@ -1338,6 +1491,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45208',
         },
         {
+          id: '183014',
           code: 'Health Care Centre',
           active: true,
           label: 'Health Care Centre',
@@ -1346,6 +1500,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45208',
         },
         {
+          id: '183015',
           code: 'Farms and Gardens',
           active: true,
           label: 'Farms and Gardens',
@@ -1354,6 +1509,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45208',
         },
         {
+          id: '183016',
           code: 'Staff',
           active: true,
           label: 'Staff',
@@ -1362,6 +1518,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45208',
         },
         {
+          id: '183017',
           code: 'Visitor',
           active: true,
           label: 'Visitor',
@@ -1370,6 +1527,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45208',
         },
         {
+          id: '183018',
           code: 'Other: Please specify',
           active: true,
           label: 'Other: Please specify',
@@ -1378,6 +1536,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45208',
         },
         {
+          id: '183019',
           code: 'Not Known',
           active: true,
           label: 'Not Known',
@@ -1395,6 +1554,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182823',
           code: 'Yes: Date',
           active: true,
           label: 'Yes: Date',
@@ -1403,6 +1563,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182824',
           code: 'No',
           active: true,
           label: 'No',
@@ -1411,6 +1572,7 @@ const KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182825',
           code: 'Incident Ref No:',
           active: true,
           label: 'Incident Ref No:',

--- a/server/reportConfiguration/types/MISCELLANEOUS.ts
+++ b/server/reportConfiguration/types/MISCELLANEOUS.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:18.248Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:45.018Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178923',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44503',
         },
         {
+          id: '178924',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178931',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -48,6 +51,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45122',
         },
         {
+          id: '178930',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -65,6 +69,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '178981',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -73,6 +78,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44730',
         },
         {
+          id: '178982',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -81,6 +87,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44730',
         },
         {
+          id: '178985',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -89,6 +96,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44730',
         },
         {
+          id: '178984',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -97,6 +105,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44730',
         },
         {
+          id: '178983',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -114,6 +123,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179220',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -122,6 +132,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44133',
         },
         {
+          id: '179219',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -139,6 +150,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179418',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -147,6 +159,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44607',
         },
         {
+          id: '179419',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -164,6 +177,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180003',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -172,6 +186,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44667',
         },
         {
+          id: '180004',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -189,6 +204,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180236',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -197,6 +213,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44588',
         },
         {
+          id: '180235',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -205,6 +222,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44588',
         },
         {
+          id: '180232',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -213,6 +231,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44588',
         },
         {
+          id: '180234',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -221,6 +240,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44588',
         },
         {
+          id: '180233',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -238,6 +258,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180412',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -246,6 +267,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44601',
         },
         {
+          id: '180411',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -263,6 +285,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180544',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -271,6 +294,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44541',
         },
         {
+          id: '180543',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -288,6 +312,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180557',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -296,6 +321,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44995',
         },
         {
+          id: '180556',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -313,6 +339,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180604',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -321,6 +348,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45159',
         },
         {
+          id: '180605',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -338,6 +366,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180620',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -346,6 +375,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44223',
         },
         {
+          id: '180621',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -363,6 +393,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180815',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -371,6 +402,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45161',
         },
         {
+          id: '180816',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -379,6 +411,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45161',
         },
         {
+          id: '180817',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -387,6 +420,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45161',
         },
         {
+          id: '180812',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -395,6 +429,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45161',
         },
         {
+          id: '180814',
           code: 'EXTENSIVE OR MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE OR MULTIPLE BRUISING',
@@ -403,6 +438,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45161',
         },
         {
+          id: '180809',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -411,6 +447,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45161',
         },
         {
+          id: '180810',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -419,6 +456,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45161',
         },
         {
+          id: '180811',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -427,6 +465,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45161',
         },
         {
+          id: '180813',
           code: 'CUTS REQUIRING SUTURING',
           active: true,
           label: 'CUTS REQUIRING SUTURING',
@@ -435,6 +474,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45161',
         },
         {
+          id: '180808',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -443,6 +483,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45161',
         },
         {
+          id: '180818',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -460,6 +501,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181057',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -468,6 +510,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44129',
         },
         {
+          id: '181056',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -476,6 +519,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44129',
         },
         {
+          id: '181053',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -484,6 +528,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44129',
         },
         {
+          id: '181055',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -492,6 +537,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44129',
         },
         {
+          id: '181054',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -509,6 +555,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181416',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -517,6 +564,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44456',
         },
         {
+          id: '181417',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -534,6 +582,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181946',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -542,6 +591,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44857',
         },
         {
+          id: '181945',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -559,6 +609,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182370',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: true,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -576,6 +627,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182445',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -584,6 +636,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45139',
         },
         {
+          id: '182444',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -601,6 +654,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182454',
           code: 'MINOR',
           active: true,
           label: 'MINOR',
@@ -609,6 +663,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45106',
         },
         {
+          id: '182455',
           code: 'SERIOUS',
           active: true,
           label: 'SERIOUS',
@@ -617,6 +672,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45106',
         },
         {
+          id: '182453',
           code: 'EXTENSIVE',
           active: true,
           label: 'EXTENSIVE',
@@ -634,6 +690,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182523',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -642,6 +699,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44591',
         },
         {
+          id: '182522',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -659,6 +717,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182596',
           code: 'FURNITURE',
           active: true,
           label: 'FURNITURE',
@@ -667,6 +726,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45125',
         },
         {
+          id: '182595',
           code: 'FITTINGS',
           active: true,
           label: 'FITTINGS',
@@ -675,6 +735,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45125',
         },
         {
+          id: '182597',
           code: 'MACHINERY',
           active: true,
           label: 'MACHINERY',
@@ -683,6 +744,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45125',
         },
         {
+          id: '182594',
           code: 'EQUIPMENT',
           active: true,
           label: 'EQUIPMENT',
@@ -691,6 +753,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '45125',
         },
         {
+          id: '182598',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -708,6 +771,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182601',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -716,6 +780,7 @@ const MISCELLANEOUS: IncidentTypeConfiguration = {
           nextQuestionId: '44144',
         },
         {
+          id: '182602',
           code: 'NO',
           active: true,
           label: 'NO',

--- a/server/reportConfiguration/types/OLD_ASSAULT.ts
+++ b/server/reportConfiguration/types/OLD_ASSAULT.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:41.645Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:08.927Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178912',
           code: 'YES (ENTER DATE)',
           active: true,
           label: 'YES (ENTER DATE)',
@@ -23,6 +24,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44913',
         },
         {
+          id: '178913',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178968',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -48,6 +51,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44612',
         },
         {
+          id: '178969',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -65,6 +69,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179009',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -73,6 +78,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44186',
         },
         {
+          id: '179008',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -90,6 +96,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179102',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -98,6 +105,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44201',
         },
         {
+          id: '179101',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -115,6 +123,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179167',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -123,6 +132,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45134',
         },
         {
+          id: '179168',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -140,6 +150,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179331',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -148,6 +159,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44793',
         },
         {
+          id: '179332',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -165,6 +177,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179660',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -173,6 +186,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44464',
         },
         {
+          id: '179661',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -190,6 +204,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179730',
           code: 'PRISONER ON PRISONER',
           active: true,
           label: 'PRISONER ON PRISONER',
@@ -198,6 +213,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45130',
         },
         {
+          id: '179732',
           code: 'PRISONER ON OFFICER',
           active: true,
           label: 'PRISONER ON OFFICER',
@@ -206,6 +222,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44495',
         },
         {
+          id: '179733',
           code: 'PRISONER ON OTHER',
           active: true,
           label: 'PRISONER ON OTHER',
@@ -214,6 +231,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44495',
         },
         {
+          id: '179731',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -231,6 +249,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179821',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -239,6 +258,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44652',
         },
         {
+          id: '179820',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -256,6 +276,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179854',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -264,6 +285,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45088',
         },
         {
+          id: '179853',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -281,6 +303,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180014',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -289,6 +312,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44943',
         },
         {
+          id: '180015',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -306,6 +330,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180071',
           code: 'FIREARM',
           active: true,
           label: 'FIREARM',
@@ -314,6 +339,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180068',
           code: 'CHEMICAL INCAPACITANT',
           active: true,
           label: 'CHEMICAL INCAPACITANT',
@@ -322,6 +348,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180073',
           code: 'KNIFE/BLADE',
           active: true,
           label: 'KNIFE/BLADE',
@@ -330,6 +357,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180076',
           code: 'OTHER SHARP INSTRUMENT',
           active: true,
           label: 'OTHER SHARP INSTRUMENT',
@@ -338,6 +366,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180067',
           code: 'BLUNT INSTRUMENT',
           active: true,
           label: 'BLUNT INSTRUMENT',
@@ -346,6 +375,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180074',
           code: 'LIGATURE',
           active: true,
           label: 'LIGATURE',
@@ -354,6 +384,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180069',
           code: 'DANGEROUS LIQUID',
           active: true,
           label: 'DANGEROUS LIQUID',
@@ -362,6 +393,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180070',
           code: 'EXCRETA/URINE',
           active: true,
           label: 'EXCRETA/URINE',
@@ -370,6 +402,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180077',
           code: 'SPITTING',
           active: true,
           label: 'SPITTING',
@@ -378,6 +411,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180072',
           code: 'FOOD',
           active: true,
           label: 'FOOD',
@@ -386,6 +420,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180079',
           code: 'THROWN FURNITURE',
           active: true,
           label: 'THROWN FURNITURE',
@@ -394,6 +429,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180078',
           code: 'THROWN EQUIPMENT',
           active: true,
           label: 'THROWN EQUIPMENT',
@@ -402,6 +438,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45074',
         },
         {
+          id: '180075',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -419,6 +456,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180193',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -427,6 +465,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44344',
         },
         {
+          id: '180192',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -444,6 +483,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180283',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -452,6 +492,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44254',
         },
         {
+          id: '180282',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -469,6 +510,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180540',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -477,6 +519,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44522',
         },
         {
+          id: '180539',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -494,6 +537,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180632',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: true,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -502,6 +546,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44460',
         },
         {
+          id: '180633',
           code: 'MINOR BRUISES',
           active: true,
           label: 'MINOR BRUISES',
@@ -510,6 +555,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44460',
         },
         {
+          id: '180636',
           code: 'SWELLINGS',
           active: true,
           label: 'SWELLINGS',
@@ -518,6 +564,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44460',
         },
         {
+          id: '180635',
           code: 'SUPERFICIAL CUTS',
           active: true,
           label: 'SUPERFICIAL CUTS',
@@ -526,6 +573,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44460',
         },
         {
+          id: '180634',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -543,6 +591,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180754',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -551,6 +600,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44367',
         },
         {
+          id: '180753',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -568,6 +618,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181164',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -576,6 +627,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45042',
         },
         {
+          id: '181165',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -593,6 +645,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181242',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -601,6 +654,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44773',
         },
         {
+          id: '181241',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -609,6 +663,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44773',
         },
         {
+          id: '181238',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -617,6 +672,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44773',
         },
         {
+          id: '181240',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -625,6 +681,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44773',
         },
         {
+          id: '181239',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -642,6 +699,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181518',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -650,6 +708,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44153',
         },
         {
+          id: '181517',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -667,6 +726,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181628',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -675,6 +735,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '45092',
         },
         {
+          id: '181629',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -692,6 +753,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181771',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -700,6 +762,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44391',
         },
         {
+          id: '181770',
           code: 'PRISONERS',
           active: true,
           label: 'PRISONERS',
@@ -708,6 +771,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44391',
         },
         {
+          id: '181767',
           code: 'CIVILIAN GRADES',
           active: true,
           label: 'CIVILIAN GRADES',
@@ -716,6 +780,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44391',
         },
         {
+          id: '181769',
           code: 'POLICE',
           active: true,
           label: 'POLICE',
@@ -724,6 +789,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44391',
         },
         {
+          id: '181768',
           code: 'EXTERNAL CIVILIANS',
           active: true,
           label: 'EXTERNAL CIVILIANS',
@@ -741,6 +807,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182153',
           code: 'FRACTURE',
           active: true,
           label: 'FRACTURE',
@@ -749,6 +816,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182155',
           code: 'SCALD OR BURN',
           active: true,
           label: 'SCALD OR BURN',
@@ -757,6 +825,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182156',
           code: 'STABBING',
           active: true,
           label: 'STABBING',
@@ -765,6 +834,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182150',
           code: 'CRUSHING',
           active: true,
           label: 'CRUSHING',
@@ -773,6 +843,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182152',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: true,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -781,6 +852,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182147',
           code: 'BLACK EYE',
           active: true,
           label: 'BLACK EYE',
@@ -789,6 +861,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182148',
           code: 'BROKEN NOSE',
           active: true,
           label: 'BROKEN NOSE',
@@ -797,6 +870,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182149',
           code: 'BROKEN TEETH',
           active: true,
           label: 'BROKEN TEETH',
@@ -805,6 +879,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182151',
           code: 'CUTS REQUIRING SUTURES',
           active: true,
           label: 'CUTS REQUIRING SUTURES',
@@ -813,6 +888,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182146',
           code: 'BITES',
           active: true,
           label: 'BITES',
@@ -821,6 +897,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182154',
           code: 'GUN SHOT WOUND',
           active: true,
           label: 'GUN SHOT WOUND',
@@ -829,6 +906,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44141',
         },
         {
+          id: '182157',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: true,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -846,6 +924,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182269',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -854,6 +933,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182268',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -871,6 +951,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182300',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -879,6 +960,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44880',
         },
         {
+          id: '182299',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -896,6 +978,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182320',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -904,6 +987,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44405',
         },
         {
+          id: '182319',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -921,6 +1005,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182468',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -929,6 +1014,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44495',
         },
         {
+          id: '182467',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -946,6 +1032,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182475',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -954,6 +1041,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182476',
           code: 'ASSOCIATION AREA',
           active: true,
           label: 'ASSOCIATION AREA',
@@ -962,6 +1050,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182477',
           code: 'CELL',
           active: true,
           label: 'CELL',
@@ -970,6 +1059,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182478',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -978,6 +1068,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182480',
           code: 'DINING ROOM',
           active: true,
           label: 'DINING ROOM',
@@ -986,6 +1077,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182481',
           code: 'DORMITORY',
           active: true,
           label: 'DORMITORY',
@@ -994,6 +1086,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182482',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -1002,6 +1095,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182484',
           code: 'EXERCISE YARD',
           active: true,
           label: 'EXERCISE YARD',
@@ -1010,6 +1104,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182486',
           code: 'GATE',
           active: true,
           label: 'GATE',
@@ -1018,6 +1113,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182487',
           code: 'GYM',
           active: true,
           label: 'GYM',
@@ -1026,6 +1122,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182488',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -1034,6 +1131,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182491',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -1042,6 +1140,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182493',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -1050,6 +1149,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182495',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -1058,6 +1158,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182496',
           code: 'RECESS',
           active: true,
           label: 'RECESS',
@@ -1066,6 +1167,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182497',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -1074,6 +1176,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182499',
           code: 'SPECIAL UNIT',
           active: true,
           label: 'SPECIAL UNIT',
@@ -1082,6 +1185,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182498',
           code: 'SHOWERS/CHANGING ROOM',
           active: true,
           label: 'SHOWERS/CHANGING ROOM',
@@ -1090,6 +1194,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182502',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -1098,6 +1203,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182504',
           code: 'WING',
           active: true,
           label: 'WING',
@@ -1106,6 +1212,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182506',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -1114,6 +1221,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182507',
           code: 'WORKSHOP',
           active: true,
           label: 'WORKSHOP',
@@ -1122,6 +1230,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182505',
           code: 'WITHIN PERIMETER',
           active: true,
           label: 'WITHIN PERIMETER',
@@ -1130,6 +1239,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182483',
           code: 'ELSEWHERE',
           active: true,
           label: 'ELSEWHERE',
@@ -1138,6 +1248,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182485',
           code: 'FUNERAL',
           active: true,
           label: 'FUNERAL',
@@ -1146,6 +1257,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182489',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: true,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -1154,6 +1266,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182490',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: true,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -1162,6 +1275,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182494',
           code: 'OUTSIDE WORKING PARTY',
           active: true,
           label: 'OUTSIDE WORKING PARTY',
@@ -1170,6 +1284,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182500',
           code: 'SPORTS FIELD',
           active: true,
           label: 'SPORTS FIELD',
@@ -1178,6 +1293,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182501',
           code: 'VEHICLE',
           active: true,
           label: 'VEHICLE',
@@ -1186,6 +1302,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182503',
           code: 'WEDDINGS',
           active: true,
           label: 'WEDDINGS',
@@ -1194,6 +1311,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182492',
           code: 'MAGISTRATES COURT',
           active: true,
           label: 'MAGISTRATES COURT',
@@ -1202,6 +1320,7 @@ const OLD_ASSAULT: IncidentTypeConfiguration = {
           nextQuestionId: '44586',
         },
         {
+          id: '182479',
           code: 'CROWN COURT',
           active: true,
           label: 'CROWN COURT',

--- a/server/reportConfiguration/types/OLD_ASSAULT1.ts
+++ b/server/reportConfiguration/types/OLD_ASSAULT1.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:42.446Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:09.807Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212684',
           code: 'No further action',
           active: false,
           label: 'No further action',
@@ -23,6 +24,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
           nextQuestionId: '61180',
         },
         {
+          id: '212685',
           code: 'IEP regression',
           active: false,
           label: 'IEP regression',
@@ -31,6 +33,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
           nextQuestionId: '61180',
         },
         {
+          id: '212686',
           code: 'Placed on report/adjudication referral',
           active: false,
           label: 'Placed on report/adjudication referral',
@@ -39,6 +42,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
           nextQuestionId: '61180',
         },
         {
+          id: '212687',
           code: 'Police referral',
           active: false,
           label: 'Police referral',
@@ -56,6 +60,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213007',
           code: 'no',
           active: false,
           label: 'no',
@@ -73,6 +78,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213011',
           code: 'n',
           active: false,
           label: 'n',
@@ -90,6 +96,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213012',
           code: 'n',
           active: false,
           label: 'n',
@@ -107,6 +114,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213008',
           code: 'n',
           active: true,
           label: 'n',
@@ -124,6 +132,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213009',
           code: 'n',
           active: false,
           label: 'n',
@@ -141,6 +150,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213010',
           code: 'n',
           active: false,
           label: 'n',
@@ -158,6 +168,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213013',
           code: 'n',
           active: false,
           label: 'n',
@@ -175,6 +186,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213014',
           code: 'n',
           active: false,
           label: 'n',
@@ -192,6 +204,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213015',
           code: 'n',
           active: false,
           label: 'n',
@@ -209,6 +222,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213016',
           code: 'n',
           active: false,
           label: 'n',
@@ -226,6 +240,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213017',
           code: 'n',
           active: false,
           label: 'n',
@@ -243,6 +258,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213018',
           code: 'n',
           active: false,
           label: 'n',
@@ -260,6 +276,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213019',
           code: 'n',
           active: false,
           label: 'n',
@@ -277,6 +294,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213020',
           code: 'n',
           active: false,
           label: 'n',
@@ -294,6 +312,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213021',
           code: 'n',
           active: false,
           label: 'n',
@@ -311,6 +330,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213022',
           code: 'n',
           active: false,
           label: 'n',
@@ -328,6 +348,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213023',
           code: 'n',
           active: false,
           label: 'n',
@@ -345,6 +366,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213024',
           code: 'n',
           active: false,
           label: 'n',
@@ -362,6 +384,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213025',
           code: 'n',
           active: false,
           label: 'n',
@@ -379,6 +402,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213026',
           code: 'n',
           active: false,
           label: 'n',
@@ -396,6 +420,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213027',
           code: 'n',
           active: false,
           label: 'n',
@@ -413,6 +438,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213028',
           code: 'n',
           active: false,
           label: 'n',
@@ -430,6 +456,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213029',
           code: 'n',
           active: false,
           label: 'n',
@@ -447,6 +474,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213030',
           code: 'n',
           active: false,
           label: 'n',
@@ -464,6 +492,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213031',
           code: 'n',
           active: false,
           label: 'n',
@@ -481,6 +510,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213032',
           code: 'n',
           active: false,
           label: 'n',
@@ -498,6 +528,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213033',
           code: 'n',
           active: false,
           label: 'n',
@@ -515,6 +546,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213034',
           code: 'n',
           active: false,
           label: 'n',
@@ -532,6 +564,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213035',
           code: 'n',
           active: false,
           label: 'n',
@@ -549,6 +582,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213036',
           code: 'n',
           active: false,
           label: 'n',
@@ -566,6 +600,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213037',
           code: 'n',
           active: false,
           label: 'n',
@@ -583,6 +618,7 @@ const OLD_ASSAULT1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213038',
           code: 'n',
           active: false,
           label: 'n',

--- a/server/reportConfiguration/types/OLD_ASSAULT2.ts
+++ b/server/reportConfiguration/types/OLD_ASSAULT2.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:44.128Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:11.455Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212725',
           code: 'No further action',
           active: false,
           label: 'No further action',
@@ -23,6 +24,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61214',
         },
         {
+          id: '212726',
           code: 'IEP regression',
           active: false,
           label: 'IEP regression',
@@ -31,6 +33,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61214',
         },
         {
+          id: '212727',
           code: 'Placed on report/adjudication referral',
           active: false,
           label: 'Placed on report/adjudication referral',
@@ -39,6 +42,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61214',
         },
         {
+          id: '212728',
           code: 'Police referral',
           active: false,
           label: 'Police referral',
@@ -56,6 +60,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212729',
           code: 'No',
           active: false,
           label: 'No',
@@ -64,6 +69,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61215',
         },
         {
+          id: '212730',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -81,6 +87,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212731',
           code: 'No',
           active: false,
           label: 'No',
@@ -89,6 +96,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61216',
         },
         {
+          id: '212732',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -106,6 +114,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212733',
           code: 'No',
           active: false,
           label: 'No',
@@ -114,6 +123,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61217',
         },
         {
+          id: '212734',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -131,6 +141,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212735',
           code: 'No',
           active: false,
           label: 'No',
@@ -139,6 +150,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212736',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -156,6 +168,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212737',
           code: 'Administration',
           active: false,
           label: 'Administration',
@@ -164,6 +177,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212738',
           code: 'Association area',
           active: false,
           label: 'Association area',
@@ -172,6 +186,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212739',
           code: 'Cell',
           active: false,
           label: 'Cell',
@@ -180,6 +195,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212740',
           code: 'Chapel',
           active: false,
           label: 'Chapel',
@@ -188,6 +204,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212741',
           code: 'Crown Court',
           active: false,
           label: 'Crown Court',
@@ -196,6 +213,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212742',
           code: 'Dining room',
           active: false,
           label: 'Dining room',
@@ -204,6 +222,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212743',
           code: 'Dormitory',
           active: false,
           label: 'Dormitory',
@@ -212,6 +231,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212744',
           code: 'Education',
           active: false,
           label: 'Education',
@@ -220,6 +240,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212745',
           code: 'Elsewhere',
           active: false,
           label: 'Elsewhere',
@@ -228,6 +249,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212746',
           code: 'Exercise yard',
           active: false,
           label: 'Exercise yard',
@@ -236,6 +258,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212747',
           code: 'External roof',
           active: false,
           label: 'External roof',
@@ -244,6 +267,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212748',
           code: 'Funeral',
           active: false,
           label: 'Funeral',
@@ -252,6 +276,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212749',
           code: 'Gate',
           active: false,
           label: 'Gate',
@@ -260,6 +285,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212750',
           code: 'Gym',
           active: false,
           label: 'Gym',
@@ -268,6 +294,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212751',
           code: 'Health care centre',
           active: false,
           label: 'Health care centre',
@@ -276,6 +303,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212752',
           code: 'Hospital outside (patient)',
           active: false,
           label: 'Hospital outside (patient)',
@@ -284,6 +312,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212753',
           code: 'Hospital outside (visiting)',
           active: false,
           label: 'Hospital outside (visiting)',
@@ -292,6 +321,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212754',
           code: 'Induction/First night centre',
           active: false,
           label: 'Induction/First night centre',
@@ -300,6 +330,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212755',
           code: 'Kitchen',
           active: false,
           label: 'Kitchen',
@@ -308,6 +339,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212756',
           code: 'Magistrates court',
           active: false,
           label: 'Magistrates court',
@@ -316,6 +348,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212757',
           code: 'Mail room',
           active: false,
           label: 'Mail room',
@@ -324,6 +357,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212758',
           code: 'Office',
           active: false,
           label: 'Office',
@@ -332,6 +366,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212759',
           code: 'Outside working party',
           active: false,
           label: 'Outside working party',
@@ -340,6 +375,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212760',
           code: 'Reception',
           active: false,
           label: 'Reception',
@@ -348,6 +384,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212761',
           code: 'Recess',
           active: false,
           label: 'Recess',
@@ -356,6 +393,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212762',
           code: 'Segregation unit',
           active: false,
           label: 'Segregation unit',
@@ -364,6 +402,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212763',
           code: 'Showers/changing room',
           active: false,
           label: 'Showers/changing room',
@@ -372,6 +411,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212764',
           code: 'Special unit',
           active: false,
           label: 'Special unit',
@@ -380,6 +420,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212765',
           code: 'Sports field',
           active: false,
           label: 'Sports field',
@@ -388,6 +429,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212766',
           code: 'Vehicle',
           active: false,
           label: 'Vehicle',
@@ -396,6 +438,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212767',
           code: 'Visits',
           active: false,
           label: 'Visits',
@@ -404,6 +447,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212768',
           code: 'Vulnerable prisoners unit (VPU)',
           active: false,
           label: 'Vulnerable prisoners unit (VPU)',
@@ -412,6 +456,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212769',
           code: 'Weddings',
           active: false,
           label: 'Weddings',
@@ -420,6 +465,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212770',
           code: 'Wing',
           active: false,
           label: 'Wing',
@@ -428,6 +474,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212771',
           code: 'Within perimeter',
           active: false,
           label: 'Within perimeter',
@@ -436,6 +483,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212772',
           code: 'Works department',
           active: false,
           label: 'Works department',
@@ -444,6 +492,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61219',
         },
         {
+          id: '212773',
           code: 'Workshop',
           active: false,
           label: 'Workshop',
@@ -461,6 +510,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212774',
           code: 'No',
           active: false,
           label: 'No',
@@ -469,6 +519,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61220',
         },
         {
+          id: '212775',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -486,6 +537,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212776',
           code: 'No',
           active: false,
           label: 'No',
@@ -494,6 +546,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61221',
         },
         {
+          id: '212777',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -511,6 +564,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212778',
           code: 'Prisoner on prisoner',
           active: false,
           label: 'Prisoner on prisoner',
@@ -519,6 +573,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61222',
         },
         {
+          id: '212779',
           code: 'Prisoner on staff',
           active: false,
           label: 'Prisoner on staff',
@@ -527,6 +582,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61223',
         },
         {
+          id: '212780',
           code: 'Prisoner on other',
           active: false,
           label: 'Prisoner on other',
@@ -535,6 +591,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61222',
         },
         {
+          id: '212781',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -552,6 +609,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212782',
           code: 'No',
           active: false,
           label: 'No',
@@ -560,6 +618,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
           nextQuestionId: '61224',
         },
         {
+          id: '212783',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -577,6 +636,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213039',
           code: 'n',
           active: false,
           label: 'n',
@@ -594,6 +654,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213040',
           code: 'n',
           active: false,
           label: 'n',
@@ -611,6 +672,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213041',
           code: 'n',
           active: false,
           label: 'n',
@@ -628,6 +690,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213042',
           code: 'n',
           active: false,
           label: 'n',
@@ -645,6 +708,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213043',
           code: 'n',
           active: false,
           label: 'n',
@@ -662,6 +726,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213044',
           code: 'n',
           active: false,
           label: 'n',
@@ -679,6 +744,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213045',
           code: 'n',
           active: true,
           label: 'n',
@@ -696,6 +762,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213046',
           code: 'n',
           active: false,
           label: 'n',
@@ -713,6 +780,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213047',
           code: 'n',
           active: false,
           label: 'n',
@@ -730,6 +798,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213048',
           code: 'n',
           active: false,
           label: 'n',
@@ -747,6 +816,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213049',
           code: 'n',
           active: false,
           label: 'n',
@@ -764,6 +834,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213050',
           code: 'n',
           active: false,
           label: 'n',
@@ -781,6 +852,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213051',
           code: 'n',
           active: false,
           label: 'n',
@@ -798,6 +870,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213052',
           code: 'n',
           active: false,
           label: 'n',
@@ -815,6 +888,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213053',
           code: 'n',
           active: false,
           label: 'n',
@@ -832,6 +906,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213054',
           code: 'n',
           active: false,
           label: 'n',
@@ -849,6 +924,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213055',
           code: 'n',
           active: false,
           label: 'n',
@@ -866,6 +942,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213056',
           code: 'n',
           active: false,
           label: 'n',
@@ -883,6 +960,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213057',
           code: 'n',
           active: false,
           label: 'n',
@@ -900,6 +978,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213058',
           code: 'n',
           active: false,
           label: 'n',
@@ -917,6 +996,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213059',
           code: 'n',
           active: false,
           label: 'n',
@@ -934,6 +1014,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '213060',
           code: 'n',
           active: false,
           label: 'n',
@@ -951,6 +1032,7 @@ const OLD_ASSAULT2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213061',
           code: 'n',
           active: false,
           label: 'n',

--- a/server/reportConfiguration/types/OLD_ASSAULT3.ts
+++ b/server/reportConfiguration/types/OLD_ASSAULT3.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:43.296Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:10.578Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212856',
           code: 'No further action',
           active: false,
           label: 'No further action',
@@ -23,6 +24,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61247',
         },
         {
+          id: '212857',
           code: 'IEP regression',
           active: false,
           label: 'IEP regression',
@@ -31,6 +33,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61247',
         },
         {
+          id: '212858',
           code: 'Placed on report/adjudication referral',
           active: false,
           label: 'Placed on report/adjudication referral',
@@ -39,6 +42,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61247',
         },
         {
+          id: '212859',
           code: 'Police referral',
           active: false,
           label: 'Police referral',
@@ -56,6 +60,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212860',
           code: 'No',
           active: false,
           label: 'No',
@@ -64,6 +69,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61248',
         },
         {
+          id: '212861',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -81,6 +87,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212862',
           code: 'No',
           active: false,
           label: 'No',
@@ -89,6 +96,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61249',
         },
         {
+          id: '212863',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -106,6 +114,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212864',
           code: 'No',
           active: false,
           label: 'No',
@@ -114,6 +123,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61250',
         },
         {
+          id: '212865',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -131,6 +141,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212866',
           code: 'No',
           active: false,
           label: 'No',
@@ -139,6 +150,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212867',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -156,6 +168,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212868',
           code: 'Administration',
           active: false,
           label: 'Administration',
@@ -164,6 +177,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212869',
           code: 'Association area',
           active: false,
           label: 'Association area',
@@ -172,6 +186,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212870',
           code: 'Cell',
           active: false,
           label: 'Cell',
@@ -180,6 +195,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212871',
           code: 'Chapel',
           active: false,
           label: 'Chapel',
@@ -188,6 +204,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212872',
           code: 'Crown Court',
           active: false,
           label: 'Crown Court',
@@ -196,6 +213,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212873',
           code: 'Dining room',
           active: false,
           label: 'Dining room',
@@ -204,6 +222,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212874',
           code: 'Dormitory',
           active: false,
           label: 'Dormitory',
@@ -212,6 +231,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212875',
           code: 'Education',
           active: false,
           label: 'Education',
@@ -220,6 +240,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212876',
           code: 'Elsewhere',
           active: false,
           label: 'Elsewhere',
@@ -228,6 +249,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212877',
           code: 'Exercise yard',
           active: false,
           label: 'Exercise yard',
@@ -236,6 +258,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212878',
           code: 'External roof',
           active: false,
           label: 'External roof',
@@ -244,6 +267,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212879',
           code: 'Funeral',
           active: false,
           label: 'Funeral',
@@ -252,6 +276,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212880',
           code: 'Gate',
           active: false,
           label: 'Gate',
@@ -260,6 +285,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212881',
           code: 'Gym',
           active: false,
           label: 'Gym',
@@ -268,6 +294,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212882',
           code: 'Health care centre',
           active: false,
           label: 'Health care centre',
@@ -276,6 +303,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212883',
           code: 'Hospital outside (patient)',
           active: false,
           label: 'Hospital outside (patient)',
@@ -284,6 +312,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212884',
           code: 'Hospital outside (visiting)',
           active: false,
           label: 'Hospital outside (visiting)',
@@ -292,6 +321,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212885',
           code: 'Induction/First night centre',
           active: false,
           label: 'Induction/First night centre',
@@ -300,6 +330,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212886',
           code: 'Kitchen',
           active: false,
           label: 'Kitchen',
@@ -308,6 +339,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212887',
           code: 'Magistrates court',
           active: false,
           label: 'Magistrates court',
@@ -316,6 +348,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212888',
           code: 'Mail room',
           active: false,
           label: 'Mail room',
@@ -324,6 +357,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212889',
           code: 'Office',
           active: false,
           label: 'Office',
@@ -332,6 +366,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212890',
           code: 'Outside working party',
           active: false,
           label: 'Outside working party',
@@ -340,6 +375,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212891',
           code: 'Reception',
           active: false,
           label: 'Reception',
@@ -348,6 +384,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212892',
           code: 'Recess',
           active: false,
           label: 'Recess',
@@ -356,6 +393,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212893',
           code: 'Segregation unit',
           active: false,
           label: 'Segregation unit',
@@ -364,6 +402,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212894',
           code: 'Showers/changing room',
           active: false,
           label: 'Showers/changing room',
@@ -372,6 +411,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212895',
           code: 'Special unit',
           active: false,
           label: 'Special unit',
@@ -380,6 +420,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212896',
           code: 'Sports field',
           active: false,
           label: 'Sports field',
@@ -388,6 +429,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212897',
           code: 'Vehicle',
           active: false,
           label: 'Vehicle',
@@ -396,6 +438,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212898',
           code: 'Visits',
           active: false,
           label: 'Visits',
@@ -404,6 +447,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212899',
           code: 'Vulnerable prisoners unit (VPU)',
           active: false,
           label: 'Vulnerable prisoners unit (VPU)',
@@ -412,6 +456,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212900',
           code: 'Weddings',
           active: false,
           label: 'Weddings',
@@ -420,6 +465,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212901',
           code: 'Wing',
           active: false,
           label: 'Wing',
@@ -428,6 +474,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212902',
           code: 'Within perimeter',
           active: false,
           label: 'Within perimeter',
@@ -436,6 +483,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212903',
           code: 'Works department',
           active: false,
           label: 'Works department',
@@ -444,6 +492,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61252',
         },
         {
+          id: '212904',
           code: 'Workshop',
           active: false,
           label: 'Workshop',
@@ -461,6 +510,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212905',
           code: 'No',
           active: false,
           label: 'No',
@@ -469,6 +519,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61253',
         },
         {
+          id: '212906',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -486,6 +537,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212907',
           code: 'No',
           active: false,
           label: 'No',
@@ -494,6 +546,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61254',
         },
         {
+          id: '212908',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -511,6 +564,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212909',
           code: 'Prisoner on prisoner',
           active: false,
           label: 'Prisoner on prisoner',
@@ -519,6 +573,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61255',
         },
         {
+          id: '212910',
           code: 'Prisoner on staff',
           active: false,
           label: 'Prisoner on staff',
@@ -527,6 +582,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61256',
         },
         {
+          id: '212911',
           code: 'Prisoner on other',
           active: false,
           label: 'Prisoner on other',
@@ -535,6 +591,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61255',
         },
         {
+          id: '212912',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -552,6 +609,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212913',
           code: 'No',
           active: false,
           label: 'No',
@@ -560,6 +618,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61257',
         },
         {
+          id: '212914',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -577,6 +636,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '212915',
           code: 'Operational staff- Prison Officer',
           active: false,
           label: 'Operational staff- Prison Officer',
@@ -585,6 +645,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61257',
         },
         {
+          id: '212916',
           code: 'Operational staff - Other',
           active: false,
           label: 'Operational staff - Other',
@@ -593,6 +654,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61257',
         },
         {
+          id: '212917',
           code: 'Non-operational staff',
           active: false,
           label: 'Non-operational staff',
@@ -601,6 +663,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61257',
         },
         {
+          id: '212918',
           code: 'Non-directly employed staff',
           active: false,
           label: 'Non-directly employed staff',
@@ -618,6 +681,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212919',
           code: 'No',
           active: false,
           label: 'No',
@@ -626,6 +690,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61261',
         },
         {
+          id: '212920',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -643,6 +708,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212921',
           code: 'No',
           active: false,
           label: 'No',
@@ -651,6 +717,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61259',
         },
         {
+          id: '212922',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -668,6 +735,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212923',
           code: 'No',
           active: false,
           label: 'No',
@@ -676,6 +744,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61261',
         },
         {
+          id: '212924',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -693,6 +762,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '212925',
           code: 'Neck or above',
           active: false,
           label: 'Neck or above',
@@ -701,6 +771,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61261',
         },
         {
+          id: '212926',
           code: 'Torso',
           active: false,
           label: 'Torso',
@@ -709,6 +780,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61261',
         },
         {
+          id: '212927',
           code: 'Arms or hands',
           active: false,
           label: 'Arms or hands',
@@ -717,6 +789,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61261',
         },
         {
+          id: '212928',
           code: 'Legs or feet',
           active: false,
           label: 'Legs or feet',
@@ -734,6 +807,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212929',
           code: 'No',
           active: false,
           label: 'No',
@@ -742,6 +816,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212930',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -759,6 +834,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '212931',
           code: 'Blunt instrument',
           active: false,
           label: 'Blunt instrument',
@@ -767,6 +843,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212932',
           code: 'Knife/blade',
           active: false,
           label: 'Knife/blade',
@@ -775,6 +852,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212933',
           code: 'Other sharp instrument',
           active: false,
           label: 'Other sharp instrument',
@@ -783,6 +861,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212934',
           code: 'Dangerous liquid',
           active: false,
           label: 'Dangerous liquid',
@@ -791,6 +870,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212935',
           code: 'Excreta/urine',
           active: false,
           label: 'Excreta/urine',
@@ -799,6 +879,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212936',
           code: 'Thrown equipment',
           active: false,
           label: 'Thrown equipment',
@@ -807,6 +888,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212937',
           code: 'Thrown furniture',
           active: false,
           label: 'Thrown furniture',
@@ -815,6 +897,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212938',
           code: 'Food',
           active: false,
           label: 'Food',
@@ -823,6 +906,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212939',
           code: 'Ligature',
           active: false,
           label: 'Ligature',
@@ -831,6 +915,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212940',
           code: 'Chemical incapacitant',
           active: false,
           label: 'Chemical incapacitant',
@@ -839,6 +924,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212941',
           code: 'Firearm',
           active: false,
           label: 'Firearm',
@@ -847,6 +933,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61263',
         },
         {
+          id: '212942',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -864,6 +951,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212943',
           code: 'No',
           active: false,
           label: 'No',
@@ -872,6 +960,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61273',
         },
         {
+          id: '212944',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -889,6 +978,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '212945',
           code: 'Prisoners',
           active: false,
           label: 'Prisoners',
@@ -897,6 +987,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61265',
         },
         {
+          id: '212946',
           code: 'Operational staff- Prison Officer',
           active: false,
           label: 'Operational staff- Prison Officer',
@@ -905,6 +996,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61265',
         },
         {
+          id: '212947',
           code: 'Operational staff - Other',
           active: false,
           label: 'Operational staff - Other',
@@ -913,6 +1005,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61265',
         },
         {
+          id: '212948',
           code: 'Non-operational staff',
           active: false,
           label: 'Non-operational staff',
@@ -921,6 +1014,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61265',
         },
         {
+          id: '212949',
           code: 'Non-directly employed staff',
           active: false,
           label: 'Non-directly employed staff',
@@ -929,6 +1023,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61265',
         },
         {
+          id: '212950',
           code: 'Police',
           active: false,
           label: 'Police',
@@ -937,6 +1032,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61265',
         },
         {
+          id: '212951',
           code: 'Visitor',
           active: false,
           label: 'Visitor',
@@ -945,6 +1041,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61265',
         },
         {
+          id: '212952',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -962,6 +1059,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212953',
           code: 'No',
           active: false,
           label: 'No',
@@ -970,6 +1068,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212954',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -987,6 +1086,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '212955',
           code: 'Black eye',
           active: false,
           label: 'Black eye',
@@ -995,6 +1095,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212956',
           code: 'Bites',
           active: false,
           label: 'Bites',
@@ -1003,6 +1104,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212957',
           code: 'Cuts requiring sutures',
           active: false,
           label: 'Cuts requiring sutures',
@@ -1011,6 +1113,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212958',
           code: 'Extensive/multiple bruising',
           active: false,
           label: 'Extensive/multiple bruising',
@@ -1019,6 +1122,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212959',
           code: 'Fracture',
           active: false,
           label: 'Fracture',
@@ -1027,6 +1131,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212960',
           code: 'Scald or burn',
           active: false,
           label: 'Scald or burn',
@@ -1035,6 +1140,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212961',
           code: 'Stabbing',
           active: false,
           label: 'Stabbing',
@@ -1043,6 +1149,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212962',
           code: 'Broken teeth',
           active: false,
           label: 'Broken teeth',
@@ -1051,6 +1158,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212963',
           code: 'Broken nose',
           active: false,
           label: 'Broken nose',
@@ -1059,6 +1167,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212964',
           code: 'Crushing',
           active: false,
           label: 'Crushing',
@@ -1067,6 +1176,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212965',
           code: 'Temporary/permanent blindness',
           active: false,
           label: 'Temporary/permanent blindness',
@@ -1075,6 +1185,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61267',
         },
         {
+          id: '212966',
           code: 'Gun shot wound',
           active: false,
           label: 'Gun shot wound',
@@ -1092,6 +1203,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212967',
           code: 'No',
           active: false,
           label: 'No',
@@ -1100,6 +1212,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61269',
         },
         {
+          id: '212968',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1117,6 +1230,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '212969',
           code: 'Grazes, scratches or abrasions',
           active: false,
           label: 'Grazes, scratches or abrasions',
@@ -1125,6 +1239,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61269',
         },
         {
+          id: '212970',
           code: 'Minor bruises',
           active: false,
           label: 'Minor bruises',
@@ -1133,6 +1248,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61269',
         },
         {
+          id: '212971',
           code: 'Superficial cuts',
           active: false,
           label: 'Superficial cuts',
@@ -1141,6 +1257,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61269',
         },
         {
+          id: '212972',
           code: 'Swellings',
           active: false,
           label: 'Swellings',
@@ -1149,6 +1266,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61269',
         },
         {
+          id: '212973',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -1166,6 +1284,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212974',
           code: 'No',
           active: false,
           label: 'No',
@@ -1174,6 +1293,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61272',
         },
         {
+          id: '212975',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1191,6 +1311,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '212976',
           code: 'A and E',
           active: false,
           label: 'A and E',
@@ -1199,6 +1320,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61271',
         },
         {
+          id: '212977',
           code: 'Inpatient (overnight only)',
           active: false,
           label: 'Inpatient (overnight only)',
@@ -1207,6 +1329,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61271',
         },
         {
+          id: '212978',
           code: 'Inpatient (over 24hr)',
           active: false,
           label: 'Inpatient (over 24hr)',
@@ -1215,6 +1338,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61271',
         },
         {
+          id: '212979',
           code: 'Life support',
           active: false,
           label: 'Life support',
@@ -1232,6 +1356,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '212980',
           code: 'Prisoners',
           active: false,
           label: 'Prisoners',
@@ -1240,6 +1365,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61272',
         },
         {
+          id: '212981',
           code: 'Operational staff- Prison Officer',
           active: false,
           label: 'Operational staff- Prison Officer',
@@ -1248,6 +1374,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61272',
         },
         {
+          id: '212982',
           code: 'Operational staff - Other',
           active: false,
           label: 'Operational staff - Other',
@@ -1256,6 +1383,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61272',
         },
         {
+          id: '212983',
           code: 'Non-operational staff',
           active: false,
           label: 'Non-operational staff',
@@ -1264,6 +1392,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61272',
         },
         {
+          id: '212984',
           code: 'Non-directly employed staff',
           active: false,
           label: 'Non-directly employed staff',
@@ -1272,6 +1401,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61272',
         },
         {
+          id: '212985',
           code: 'Police',
           active: false,
           label: 'Police',
@@ -1280,6 +1410,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61272',
         },
         {
+          id: '212986',
           code: 'Visitor',
           active: false,
           label: 'Visitor',
@@ -1288,6 +1419,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61272',
         },
         {
+          id: '212987',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -1305,6 +1437,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212988',
           code: 'No',
           active: false,
           label: 'No',
@@ -1313,6 +1446,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61273',
         },
         {
+          id: '212989',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1330,6 +1464,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212990',
           code: 'No',
           active: false,
           label: 'No',
@@ -1338,6 +1473,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61274',
         },
         {
+          id: '212991',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1355,6 +1491,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212992',
           code: 'No',
           active: false,
           label: 'No',
@@ -1363,6 +1500,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61275',
         },
         {
+          id: '212993',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1380,6 +1518,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212994',
           code: 'No',
           active: false,
           label: 'No',
@@ -1388,6 +1527,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61276',
         },
         {
+          id: '212995',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1405,6 +1545,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '212996',
           code: 'No',
           active: false,
           label: 'No',
@@ -1413,6 +1554,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61278',
         },
         {
+          id: '212997',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1430,6 +1572,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '212998',
           code: 'Body Worn Video Camera',
           active: false,
           label: 'Body Worn Video Camera',
@@ -1438,6 +1581,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61278',
         },
         {
+          id: '212999',
           code: 'CCTV',
           active: false,
           label: 'CCTV',
@@ -1446,6 +1590,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61278',
         },
         {
+          id: '213000',
           code: 'Pin Phones',
           active: false,
           label: 'Pin Phones',
@@ -1454,6 +1599,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61278',
         },
         {
+          id: '213001',
           code: 'Radio Net',
           active: false,
           label: 'Radio Net',
@@ -1462,6 +1608,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: '61278',
         },
         {
+          id: '213002',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -1479,6 +1626,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '213005',
           code: 'No',
           active: false,
           label: 'No',
@@ -1487,6 +1635,7 @@ const OLD_ASSAULT3: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '213006',
           code: 'Yes',
           active: false,
           label: 'Yes',

--- a/server/reportConfiguration/types/OLD_BARRICADE.ts
+++ b/server/reportConfiguration/types/OLD_BARRICADE.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:48.382Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:15.242Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179077',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -23,6 +24,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45071',
         },
         {
+          id: '179076',
           code: 'PRISONERS',
           active: false,
           label: 'PRISONERS',
@@ -31,6 +33,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45071',
         },
         {
+          id: '179073',
           code: 'CIVILIAN GRADES',
           active: false,
           label: 'CIVILIAN GRADES',
@@ -39,6 +42,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45071',
         },
         {
+          id: '179075',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -47,6 +51,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45071',
         },
         {
+          id: '179074',
           code: 'EXTERNAL CIVILIANS',
           active: false,
           label: 'EXTERNAL CIVILIANS',
@@ -64,6 +69,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179100',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -72,6 +78,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44263',
         },
         {
+          id: '179099',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -89,6 +96,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179116',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -97,6 +105,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44860',
         },
         {
+          id: '179115',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -114,6 +123,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179185',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -122,6 +132,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44987',
         },
         {
+          id: '179186',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -139,6 +150,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179218',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -147,6 +159,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44665',
         },
         {
+          id: '179217',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -164,6 +177,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179237',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -172,6 +186,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44629',
         },
         {
+          id: '179238',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -189,6 +204,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179352',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -197,6 +213,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44532',
         },
         {
+          id: '179353',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -214,6 +231,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179670',
           code: 'EXTENSIVE',
           active: false,
           label: 'EXTENSIVE',
@@ -222,6 +240,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44413',
         },
         {
+          id: '179671',
           code: 'MINOR',
           active: false,
           label: 'MINOR',
@@ -230,6 +249,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44413',
         },
         {
+          id: '179672',
           code: 'SERIOUS',
           active: false,
           label: 'SERIOUS',
@@ -247,6 +267,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179702',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -255,6 +276,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44879',
         },
         {
+          id: '179703',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -272,6 +294,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179782',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -280,6 +303,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44348',
         },
         {
+          id: '179783',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -297,6 +321,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179844',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -305,6 +330,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44932',
         },
         {
+          id: '179845',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -322,6 +348,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179884',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: false,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -339,6 +366,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179942',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -347,6 +375,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44357',
         },
         {
+          id: '179943',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -364,6 +393,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180020',
           code: 'FIREARM',
           active: false,
           label: 'FIREARM',
@@ -372,6 +402,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180017',
           code: 'CHEMICAL INCAPACITANT',
           active: false,
           label: 'CHEMICAL INCAPACITANT',
@@ -380,6 +411,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180022',
           code: 'KNIFE/BLADE',
           active: false,
           label: 'KNIFE/BLADE',
@@ -388,6 +420,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180025',
           code: 'OTHER SHARP INSTRUMENT',
           active: false,
           label: 'OTHER SHARP INSTRUMENT',
@@ -396,6 +429,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180016',
           code: 'BLUNT INSTRUMENT',
           active: false,
           label: 'BLUNT INSTRUMENT',
@@ -404,6 +438,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180023',
           code: 'LIGATURE',
           active: false,
           label: 'LIGATURE',
@@ -412,6 +447,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180018',
           code: 'DANGEROUS LIQUID',
           active: false,
           label: 'DANGEROUS LIQUID',
@@ -420,6 +456,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180019',
           code: 'EXCRETA/URINE',
           active: false,
           label: 'EXCRETA/URINE',
@@ -428,6 +465,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180026',
           code: 'SPITTING',
           active: false,
           label: 'SPITTING',
@@ -436,6 +474,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180021',
           code: 'FOOD',
           active: false,
           label: 'FOOD',
@@ -444,6 +483,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180028',
           code: 'THROWN FURNITURE',
           active: false,
           label: 'THROWN FURNITURE',
@@ -452,6 +492,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180027',
           code: 'THROWN EQUIPMENT',
           active: false,
           label: 'THROWN EQUIPMENT',
@@ -460,6 +501,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44378',
         },
         {
+          id: '180024',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -477,6 +519,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180153',
           code: 'ENTER NUMBER',
           active: false,
           label: 'ENTER NUMBER',
@@ -494,6 +537,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180186',
           code: 'GOVERNOR',
           active: false,
           label: 'GOVERNOR',
@@ -502,6 +546,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44206',
         },
         {
+          id: '180184',
           code: 'DEPUTY GOVERNOR',
           active: false,
           label: 'DEPUTY GOVERNOR',
@@ -510,6 +555,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44206',
         },
         {
+          id: '180185',
           code: 'DUTY GOVERNOR',
           active: false,
           label: 'DUTY GOVERNOR',
@@ -518,6 +564,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44206',
         },
         {
+          id: '180187',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -535,6 +582,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180239',
           code: 'NEGOTIATION',
           active: false,
           label: 'NEGOTIATION',
@@ -543,6 +591,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44191',
         },
         {
+          id: '180238',
           code: 'INTERVENTION',
           active: false,
           label: 'INTERVENTION',
@@ -551,6 +600,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44191',
         },
         {
+          id: '180240',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -568,6 +618,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180264',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -576,6 +627,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44461',
         },
         {
+          id: '180265',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -593,6 +645,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180351',
           code: 'TELEPHONY',
           active: false,
           label: 'TELEPHONY',
@@ -601,6 +654,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44666',
         },
         {
+          id: '180350',
           code: 'IT',
           active: false,
           label: 'IT',
@@ -618,6 +672,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180354',
           code: 'ADMINISTRATION',
           active: false,
           label: 'ADMINISTRATION',
@@ -626,6 +681,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180355',
           code: 'ASSOCIATION AREA',
           active: false,
           label: 'ASSOCIATION AREA',
@@ -634,6 +690,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180356',
           code: 'CELL',
           active: false,
           label: 'CELL',
@@ -642,6 +699,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180357',
           code: 'CHAPEL',
           active: false,
           label: 'CHAPEL',
@@ -650,6 +708,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180359',
           code: 'DINING ROOM',
           active: false,
           label: 'DINING ROOM',
@@ -658,6 +717,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180360',
           code: 'DORMITORY',
           active: false,
           label: 'DORMITORY',
@@ -666,6 +726,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180361',
           code: 'EDUCATION',
           active: false,
           label: 'EDUCATION',
@@ -674,6 +735,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180363',
           code: 'EXERCISE YARD',
           active: false,
           label: 'EXERCISE YARD',
@@ -682,6 +744,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180365',
           code: 'GATE',
           active: false,
           label: 'GATE',
@@ -690,6 +753,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180366',
           code: 'GYM',
           active: false,
           label: 'GYM',
@@ -698,6 +762,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180367',
           code: 'HEALTH CARE CENTRE',
           active: false,
           label: 'HEALTH CARE CENTRE',
@@ -706,6 +771,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180370',
           code: 'KITCHEN',
           active: false,
           label: 'KITCHEN',
@@ -714,6 +780,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180372',
           code: 'OFFICE',
           active: false,
           label: 'OFFICE',
@@ -722,6 +789,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180374',
           code: 'RECEPTION',
           active: false,
           label: 'RECEPTION',
@@ -730,6 +798,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180375',
           code: 'RECESS',
           active: false,
           label: 'RECESS',
@@ -738,6 +807,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180376',
           code: 'SEGREGATION UNIT',
           active: false,
           label: 'SEGREGATION UNIT',
@@ -746,6 +816,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180378',
           code: 'SPECIAL UNIT',
           active: false,
           label: 'SPECIAL UNIT',
@@ -754,6 +825,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180377',
           code: 'SHOWERS/CHANGING ROOM',
           active: false,
           label: 'SHOWERS/CHANGING ROOM',
@@ -762,6 +834,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180381',
           code: 'VISITS',
           active: false,
           label: 'VISITS',
@@ -770,6 +843,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180383',
           code: 'WING',
           active: false,
           label: 'WING',
@@ -778,6 +852,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180385',
           code: 'WORKS DEPARTMENT',
           active: false,
           label: 'WORKS DEPARTMENT',
@@ -786,6 +861,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180386',
           code: 'WORKSHOP',
           active: false,
           label: 'WORKSHOP',
@@ -794,6 +870,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180384',
           code: 'WITHIN PERIMETER',
           active: false,
           label: 'WITHIN PERIMETER',
@@ -802,6 +879,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180362',
           code: 'ELSEWHERE (ENTER DETAILS)',
           active: false,
           label: 'ELSEWHERE (ENTER DETAILS)',
@@ -810,6 +888,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180364',
           code: 'FUNERAL',
           active: false,
           label: 'FUNERAL',
@@ -818,6 +897,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180368',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: false,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -826,6 +906,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180369',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: false,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -834,6 +915,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180373',
           code: 'OUTSIDE WORKING PARTY',
           active: false,
           label: 'OUTSIDE WORKING PARTY',
@@ -842,6 +924,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180379',
           code: 'SPORTS FIELD',
           active: false,
           label: 'SPORTS FIELD',
@@ -850,6 +933,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180380',
           code: 'VEHICLE',
           active: false,
           label: 'VEHICLE',
@@ -858,6 +942,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180382',
           code: 'WEDDINGS',
           active: false,
           label: 'WEDDINGS',
@@ -866,6 +951,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180371',
           code: 'MAGISTRATES COURT',
           active: false,
           label: 'MAGISTRATES COURT',
@@ -874,6 +960,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44938',
         },
         {
+          id: '180358',
           code: 'CROWN COURT',
           active: false,
           label: 'CROWN COURT',
@@ -891,6 +978,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180471',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -899,6 +987,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44796',
         },
         {
+          id: '180470',
           code: 'PRISONERS',
           active: false,
           label: 'PRISONERS',
@@ -907,6 +996,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44796',
         },
         {
+          id: '180467',
           code: 'CIVILIAN GRADES',
           active: false,
           label: 'CIVILIAN GRADES',
@@ -915,6 +1005,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44796',
         },
         {
+          id: '180469',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -923,6 +1014,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44796',
         },
         {
+          id: '180468',
           code: 'EXTERNAL CIVILIANS',
           active: false,
           label: 'EXTERNAL CIVILIANS',
@@ -940,6 +1032,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180657',
           code: 'LOCAL',
           active: false,
           label: 'LOCAL',
@@ -948,6 +1041,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '180658',
           code: 'SERVICE SUPPLIER',
           active: false,
           label: 'SERVICE SUPPLIER',
@@ -965,6 +1059,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180692',
           code: 'LOCAL',
           active: false,
           label: 'LOCAL',
@@ -973,6 +1068,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44530',
         },
         {
+          id: '180691',
           code: 'SERVICE SUPPLIER',
           active: false,
           label: 'SERVICE SUPPLIER',
@@ -990,6 +1086,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180698',
           code: 'ENTER COMMENT AND DATE',
           active: false,
           label: 'ENTER COMMENT AND DATE',
@@ -1007,6 +1104,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180704',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: false,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -1015,6 +1113,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44563',
         },
         {
+          id: '180705',
           code: 'MINOR BRUISES',
           active: false,
           label: 'MINOR BRUISES',
@@ -1023,6 +1122,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44563',
         },
         {
+          id: '180708',
           code: 'SWELLINGS',
           active: false,
           label: 'SWELLINGS',
@@ -1031,6 +1131,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44563',
         },
         {
+          id: '180707',
           code: 'SUPERFICIAL CUTS',
           active: false,
           label: 'SUPERFICIAL CUTS',
@@ -1039,6 +1140,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44563',
         },
         {
+          id: '180706',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1056,6 +1158,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180805',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1064,6 +1167,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44704',
         },
         {
+          id: '180806',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1081,6 +1185,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180807',
           code: 'ENTER TIME',
           active: false,
           label: 'ENTER TIME',
@@ -1098,6 +1203,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180961',
           code: 'FACILITIES',
           active: false,
           label: 'FACILITIES',
@@ -1106,6 +1212,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44505',
         },
         {
+          id: '180962',
           code: 'FOOD',
           active: false,
           label: 'FOOD',
@@ -1114,6 +1221,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44505',
         },
         {
+          id: '180964',
           code: 'PAY',
           active: false,
           label: 'PAY',
@@ -1122,6 +1230,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44505',
         },
         {
+          id: '180966',
           code: 'VISITS',
           active: false,
           label: 'VISITS',
@@ -1130,6 +1239,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44505',
         },
         {
+          id: '180965',
           code: 'TIME OUT OF CELL',
           active: false,
           label: 'TIME OUT OF CELL',
@@ -1138,6 +1248,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44505',
         },
         {
+          id: '180963',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1155,6 +1266,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181014',
           code: 'FRACTURE',
           active: false,
           label: 'FRACTURE',
@@ -1163,6 +1275,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181016',
           code: 'SCALD OR BURN',
           active: false,
           label: 'SCALD OR BURN',
@@ -1171,6 +1284,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181017',
           code: 'STABBING',
           active: false,
           label: 'STABBING',
@@ -1179,6 +1293,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181011',
           code: 'CRUSHING',
           active: false,
           label: 'CRUSHING',
@@ -1187,6 +1302,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181013',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: false,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -1195,6 +1311,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181008',
           code: 'BLACK EYE',
           active: false,
           label: 'BLACK EYE',
@@ -1203,6 +1320,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181009',
           code: 'BROKEN NOSE',
           active: false,
           label: 'BROKEN NOSE',
@@ -1211,6 +1329,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181010',
           code: 'BROKEN TEETH',
           active: false,
           label: 'BROKEN TEETH',
@@ -1219,6 +1338,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181012',
           code: 'CUTS REQUIRING SUTURES',
           active: false,
           label: 'CUTS REQUIRING SUTURES',
@@ -1227,6 +1347,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181007',
           code: 'BITES',
           active: false,
           label: 'BITES',
@@ -1235,6 +1356,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181015',
           code: 'GUN SHOT WOUND',
           active: false,
           label: 'GUN SHOT WOUND',
@@ -1243,6 +1365,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45083',
         },
         {
+          id: '181018',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: false,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -1260,6 +1383,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181249',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1268,6 +1392,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44174',
         },
         {
+          id: '181250',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1285,6 +1410,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181297',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1293,6 +1419,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44914',
         },
         {
+          id: '181296',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1310,6 +1437,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181438',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1318,6 +1446,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45022',
         },
         {
+          id: '181437',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1335,6 +1464,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181516',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1343,6 +1473,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45086',
         },
         {
+          id: '181515',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1360,6 +1491,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181631',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1368,6 +1500,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44185',
         },
         {
+          id: '181630',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1385,6 +1518,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181728',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1393,6 +1527,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44530',
         },
         {
+          id: '181727',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1410,6 +1545,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181749',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1418,6 +1554,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '45075',
         },
         {
+          id: '181750',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1435,6 +1572,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181779',
           code: 'FULL',
           active: false,
           label: 'FULL',
@@ -1443,6 +1581,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44492',
         },
         {
+          id: '181780',
           code: 'PARTIAL',
           active: false,
           label: 'PARTIAL',
@@ -1460,6 +1599,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181924',
           code: 'DESCRIBE COMPROMISE',
           active: false,
           label: 'DESCRIBE COMPROMISE',
@@ -1477,6 +1617,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182031',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1485,6 +1626,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44515',
         },
         {
+          id: '182030',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1502,6 +1644,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182259',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1510,6 +1653,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44222',
         },
         {
+          id: '182258',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1527,6 +1671,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182270',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1535,6 +1680,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44722',
         },
         {
+          id: '182271',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1552,6 +1698,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182288',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1560,6 +1707,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44634',
         },
         {
+          id: '182289',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1577,6 +1725,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182296',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1585,6 +1734,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
           nextQuestionId: '44816',
         },
         {
+          id: '182295',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1602,6 +1752,7 @@ const OLD_BARRICADE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182628',
           code: 'ENTER HOURS',
           active: false,
           label: 'ENTER HOURS',

--- a/server/reportConfiguration/types/OLD_CONCERTED_INDISCIPLINE.ts
+++ b/server/reportConfiguration/types/OLD_CONCERTED_INDISCIPLINE.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:51.024Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:17.788Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178890',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -23,6 +24,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44979',
         },
         {
+          id: '178889',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -40,6 +42,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178967',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -48,6 +51,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44256',
         },
         {
+          id: '178966',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -65,6 +69,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179016',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -73,6 +78,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44267',
         },
         {
+          id: '179015',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -90,6 +96,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179029',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -98,6 +105,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '45165',
         },
         {
+          id: '179028',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -115,6 +123,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179031',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -123,6 +132,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44216',
         },
         {
+          id: '179030',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -140,6 +150,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179060',
           code: 'NUMBER',
           active: false,
           label: 'NUMBER',
@@ -157,6 +168,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179094',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -165,6 +177,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44783',
         },
         {
+          id: '179095',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -182,6 +195,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179206',
           code: 'TELEPHONY',
           active: false,
           label: 'TELEPHONY',
@@ -190,6 +204,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44562',
         },
         {
+          id: '179205',
           code: 'IT',
           active: false,
           label: 'IT',
@@ -207,6 +222,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179284',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -215,6 +231,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44338',
         },
         {
+          id: '179283',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -232,6 +249,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179323',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -240,6 +258,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44162',
         },
         {
+          id: '179324',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -257,6 +276,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179336',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -265,6 +285,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '45065',
         },
         {
+          id: '179335',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -282,6 +303,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179360',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -290,6 +312,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '45129',
         },
         {
+          id: '179361',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -307,6 +330,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179394',
           code: 'NUMBER',
           active: false,
           label: 'NUMBER',
@@ -324,6 +348,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179433',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -332,6 +357,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44317',
         },
         {
+          id: '179432',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -349,6 +375,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179450',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -357,6 +384,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '45174',
         },
         {
+          id: '179449',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -374,6 +402,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179481',
           code: 'ADMINISTRATION',
           active: false,
           label: 'ADMINISTRATION',
@@ -382,6 +411,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179482',
           code: 'ASSOCIATION AREA',
           active: false,
           label: 'ASSOCIATION AREA',
@@ -390,6 +420,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179483',
           code: 'CELL',
           active: false,
           label: 'CELL',
@@ -398,6 +429,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179484',
           code: 'CHAPEL',
           active: false,
           label: 'CHAPEL',
@@ -406,6 +438,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179486',
           code: 'DINING ROOM',
           active: false,
           label: 'DINING ROOM',
@@ -414,6 +447,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179487',
           code: 'DORMITORY',
           active: false,
           label: 'DORMITORY',
@@ -422,6 +456,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179488',
           code: 'EDUCATION',
           active: false,
           label: 'EDUCATION',
@@ -430,6 +465,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179490',
           code: 'EXERCISE YARD',
           active: false,
           label: 'EXERCISE YARD',
@@ -438,6 +474,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179492',
           code: 'GATE',
           active: false,
           label: 'GATE',
@@ -446,6 +483,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179493',
           code: 'GYM',
           active: false,
           label: 'GYM',
@@ -454,6 +492,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179494',
           code: 'HEALTH CARE CENTRE',
           active: false,
           label: 'HEALTH CARE CENTRE',
@@ -462,6 +501,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179497',
           code: 'KITCHEN',
           active: false,
           label: 'KITCHEN',
@@ -470,6 +510,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179499',
           code: 'OFFICE',
           active: false,
           label: 'OFFICE',
@@ -478,6 +519,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179501',
           code: 'RECEPTION',
           active: false,
           label: 'RECEPTION',
@@ -486,6 +528,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179502',
           code: 'RECESS',
           active: false,
           label: 'RECESS',
@@ -494,6 +537,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179503',
           code: 'SEGREGATION UNIT',
           active: false,
           label: 'SEGREGATION UNIT',
@@ -502,6 +546,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179505',
           code: 'SPECIAL UNIT',
           active: false,
           label: 'SPECIAL UNIT',
@@ -510,6 +555,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179504',
           code: 'SHOWERS/CHANGING ROOM',
           active: false,
           label: 'SHOWERS/CHANGING ROOM',
@@ -518,6 +564,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179508',
           code: 'VISITS',
           active: false,
           label: 'VISITS',
@@ -526,6 +573,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179510',
           code: 'WING',
           active: false,
           label: 'WING',
@@ -534,6 +582,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179512',
           code: 'WORKS DEPARTMENT',
           active: false,
           label: 'WORKS DEPARTMENT',
@@ -542,6 +591,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179513',
           code: 'WORKSHOP',
           active: false,
           label: 'WORKSHOP',
@@ -550,6 +600,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179511',
           code: 'WITHIN PERIMETER',
           active: false,
           label: 'WITHIN PERIMETER',
@@ -558,6 +609,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179489',
           code: 'ELSEWHERE',
           active: false,
           label: 'ELSEWHERE',
@@ -566,6 +618,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179491',
           code: 'FUNERAL',
           active: false,
           label: 'FUNERAL',
@@ -574,6 +627,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179495',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: false,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -582,6 +636,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179496',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: false,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -590,6 +645,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179500',
           code: 'OUTSIDE WORKING PARTY',
           active: false,
           label: 'OUTSIDE WORKING PARTY',
@@ -598,6 +654,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179506',
           code: 'SPORTS FIELD',
           active: false,
           label: 'SPORTS FIELD',
@@ -606,6 +663,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179507',
           code: 'VEHICLE',
           active: false,
           label: 'VEHICLE',
@@ -614,6 +672,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179509',
           code: 'WEDDINGS',
           active: false,
           label: 'WEDDINGS',
@@ -622,6 +681,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179498',
           code: 'MAGISTRATES COURT',
           active: false,
           label: 'MAGISTRATES COURT',
@@ -630,6 +690,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44910',
         },
         {
+          id: '179485',
           code: 'CROWN COURT',
           active: false,
           label: 'CROWN COURT',
@@ -647,6 +708,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179552',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -655,6 +717,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '45045',
         },
         {
+          id: '179551',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -672,6 +735,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179630',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -680,6 +744,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44483',
         },
         {
+          id: '179629',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -697,6 +762,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179637',
           code: 'NUMBER OF HOURS',
           active: false,
           label: 'NUMBER OF HOURS',
@@ -714,6 +780,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179809',
           code: 'MINOR',
           active: false,
           label: 'MINOR',
@@ -722,6 +789,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44661',
         },
         {
+          id: '179810',
           code: 'SERIOUS',
           active: false,
           label: 'SERIOUS',
@@ -730,6 +798,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44661',
         },
         {
+          id: '179808',
           code: 'EXTENSIVE',
           active: false,
           label: 'EXTENSIVE',
@@ -747,6 +816,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179940',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -755,6 +825,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44654',
         },
         {
+          id: '179941',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -772,6 +843,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180154',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -780,6 +852,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44656',
         },
         {
+          id: '180155',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -797,6 +870,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180352',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -805,6 +879,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44877',
         },
         {
+          id: '180353',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -822,6 +897,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180435',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -830,6 +906,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44623',
         },
         {
+          id: '180434',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -847,6 +924,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180466',
           code: 'ENTER TIME',
           active: false,
           label: 'ENTER TIME',
@@ -864,6 +942,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180509',
           code: 'FULL',
           active: false,
           label: 'FULL',
@@ -872,6 +951,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44809',
         },
         {
+          id: '180510',
           code: 'PARTIAL',
           active: false,
           label: 'PARTIAL',
@@ -889,6 +969,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180663',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -897,6 +978,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44917',
         },
         {
+          id: '180662',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -914,6 +996,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180765',
           code: 'FIREARM',
           active: false,
           label: 'FIREARM',
@@ -922,6 +1005,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180762',
           code: 'CHEMICAL INCAPACITANT',
           active: false,
           label: 'CHEMICAL INCAPACITANT',
@@ -930,6 +1014,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180767',
           code: 'KNIFE/BLADE',
           active: false,
           label: 'KNIFE/BLADE',
@@ -938,6 +1023,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180770',
           code: 'OTHER SHARP INSTRUMENT',
           active: false,
           label: 'OTHER SHARP INSTRUMENT',
@@ -946,6 +1032,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180761',
           code: 'BLUNT INSTRUMENT',
           active: false,
           label: 'BLUNT INSTRUMENT',
@@ -954,6 +1041,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180768',
           code: 'LIGATURE',
           active: false,
           label: 'LIGATURE',
@@ -962,6 +1050,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180763',
           code: 'DANGEROUS LIQUID',
           active: false,
           label: 'DANGEROUS LIQUID',
@@ -970,6 +1059,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180764',
           code: 'EXCRETA/URINE',
           active: false,
           label: 'EXCRETA/URINE',
@@ -978,6 +1068,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180771',
           code: 'SPITTING',
           active: false,
           label: 'SPITTING',
@@ -986,6 +1077,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180766',
           code: 'FOOD',
           active: false,
           label: 'FOOD',
@@ -994,6 +1086,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180773',
           code: 'THROWN FURNITURE',
           active: false,
           label: 'THROWN FURNITURE',
@@ -1002,6 +1095,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180772',
           code: 'THROWN EQUIPMENT',
           active: false,
           label: 'THROWN EQUIPMENT',
@@ -1010,6 +1104,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44336',
         },
         {
+          id: '180769',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1027,6 +1122,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180776',
           code: 'FACILITIES',
           active: false,
           label: 'FACILITIES',
@@ -1035,6 +1131,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44738',
         },
         {
+          id: '180777',
           code: 'FOOD',
           active: false,
           label: 'FOOD',
@@ -1043,6 +1140,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44738',
         },
         {
+          id: '180779',
           code: 'PAY',
           active: false,
           label: 'PAY',
@@ -1051,6 +1149,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44738',
         },
         {
+          id: '180781',
           code: 'VISITS',
           active: false,
           label: 'VISITS',
@@ -1059,6 +1158,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44738',
         },
         {
+          id: '180780',
           code: 'TIME OUT OF CELL',
           active: false,
           label: 'TIME OUT OF CELL',
@@ -1067,6 +1167,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44738',
         },
         {
+          id: '180778',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1084,6 +1185,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180798',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: false,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -1101,6 +1203,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180799',
           code: 'LOCAL',
           active: false,
           label: 'LOCAL',
@@ -1109,6 +1212,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '180800',
           code: 'SERVICE SUPPLIER',
           active: false,
           label: 'SERVICE SUPPLIER',
@@ -1126,6 +1230,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180802',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1134,6 +1239,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44684',
         },
         {
+          id: '180801',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1151,6 +1257,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180845',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1159,6 +1266,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44867',
         },
         {
+          id: '180844',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1176,6 +1284,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180856',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1184,6 +1293,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44296',
         },
         {
+          id: '180855',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1201,6 +1311,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180918',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -1209,6 +1320,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44884',
         },
         {
+          id: '180917',
           code: 'PRISONERS',
           active: false,
           label: 'PRISONERS',
@@ -1217,6 +1329,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44884',
         },
         {
+          id: '180914',
           code: 'CIVILIAN GRADES',
           active: false,
           label: 'CIVILIAN GRADES',
@@ -1225,6 +1338,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44884',
         },
         {
+          id: '180916',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -1233,6 +1347,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44884',
         },
         {
+          id: '180915',
           code: 'EXTERNAL CIVILIANS',
           active: false,
           label: 'EXTERNAL CIVILIANS',
@@ -1250,6 +1365,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181028',
           code: 'FRACTURE',
           active: false,
           label: 'FRACTURE',
@@ -1258,6 +1374,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181030',
           code: 'SCALD OR BURN',
           active: false,
           label: 'SCALD OR BURN',
@@ -1266,6 +1383,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181031',
           code: 'STABBING',
           active: false,
           label: 'STABBING',
@@ -1274,6 +1392,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181025',
           code: 'CRUSHING',
           active: false,
           label: 'CRUSHING',
@@ -1282,6 +1401,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181027',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: false,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -1290,6 +1410,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181022',
           code: 'BLACK EYE',
           active: false,
           label: 'BLACK EYE',
@@ -1298,6 +1419,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181023',
           code: 'BROKEN NOSE',
           active: false,
           label: 'BROKEN NOSE',
@@ -1306,6 +1428,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181024',
           code: 'BROKEN TEETH',
           active: false,
           label: 'BROKEN TEETH',
@@ -1314,6 +1437,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181026',
           code: 'CUTS REQUIRING SUTURES',
           active: false,
           label: 'CUTS REQUIRING SUTURES',
@@ -1322,6 +1446,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181021',
           code: 'BITES',
           active: false,
           label: 'BITES',
@@ -1330,6 +1455,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181029',
           code: 'GUN SHOT WOUND',
           active: false,
           label: 'GUN SHOT WOUND',
@@ -1338,6 +1464,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44531',
         },
         {
+          id: '181032',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: false,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -1355,6 +1482,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181068',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -1363,6 +1491,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44973',
         },
         {
+          id: '181067',
           code: 'PRISONERS',
           active: false,
           label: 'PRISONERS',
@@ -1371,6 +1500,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44973',
         },
         {
+          id: '181064',
           code: 'CIVILIAN GRADES',
           active: false,
           label: 'CIVILIAN GRADES',
@@ -1379,6 +1509,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44973',
         },
         {
+          id: '181066',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -1387,6 +1518,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44973',
         },
         {
+          id: '181065',
           code: 'EXTERNAL CIVILIANS',
           active: false,
           label: 'EXTERNAL CIVILIANS',
@@ -1404,6 +1536,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181075',
           code: 'ACTIVE',
           active: false,
           label: 'ACTIVE',
@@ -1412,6 +1545,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44760',
         },
         {
+          id: '181076',
           code: 'PASSIVE',
           active: false,
           label: 'PASSIVE',
@@ -1429,6 +1563,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181105',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1437,6 +1572,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44304',
         },
         {
+          id: '181106',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1454,6 +1590,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181122',
           code: 'LOCAL',
           active: false,
           label: 'LOCAL',
@@ -1462,6 +1599,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44216',
         },
         {
+          id: '181121',
           code: 'SERVICE SUPPLIER',
           active: false,
           label: 'SERVICE SUPPLIER',
@@ -1479,6 +1617,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181126',
           code: 'NEGOTIATION',
           active: false,
           label: 'NEGOTIATION',
@@ -1487,6 +1626,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44170',
         },
         {
+          id: '181125',
           code: 'INTERVENTION',
           active: false,
           label: 'INTERVENTION',
@@ -1495,6 +1635,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44170',
         },
         {
+          id: '181127',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1512,6 +1653,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181141',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1520,6 +1662,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '45013',
         },
         {
+          id: '181142',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1537,6 +1680,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181167',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1545,6 +1689,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44140',
         },
         {
+          id: '181166',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1562,6 +1707,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181185',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1570,6 +1716,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44774',
         },
         {
+          id: '181184',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1587,6 +1734,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181279',
           code: 'GOVERNOR',
           active: false,
           label: 'GOVERNOR',
@@ -1595,6 +1743,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44764',
         },
         {
+          id: '181277',
           code: 'DEPUTY GOVERNOR',
           active: false,
           label: 'DEPUTY GOVERNOR',
@@ -1603,6 +1752,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44764',
         },
         {
+          id: '181278',
           code: 'DUTY GOVERNOR',
           active: false,
           label: 'DUTY GOVERNOR',
@@ -1611,6 +1761,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44764',
         },
         {
+          id: '181280',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1628,6 +1779,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181281',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1636,6 +1788,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44758',
         },
         {
+          id: '181282',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1653,6 +1806,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181453',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1661,6 +1815,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44663',
         },
         {
+          id: '181452',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1678,6 +1833,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181507',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: false,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -1686,6 +1842,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44734',
         },
         {
+          id: '181508',
           code: 'MINOR BRUISES',
           active: false,
           label: 'MINOR BRUISES',
@@ -1694,6 +1851,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44734',
         },
         {
+          id: '181511',
           code: 'SWELLINGS',
           active: false,
           label: 'SWELLINGS',
@@ -1702,6 +1860,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44734',
         },
         {
+          id: '181510',
           code: 'SUPERFICIAL CUTS',
           active: false,
           label: 'SUPERFICIAL CUTS',
@@ -1710,6 +1869,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44734',
         },
         {
+          id: '181509',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1727,6 +1887,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181533',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1735,6 +1896,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44679',
         },
         {
+          id: '181532',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1752,6 +1914,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181584',
           code: 'ENTER COMMENT AND DATE',
           active: false,
           label: 'ENTER COMMENT AND DATE',
@@ -1769,6 +1932,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181623',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1777,6 +1941,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44182',
         },
         {
+          id: '181622',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1794,6 +1959,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181640',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1802,6 +1968,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44122',
         },
         {
+          id: '181639',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1819,6 +1986,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181882',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1827,6 +1995,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44697',
         },
         {
+          id: '181883',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1844,6 +2013,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181903',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1852,6 +2022,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44238',
         },
         {
+          id: '181902',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1869,6 +2040,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181993',
           code: 'DESCRIPTION',
           active: false,
           label: 'DESCRIPTION',
@@ -1886,6 +2058,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182163',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1894,6 +2067,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44161',
         },
         {
+          id: '182162',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1911,6 +2085,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182246',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1919,6 +2094,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44156',
         },
         {
+          id: '182245',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1936,6 +2112,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182419',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1944,6 +2121,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44387',
         },
         {
+          id: '182420',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1961,6 +2139,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182465',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1969,6 +2148,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44724',
         },
         {
+          id: '182466',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1986,6 +2166,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182570',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1994,6 +2175,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '45117',
         },
         {
+          id: '182569',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -2011,6 +2193,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182593',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -2019,6 +2202,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44299',
         },
         {
+          id: '182592',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -2036,6 +2220,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182609',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -2044,6 +2229,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '45158',
         },
         {
+          id: '182608',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -2061,6 +2247,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182642',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -2069,6 +2256,7 @@ const OLD_CONCERTED_INDISCIPLINE: IncidentTypeConfiguration = {
           nextQuestionId: '44438',
         },
         {
+          id: '182641',
           code: 'NO',
           active: false,
           label: 'NO',

--- a/server/reportConfiguration/types/OLD_DISORDER.ts
+++ b/server/reportConfiguration/types/OLD_DISORDER.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:56.006Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:22.789Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194684',
           code: 'Barricade / Prevention Of Access',
           active: false,
           label: 'Barricade / Prevention Of Access',
@@ -23,6 +24,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49180',
         },
         {
+          id: '194685',
           code: 'Hostage',
           active: false,
           label: 'Hostage',
@@ -31,6 +33,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49180',
         },
         {
+          id: '194686',
           code: 'Incident At Height',
           active: false,
           label: 'Incident At Height',
@@ -39,6 +42,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49180',
         },
         {
+          id: '194687',
           code: 'Concerted Indiscipline',
           active: false,
           label: 'Concerted Indiscipline',
@@ -56,6 +60,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194688',
           code: 'No Further Action',
           active: false,
           label: 'No Further Action',
@@ -64,6 +69,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49181',
         },
         {
+          id: '194689',
           code: 'IEP Regression',
           active: false,
           label: 'IEP Regression',
@@ -72,6 +78,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49181',
         },
         {
+          id: '194690',
           code: 'Placed On Report/Adjudication Referral',
           active: false,
           label: 'Placed On Report/Adjudication Referral',
@@ -80,6 +87,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49181',
         },
         {
+          id: '194691',
           code: 'Police Referral',
           active: false,
           label: 'Police Referral',
@@ -88,6 +96,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49181',
         },
         {
+          id: '194692',
           code: 'Police And Prosecution Referral',
           active: false,
           label: 'Police And Prosecution Referral',
@@ -105,6 +114,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194693',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -113,6 +123,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49182',
         },
         {
+          id: '194694',
           code: 'No',
           active: false,
           label: 'No',
@@ -130,6 +141,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194695',
           code: 'Administration',
           active: false,
           label: 'Administration',
@@ -138,6 +150,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194696',
           code: 'Association Area',
           active: false,
           label: 'Association Area',
@@ -146,6 +159,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194697',
           code: 'Cell',
           active: false,
           label: 'Cell',
@@ -154,6 +168,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194698',
           code: 'Chapel',
           active: false,
           label: 'Chapel',
@@ -162,6 +177,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194699',
           code: 'Crown Court',
           active: false,
           label: 'Crown Court',
@@ -170,6 +186,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194700',
           code: 'Dining Room',
           active: true,
           label: 'Dining Room',
@@ -178,6 +195,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194701',
           code: 'Dormitory',
           active: true,
           label: 'Dormitory',
@@ -186,6 +204,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194702',
           code: 'Education',
           active: true,
           label: 'Education',
@@ -194,6 +213,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194703',
           code: 'Elsewhere (Enter Details)',
           active: true,
           label: 'Elsewhere (Enter Details)',
@@ -202,6 +222,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194704',
           code: 'Exercise Yard',
           active: true,
           label: 'Exercise Yard',
@@ -210,6 +231,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194705',
           code: 'Funeral',
           active: true,
           label: 'Funeral',
@@ -218,6 +240,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194706',
           code: 'Gate',
           active: true,
           label: 'Gate',
@@ -226,6 +249,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194707',
           code: 'Gym',
           active: true,
           label: 'Gym',
@@ -234,6 +258,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194708',
           code: 'Health Care Centre',
           active: true,
           label: 'Health Care Centre',
@@ -242,6 +267,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194709',
           code: 'Hospital Outside (Patient)',
           active: true,
           label: 'Hospital Outside (Patient)',
@@ -250,6 +276,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194710',
           code: 'Hospital Outside (Visiting)',
           active: true,
           label: 'Hospital Outside (Visiting)',
@@ -258,6 +285,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194711',
           code: 'Kitchen',
           active: true,
           label: 'Kitchen',
@@ -266,6 +294,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194712',
           code: 'Magistrates Court',
           active: true,
           label: 'Magistrates Court',
@@ -274,6 +303,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194713',
           code: 'Office',
           active: true,
           label: 'Office',
@@ -282,6 +312,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194714',
           code: 'Outside Working Party',
           active: true,
           label: 'Outside Working Party',
@@ -290,6 +321,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194715',
           code: 'Reception',
           active: true,
           label: 'Reception',
@@ -298,6 +330,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194716',
           code: 'Recess',
           active: true,
           label: 'Recess',
@@ -306,6 +339,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194717',
           code: 'Segregation Unit',
           active: true,
           label: 'Segregation Unit',
@@ -314,6 +348,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194718',
           code: 'Showers / Changing Room',
           active: true,
           label: 'Showers / Changing Room',
@@ -322,6 +357,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194719',
           code: 'Special Unit',
           active: true,
           label: 'Special Unit',
@@ -330,6 +366,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194720',
           code: 'Sports Field',
           active: true,
           label: 'Sports Field',
@@ -338,6 +375,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194721',
           code: 'Vehicle',
           active: true,
           label: 'Vehicle',
@@ -346,6 +384,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194722',
           code: 'Visits',
           active: true,
           label: 'Visits',
@@ -354,6 +393,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194723',
           code: 'Weddings',
           active: true,
           label: 'Weddings',
@@ -362,6 +402,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194724',
           code: 'Wing',
           active: true,
           label: 'Wing',
@@ -370,6 +411,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194725',
           code: 'Within Perimeter',
           active: true,
           label: 'Within Perimeter',
@@ -378,6 +420,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194726',
           code: 'Works Department',
           active: true,
           label: 'Works Department',
@@ -386,6 +429,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194727',
           code: 'Workshop',
           active: true,
           label: 'Workshop',
@@ -394,6 +438,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194728',
           code: 'Induction / 1st Night Centre',
           active: true,
           label: 'Induction / 1st Night Centre',
@@ -402,6 +447,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194729',
           code: 'External Roof',
           active: true,
           label: 'External Roof',
@@ -410,6 +456,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49183',
         },
         {
+          id: '194730',
           code: 'Vulnerable Prisoners Unit',
           active: true,
           label: 'Vulnerable Prisoners Unit',
@@ -427,6 +474,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194731',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -435,6 +483,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49184',
         },
         {
+          id: '194732',
           code: 'No',
           active: false,
           label: 'No',
@@ -452,6 +501,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194733',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -460,6 +510,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49185',
         },
         {
+          id: '194734',
           code: 'No',
           active: false,
           label: 'No',
@@ -477,6 +528,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194735',
           code: 'Bites',
           active: false,
           label: 'Bites',
@@ -485,6 +537,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194736',
           code: 'Black Eye',
           active: false,
           label: 'Black Eye',
@@ -493,6 +546,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194737',
           code: 'Broken Nose',
           active: false,
           label: 'Broken Nose',
@@ -501,6 +555,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194738',
           code: 'Broken Teeth',
           active: false,
           label: 'Broken Teeth',
@@ -509,6 +564,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194739',
           code: 'Crushing',
           active: false,
           label: 'Crushing',
@@ -517,6 +573,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194740',
           code: 'Cuts Requiring Sutures',
           active: false,
           label: 'Cuts Requiring Sutures',
@@ -525,6 +582,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194741',
           code: 'Extensive / Mutliple Bruising',
           active: false,
           label: 'Extensive / Mutliple Bruising',
@@ -533,6 +591,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194742',
           code: 'Fracture',
           active: false,
           label: 'Fracture',
@@ -541,6 +600,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194743',
           code: 'Gun Shot Wound',
           active: false,
           label: 'Gun Shot Wound',
@@ -549,6 +609,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194744',
           code: 'Scald Or Burn',
           active: false,
           label: 'Scald Or Burn',
@@ -557,6 +618,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194745',
           code: 'Stabbing',
           active: false,
           label: 'Stabbing',
@@ -565,6 +627,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49186',
         },
         {
+          id: '194746',
           code: 'Temporary / Permanent Blindness',
           active: false,
           label: 'Temporary / Permanent Blindness',
@@ -582,6 +645,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194747',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -590,6 +654,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49187',
         },
         {
+          id: '194748',
           code: 'No',
           active: false,
           label: 'No',
@@ -607,6 +672,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194749',
           code: 'Grazes. Scratches or Abrasions',
           active: false,
           label: 'Grazes. Scratches or Abrasions',
@@ -615,6 +681,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49188',
         },
         {
+          id: '194750',
           code: 'Minor Bruises',
           active: false,
           label: 'Minor Bruises',
@@ -623,6 +690,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49188',
         },
         {
+          id: '194751',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -631,6 +699,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49188',
         },
         {
+          id: '194752',
           code: 'Superficial Cuts',
           active: false,
           label: 'Superficial Cuts',
@@ -639,6 +708,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49188',
         },
         {
+          id: '194753',
           code: 'Swellings',
           active: false,
           label: 'Swellings',
@@ -656,6 +726,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194754',
           code: 'Civilian Grades',
           active: false,
           label: 'Civilian Grades',
@@ -664,6 +735,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49189',
         },
         {
+          id: '194755',
           code: 'External Citizens',
           active: false,
           label: 'External Citizens',
@@ -672,6 +744,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49189',
         },
         {
+          id: '194756',
           code: 'Police',
           active: false,
           label: 'Police',
@@ -680,6 +753,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49189',
         },
         {
+          id: '194757',
           code: 'Prisoners',
           active: false,
           label: 'Prisoners',
@@ -688,6 +762,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49189',
         },
         {
+          id: '194758',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -705,6 +780,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194759',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -713,6 +789,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49190',
         },
         {
+          id: '194760',
           code: 'No',
           active: false,
           label: 'No',
@@ -730,6 +807,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194761',
           code: 'Civilian Grades',
           active: false,
           label: 'Civilian Grades',
@@ -738,6 +816,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49191',
         },
         {
+          id: '194762',
           code: 'External Civilians',
           active: false,
           label: 'External Civilians',
@@ -746,6 +825,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49191',
         },
         {
+          id: '194763',
           code: 'Police',
           active: false,
           label: 'Police',
@@ -754,6 +834,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49191',
         },
         {
+          id: '194764',
           code: 'Prisoners',
           active: false,
           label: 'Prisoners',
@@ -762,6 +843,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49192',
         },
         {
+          id: '194765',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -779,6 +861,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194766',
           code: 'No',
           active: false,
           label: 'No',
@@ -787,6 +870,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49192',
         },
         {
+          id: '194767',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -804,6 +888,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194768',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -812,6 +897,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49193',
         },
         {
+          id: '194769',
           code: 'No',
           active: false,
           label: 'No',
@@ -829,6 +915,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194770',
           code: 'Facilities',
           active: false,
           label: 'Facilities',
@@ -837,6 +924,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49194',
         },
         {
+          id: '194771',
           code: 'Food',
           active: false,
           label: 'Food',
@@ -845,6 +933,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49194',
         },
         {
+          id: '194772',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -853,6 +942,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49194',
         },
         {
+          id: '194773',
           code: 'Pay',
           active: false,
           label: 'Pay',
@@ -861,6 +951,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49194',
         },
         {
+          id: '194774',
           code: 'Time Out Of Cell',
           active: false,
           label: 'Time Out Of Cell',
@@ -869,6 +960,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49194',
         },
         {
+          id: '194775',
           code: 'Visits',
           active: false,
           label: 'Visits',
@@ -877,6 +969,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49194',
         },
         {
+          id: '194776',
           code: 'Demanding Internal Transfer',
           active: false,
           label: 'Demanding Internal Transfer',
@@ -885,6 +978,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49194',
         },
         {
+          id: '194777',
           code: 'Refusing Internal Transfer',
           active: false,
           label: 'Refusing Internal Transfer',
@@ -893,6 +987,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49194',
         },
         {
+          id: '194778',
           code: 'Demanding External Transfer',
           active: false,
           label: 'Demanding External Transfer',
@@ -901,6 +996,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49194',
         },
         {
+          id: '194779',
           code: 'Refusing External Transfer',
           active: false,
           label: 'Refusing External Transfer',
@@ -918,6 +1014,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194780',
           code: 'Negotiation',
           active: false,
           label: 'Negotiation',
@@ -926,6 +1023,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49195',
         },
         {
+          id: '194781',
           code: 'Intervention (Local Staff)',
           active: false,
           label: 'Intervention (Local Staff)',
@@ -934,6 +1032,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49195',
         },
         {
+          id: '194782',
           code: 'Intervention (NTRG Staff)',
           active: false,
           label: 'Intervention (NTRG Staff)',
@@ -942,6 +1041,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49195',
         },
         {
+          id: '194783',
           code: 'Complied With Order Or Instruction',
           active: false,
           label: 'Complied With Order Or Instruction',
@@ -950,6 +1050,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49195',
         },
         {
+          id: '194784',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -967,6 +1068,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194785',
           code: 'No',
           active: false,
           label: 'No',
@@ -975,6 +1077,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49196',
         },
         {
+          id: '194786',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -992,6 +1095,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194787',
           code: 'No',
           active: false,
           label: 'No',
@@ -1000,6 +1104,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49197',
         },
         {
+          id: '194788',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1017,6 +1122,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194789',
           code: 'No',
           active: false,
           label: 'No',
@@ -1025,6 +1131,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49198',
         },
         {
+          id: '194790',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1042,6 +1149,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194791',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1050,6 +1158,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49199',
         },
         {
+          id: '194792',
           code: 'No',
           active: false,
           label: 'No',
@@ -1067,6 +1176,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194793',
           code: 'Blunt Instrument',
           active: false,
           label: 'Blunt Instrument',
@@ -1075,6 +1185,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194794',
           code: 'Chemical Incapicitant',
           active: false,
           label: 'Chemical Incapicitant',
@@ -1083,6 +1194,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194795',
           code: 'Dangerous Liquid',
           active: false,
           label: 'Dangerous Liquid',
@@ -1091,6 +1203,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194796',
           code: 'Excreta/Urine',
           active: false,
           label: 'Excreta/Urine',
@@ -1099,6 +1212,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194797',
           code: 'Firearm',
           active: false,
           label: 'Firearm',
@@ -1107,6 +1221,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194798',
           code: 'Food',
           active: false,
           label: 'Food',
@@ -1115,6 +1230,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194799',
           code: 'Knife / Blade',
           active: false,
           label: 'Knife / Blade',
@@ -1123,6 +1239,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194800',
           code: 'Ligature',
           active: false,
           label: 'Ligature',
@@ -1131,6 +1248,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194801',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -1139,6 +1257,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194802',
           code: 'Other Sharp Instrument',
           active: false,
           label: 'Other Sharp Instrument',
@@ -1147,6 +1266,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194803',
           code: 'Spitting',
           active: false,
           label: 'Spitting',
@@ -1155,6 +1275,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194804',
           code: 'Thrown Equipment',
           active: false,
           label: 'Thrown Equipment',
@@ -1163,6 +1284,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49200',
         },
         {
+          id: '194805',
           code: 'Thrown Furniture',
           active: false,
           label: 'Thrown Furniture',
@@ -1180,6 +1302,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194806',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1188,6 +1311,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49201',
         },
         {
+          id: '194807',
           code: 'No',
           active: false,
           label: 'No',
@@ -1205,6 +1329,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194808',
           code: 'Extensive',
           active: false,
           label: 'Extensive',
@@ -1213,6 +1338,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49202',
         },
         {
+          id: '194809',
           code: 'Minor',
           active: false,
           label: 'Minor',
@@ -1221,6 +1347,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49202',
         },
         {
+          id: '194810',
           code: 'Serious',
           active: false,
           label: 'Serious',
@@ -1238,6 +1365,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194811',
           code: '£0',
           active: false,
           label: '£0',
@@ -1246,6 +1374,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194812',
           code: '£1 to £20',
           active: false,
           label: '£1 to £20',
@@ -1254,6 +1383,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194813',
           code: '£21 to £50',
           active: false,
           label: '£21 to £50',
@@ -1262,6 +1392,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194814',
           code: '£51 to £100',
           active: false,
           label: '£51 to £100',
@@ -1270,6 +1401,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194815',
           code: '£101 to £500',
           active: false,
           label: '£101 to £500',
@@ -1278,6 +1410,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194816',
           code: '£501 to £1,000',
           active: false,
           label: '£501 to £1,000',
@@ -1286,6 +1419,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194817',
           code: '£1,001 to £5,000',
           active: false,
           label: '£1,001 to £5,000',
@@ -1294,6 +1428,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194818',
           code: '£5001 to £10,000',
           active: false,
           label: '£5001 to £10,000',
@@ -1302,6 +1437,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194819',
           code: '£10,001 to £50,000',
           active: false,
           label: '£10,001 to £50,000',
@@ -1310,6 +1446,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194820',
           code: '£50,001 to £100,000',
           active: false,
           label: '£50,001 to £100,000',
@@ -1318,6 +1455,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194821',
           code: '> £100,000',
           active: false,
           label: '> £100,000',
@@ -1326,6 +1464,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49203',
         },
         {
+          id: '194822',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -1343,6 +1482,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194823',
           code: '< 1 Minute',
           active: false,
           label: '< 1 Minute',
@@ -1351,6 +1491,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194824',
           code: '1 Min to < 5 Mins',
           active: false,
           label: '1 Min to < 5 Mins',
@@ -1359,6 +1500,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194825',
           code: '5 Mins to < 10 Mins',
           active: false,
           label: '5 Mins to < 10 Mins',
@@ -1367,6 +1509,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194826',
           code: '10 Mins to < 15 Mins',
           active: false,
           label: '10 Mins to < 15 Mins',
@@ -1375,6 +1518,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194827',
           code: '15 Mins to < 30 Mins',
           active: false,
           label: '15 Mins to < 30 Mins',
@@ -1383,6 +1527,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194828',
           code: '30 Mins to < 1 Hour',
           active: false,
           label: '30 Mins to < 1 Hour',
@@ -1391,6 +1536,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194829',
           code: '1 Hour to < 2 Hours',
           active: false,
           label: '1 Hour to < 2 Hours',
@@ -1399,6 +1545,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194830',
           code: '2 Hours to < 3 Hours',
           active: false,
           label: '2 Hours to < 3 Hours',
@@ -1407,6 +1554,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194831',
           code: '3 Hours to < 4 Hours',
           active: false,
           label: '3 Hours to < 4 Hours',
@@ -1415,6 +1563,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194832',
           code: '4 Hours to < 5 Hours',
           active: false,
           label: '4 Hours to < 5 Hours',
@@ -1423,6 +1572,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194833',
           code: '5 Hours Plus',
           active: false,
           label: '5 Hours Plus',
@@ -1431,6 +1581,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49204',
         },
         {
+          id: '194834',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -1448,6 +1599,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194835',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1456,6 +1608,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49205',
         },
         {
+          id: '194836',
           code: 'No',
           active: false,
           label: 'No',
@@ -1473,6 +1626,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194837',
           code: 'Service Supplier',
           active: false,
           label: 'Service Supplier',
@@ -1481,6 +1635,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49206',
         },
         {
+          id: '194838',
           code: 'Local',
           active: false,
           label: 'Local',
@@ -1498,6 +1653,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194839',
           code: 'Enter Number',
           active: false,
           label: 'Enter Number',
@@ -1515,6 +1671,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194840',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1523,6 +1680,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49208',
         },
         {
+          id: '194841',
           code: 'No',
           active: false,
           label: 'No',
@@ -1540,6 +1698,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194842',
           code: 'No',
           active: false,
           label: 'No',
@@ -1548,6 +1707,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49209',
         },
         {
+          id: '194843',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1565,6 +1725,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194844',
           code: 'IT',
           active: false,
           label: 'IT',
@@ -1573,6 +1734,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49210',
         },
         {
+          id: '194845',
           code: 'Telephony',
           active: false,
           label: 'Telephony',
@@ -1590,6 +1752,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194846',
           code: 'Enter Time',
           active: false,
           label: 'Enter Time',
@@ -1607,6 +1770,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194847',
           code: 'Full',
           active: false,
           label: 'Full',
@@ -1615,6 +1779,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49212',
         },
         {
+          id: '194848',
           code: 'Partial',
           active: false,
           label: 'Partial',
@@ -1632,6 +1797,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194849',
           code: 'Deputy Governor',
           active: false,
           label: 'Deputy Governor',
@@ -1640,6 +1806,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49213',
         },
         {
+          id: '194850',
           code: 'Duty Governor',
           active: false,
           label: 'Duty Governor',
@@ -1648,6 +1815,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49213',
         },
         {
+          id: '194851',
           code: 'Governor',
           active: false,
           label: 'Governor',
@@ -1656,6 +1824,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49213',
         },
         {
+          id: '194852',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -1673,6 +1842,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194853',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1681,6 +1851,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49214',
         },
         {
+          id: '194854',
           code: 'No',
           active: false,
           label: 'No',
@@ -1698,6 +1869,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194855',
           code: 'Describe Compromise',
           active: false,
           label: 'Describe Compromise',
@@ -1715,6 +1887,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194856',
           code: 'Enter Comment And Date',
           active: false,
           label: 'Enter Comment And Date',
@@ -1732,6 +1905,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194857',
           code: 'Local',
           active: false,
           label: 'Local',
@@ -1740,6 +1914,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49217',
         },
         {
+          id: '194858',
           code: 'Service Supplier',
           active: false,
           label: 'Service Supplier',
@@ -1757,6 +1932,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194859',
           code: 'No',
           active: false,
           label: 'No',
@@ -1765,6 +1941,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49218',
         },
         {
+          id: '194860',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1782,6 +1959,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194861',
           code: 'No',
           active: false,
           label: 'No',
@@ -1790,6 +1968,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49219',
         },
         {
+          id: '194862',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1807,6 +1986,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194863',
           code: 'No',
           active: false,
           label: 'No',
@@ -1815,6 +1995,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49220',
         },
         {
+          id: '194864',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1832,6 +2013,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194865',
           code: 'No',
           active: false,
           label: 'No',
@@ -1840,6 +2022,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49221',
         },
         {
+          id: '194866',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1857,6 +2040,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194867',
           code: 'No',
           active: false,
           label: 'No',
@@ -1865,6 +2049,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49222',
         },
         {
+          id: '194868',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1882,6 +2067,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194869',
           code: 'No',
           active: false,
           label: 'No',
@@ -1890,6 +2076,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49223',
         },
         {
+          id: '194870',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1907,6 +2094,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194871',
           code: 'No',
           active: false,
           label: 'No',
@@ -1915,6 +2103,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49224',
         },
         {
+          id: '194872',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1923,6 +2112,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49225',
         },
         {
+          id: '194873',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1940,6 +2130,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194874',
           code: 'No',
           active: false,
           label: 'No',
@@ -1948,6 +2139,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49225',
         },
         {
+          id: '194875',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1965,6 +2157,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194876',
           code: 'No',
           active: false,
           label: 'No',
@@ -1973,6 +2166,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49226',
         },
         {
+          id: '194877',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1990,6 +2184,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194878',
           code: 'No',
           active: false,
           label: 'No',
@@ -1998,6 +2193,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49227',
         },
         {
+          id: '194879',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2015,6 +2211,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194880',
           code: 'No',
           active: false,
           label: 'No',
@@ -2023,6 +2220,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49228',
         },
         {
+          id: '194881',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2040,6 +2238,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194882',
           code: 'No',
           active: false,
           label: 'No',
@@ -2048,6 +2247,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49229',
         },
         {
+          id: '194883',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2065,6 +2265,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194884',
           code: 'No',
           active: false,
           label: 'No',
@@ -2073,6 +2274,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49230',
         },
         {
+          id: '194885',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2090,6 +2292,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194886',
           code: 'Active',
           active: false,
           label: 'Active',
@@ -2098,6 +2301,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49231',
         },
         {
+          id: '194887',
           code: 'Passive',
           active: false,
           label: 'Passive',
@@ -2115,6 +2319,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194888',
           code: 'State Number',
           active: false,
           label: 'State Number',
@@ -2123,6 +2328,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49232',
         },
         {
+          id: '194900',
           code: 'State Number',
           active: false,
           label: 'State Number',
@@ -2140,6 +2346,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194889',
           code: 'No',
           active: false,
           label: 'No',
@@ -2148,6 +2355,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49234',
         },
         {
+          id: '194890',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2165,6 +2373,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194891',
           code: 'No',
           active: false,
           label: 'No',
@@ -2173,6 +2382,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49234',
         },
         {
+          id: '194892',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2190,6 +2400,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194893',
           code: 'No',
           active: false,
           label: 'No',
@@ -2198,6 +2409,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49235',
         },
         {
+          id: '194894',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2215,6 +2427,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194895',
           code: 'No',
           active: false,
           label: 'No',
@@ -2223,6 +2436,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49236',
         },
         {
+          id: '194896',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2240,6 +2454,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194897',
           code: 'No',
           active: false,
           label: 'No',
@@ -2248,6 +2463,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49237',
         },
         {
+          id: '194898',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2265,6 +2481,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194899',
           code: 'State Number',
           active: false,
           label: 'State Number',
@@ -2282,6 +2499,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194901',
           code: 'State Number',
           active: false,
           label: 'State Number',
@@ -2299,6 +2517,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194902',
           code: 'Civilian Staff',
           active: false,
           label: 'Civilian Staff',
@@ -2307,6 +2526,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49240',
         },
         {
+          id: '194903',
           code: 'Officer',
           active: false,
           label: 'Officer',
@@ -2315,6 +2535,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49240',
         },
         {
+          id: '194904',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -2323,6 +2544,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49240',
         },
         {
+          id: '194905',
           code: 'Prisoner',
           active: false,
           label: 'Prisoner',
@@ -2331,6 +2553,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49240',
         },
         {
+          id: '194906',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -2348,6 +2571,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194907',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -2356,6 +2580,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49241',
         },
         {
+          id: '194908',
           code: 'Prisoner',
           active: false,
           label: 'Prisoner',
@@ -2364,6 +2589,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49241',
         },
         {
+          id: '194909',
           code: 'Visitor',
           active: false,
           label: 'Visitor',
@@ -2381,6 +2607,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194910',
           code: 'No',
           active: false,
           label: 'No',
@@ -2389,6 +2616,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49242',
         },
         {
+          id: '194911',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2406,6 +2634,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194912',
           code: 'No',
           active: false,
           label: 'No',
@@ -2414,6 +2643,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49243',
         },
         {
+          id: '194913',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2431,6 +2661,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194914',
           code: 'No',
           active: false,
           label: 'No',
@@ -2439,6 +2670,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49244',
         },
         {
+          id: '194915',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2456,6 +2688,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194916',
           code: 'No',
           active: false,
           label: 'No',
@@ -2464,6 +2697,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49245',
         },
         {
+          id: '194917',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2481,6 +2715,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194918',
           code: 'No',
           active: false,
           label: 'No',
@@ -2489,6 +2724,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49246',
         },
         {
+          id: '194919',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2506,6 +2742,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194920',
           code: 'No',
           active: false,
           label: 'No',
@@ -2514,6 +2751,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49247',
         },
         {
+          id: '194921',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2531,6 +2769,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194922',
           code: 'No',
           active: false,
           label: 'No',
@@ -2539,6 +2778,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49248',
         },
         {
+          id: '194923',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2556,6 +2796,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194924',
           code: 'No',
           active: false,
           label: 'No',
@@ -2564,6 +2805,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49249',
         },
         {
+          id: '194925',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2572,6 +2814,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49250',
         },
         {
+          id: '194926',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2580,6 +2823,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49249',
         },
         {
+          id: '204684',
           code: 'No',
           active: false,
           label: 'No',
@@ -2588,6 +2832,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53179',
         },
         {
+          id: '204685',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2605,6 +2850,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194927',
           code: 'No',
           active: false,
           label: 'No',
@@ -2613,6 +2859,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49250',
         },
         {
+          id: '194928',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2630,6 +2877,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194929',
           code: 'No',
           active: false,
           label: 'No',
@@ -2638,6 +2886,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49254',
         },
         {
+          id: '194930',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2655,6 +2904,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194931',
           code: 'Internal Access: Netting',
           active: false,
           label: 'Internal Access: Netting',
@@ -2663,6 +2913,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49255',
         },
         {
+          id: '194932',
           code: 'Internal Access: Landing/Railings',
           active: false,
           label: 'Internal Access: Landing/Railings',
@@ -2671,6 +2922,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49255',
         },
         {
+          id: '194933',
           code: 'Internal Access: Window/Gate Bars',
           active: false,
           label: 'Internal Access: Window/Gate Bars',
@@ -2679,6 +2931,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49255',
         },
         {
+          id: '194934',
           code: 'Internal Other',
           active: false,
           label: 'Internal Other',
@@ -2687,6 +2940,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49255',
         },
         {
+          id: '194935',
           code: 'External Access: Roof',
           active: false,
           label: 'External Access: Roof',
@@ -2695,6 +2949,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49255',
         },
         {
+          id: '194936',
           code: 'External Access: Tree',
           active: false,
           label: 'External Access: Tree',
@@ -2703,6 +2958,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49255',
         },
         {
+          id: '194937',
           code: 'External Access: Fencing',
           active: false,
           label: 'External Access: Fencing',
@@ -2711,6 +2967,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49255',
         },
         {
+          id: '194938',
           code: 'External Other',
           active: false,
           label: 'External Other',
@@ -2719,6 +2976,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49255',
         },
         {
+          id: '194939',
           code: 'Contractors Equipment',
           active: false,
           label: 'Contractors Equipment',
@@ -2727,6 +2985,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49255',
         },
         {
+          id: '194940',
           code: 'Not Applicable',
           active: false,
           label: 'Not Applicable',
@@ -2744,6 +3003,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194941',
           code: 'Access Difficulties',
           active: false,
           label: 'Access Difficulties',
@@ -2752,6 +3012,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49256',
         },
         {
+          id: '194942',
           code: 'Damage Resulting In Loss Of Facilities Or Utilities',
           active: false,
           label: 'Damage Resulting In Loss Of Facilities Or Utilities',
@@ -2760,6 +3021,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49256',
         },
         {
+          id: '194943',
           code: 'Damage Resulting in The Loss Of Accommodation',
           active: false,
           label: 'Damage Resulting in The Loss Of Accommodation',
@@ -2768,6 +3030,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49256',
         },
         {
+          id: '194944',
           code: 'Media Interest',
           active: false,
           label: 'Media Interest',
@@ -2776,6 +3039,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49256',
         },
         {
+          id: '194945',
           code: 'NTRG And / Or NDTSG Assistance Requested',
           active: false,
           label: 'NTRG And / Or NDTSG Assistance Requested',
@@ -2784,6 +3048,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49256',
         },
         {
+          id: '194946',
           code: 'Perpetrator Under Influence Of Drugs Or Alcohol',
           active: false,
           label: 'Perpetrator Under Influence Of Drugs Or Alcohol',
@@ -2792,6 +3057,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49256',
         },
         {
+          id: '194947',
           code: 'Threat Or Actual Self Harm',
           active: false,
           label: 'Threat Or Actual Self Harm',
@@ -2800,6 +3066,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49256',
         },
         {
+          id: '194948',
           code: 'Use Of Weapons',
           active: false,
           label: 'Use Of Weapons',
@@ -2808,6 +3075,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '49256',
         },
         {
+          id: '194949',
           code: 'Violence Directed Against Staff',
           active: false,
           label: 'Violence Directed Against Staff',
@@ -2825,6 +3093,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194950',
           code: 'Between 3 Feet and < 1st Floor',
           active: false,
           label: 'Between 3 Feet and < 1st Floor',
@@ -2833,6 +3102,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '194951',
           code: '1st Floor',
           active: false,
           label: '1st Floor',
@@ -2841,6 +3111,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '194952',
           code: '2nd Floor',
           active: false,
           label: '2nd Floor',
@@ -2849,6 +3120,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '194953',
           code: '3rd Floor Or Higher',
           active: false,
           label: '3rd Floor Or Higher',
@@ -2857,6 +3129,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '194954',
           code: 'Not Applicable',
           active: false,
           label: 'Not Applicable',
@@ -2874,6 +3147,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '202684',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2882,6 +3156,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53180',
         },
         {
+          id: '202685',
           code: 'No',
           active: false,
           label: 'No',
@@ -2899,6 +3174,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '202686',
           code: 'No',
           active: false,
           label: 'No',
@@ -2907,6 +3183,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53182',
         },
         {
+          id: '202687',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2924,6 +3201,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '202712',
           code: 'Not Applicable',
           active: false,
           label: 'Not Applicable',
@@ -2941,6 +3219,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '202688',
           code: 'Internal Access: Netting',
           active: false,
           label: 'Internal Access: Netting',
@@ -2949,6 +3228,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53183',
         },
         {
+          id: '202689',
           code: 'Internal Access: Landing/Railings',
           active: false,
           label: 'Internal Access: Landing/Railings',
@@ -2957,6 +3237,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53183',
         },
         {
+          id: '202690',
           code: 'Internal Access: Window/Gate Bars',
           active: false,
           label: 'Internal Access: Window/Gate Bars',
@@ -2965,6 +3246,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53183',
         },
         {
+          id: '202691',
           code: 'Internal Other',
           active: false,
           label: 'Internal Other',
@@ -2973,6 +3255,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53183',
         },
         {
+          id: '202692',
           code: 'External Access: Roof',
           active: false,
           label: 'External Access: Roof',
@@ -2981,6 +3264,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53183',
         },
         {
+          id: '202693',
           code: 'External Access: Tree',
           active: false,
           label: 'External Access: Tree',
@@ -2989,6 +3273,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53183',
         },
         {
+          id: '202694',
           code: 'External Access: Fencing',
           active: false,
           label: 'External Access: Fencing',
@@ -2997,6 +3282,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53183',
         },
         {
+          id: '202695',
           code: 'External Access Other',
           active: false,
           label: 'External Access Other',
@@ -3005,6 +3291,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53183',
         },
         {
+          id: '202696',
           code: 'Contractors Equipment',
           active: false,
           label: 'Contractors Equipment',
@@ -3013,6 +3300,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53183',
         },
         {
+          id: '202697',
           code: 'Not Applicable',
           active: false,
           label: 'Not Applicable',
@@ -3030,6 +3318,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '202698',
           code: 'Access Difficulties',
           active: false,
           label: 'Access Difficulties',
@@ -3038,6 +3327,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53184',
         },
         {
+          id: '202699',
           code: 'Damage Resulting in Loss of Facilities or Utilities',
           active: false,
           label: 'Damage Resulting in Loss of Facilities or Utilities',
@@ -3046,6 +3336,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53184',
         },
         {
+          id: '202700',
           code: 'Damage Resulting in The Loss of Accommodation',
           active: false,
           label: 'Damage Resulting in The Loss of Accommodation',
@@ -3054,6 +3345,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53184',
         },
         {
+          id: '202701',
           code: 'Media Interest',
           active: false,
           label: 'Media Interest',
@@ -3062,6 +3354,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53184',
         },
         {
+          id: '202702',
           code: 'NRTG And/Or NDTSG Assistance Required',
           active: false,
           label: 'NRTG And/Or NDTSG Assistance Required',
@@ -3070,6 +3363,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53184',
         },
         {
+          id: '202703',
           code: 'Perpetrator Under Influence of Drugs or Alcohol',
           active: false,
           label: 'Perpetrator Under Influence of Drugs or Alcohol',
@@ -3078,6 +3372,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53184',
         },
         {
+          id: '202704',
           code: 'Threat or Actual Self Harm',
           active: false,
           label: 'Threat or Actual Self Harm',
@@ -3086,6 +3381,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53184',
         },
         {
+          id: '202705',
           code: 'Use Of Weapons',
           active: false,
           label: 'Use Of Weapons',
@@ -3094,6 +3390,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: '53184',
         },
         {
+          id: '202706',
           code: 'Violence Directed Against Staff',
           active: false,
           label: 'Violence Directed Against Staff',
@@ -3111,6 +3408,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '202707',
           code: 'Between 3 Feet and < 1st Floor',
           active: false,
           label: 'Between 3 Feet and < 1st Floor',
@@ -3119,6 +3417,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '202708',
           code: '1st Floor',
           active: false,
           label: '1st Floor',
@@ -3127,6 +3426,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '202709',
           code: '2nd Floor',
           active: false,
           label: '2nd Floor',
@@ -3135,6 +3435,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '202710',
           code: '3rd Floor or Higher',
           active: false,
           label: '3rd Floor or Higher',
@@ -3143,6 +3444,7 @@ const OLD_DISORDER: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '202711',
           code: 'Not Applicable',
           active: false,
           label: 'Not Applicable',

--- a/server/reportConfiguration/types/OLD_DRONE_SIGHTING.ts
+++ b/server/reportConfiguration/types/OLD_DRONE_SIGHTING.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:57.816Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:24.521Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208684',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -23,6 +24,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57180',
         },
         {
+          id: '208685',
           code: 'No',
           active: false,
           label: 'No',
@@ -40,6 +42,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208686',
           code: '12am to 6am',
           active: true,
           label: '12am to 6am',
@@ -48,6 +51,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57181',
         },
         {
+          id: '208687',
           code: '6am to 12pm',
           active: true,
           label: '6am to 12pm',
@@ -56,6 +60,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57181',
         },
         {
+          id: '208688',
           code: '12pm to 6pm',
           active: true,
           label: '12pm to 6pm',
@@ -64,6 +69,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57181',
         },
         {
+          id: '208689',
           code: '6pm to 12am',
           active: true,
           label: '6pm to 12am',
@@ -81,6 +87,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208690',
           code: '1',
           active: false,
           label: '1',
@@ -89,6 +96,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57184',
         },
         {
+          id: '208691',
           code: '2',
           active: false,
           label: '2',
@@ -97,6 +105,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57184',
         },
         {
+          id: '208692',
           code: '3',
           active: false,
           label: '3',
@@ -105,6 +114,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57184',
         },
         {
+          id: '208693',
           code: '4',
           active: false,
           label: '4',
@@ -113,6 +123,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57184',
         },
         {
+          id: '208694',
           code: '5',
           active: false,
           label: '5',
@@ -121,6 +132,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57184',
         },
         {
+          id: '208695',
           code: '6+',
           active: false,
           label: '6+',
@@ -138,6 +150,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208696',
           code: 'Beyond the external perimeter border',
           active: false,
           label: 'Beyond the external perimeter border',
@@ -146,6 +159,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57185',
         },
         {
+          id: '208697',
           code: 'Exercise yard',
           active: false,
           label: 'Exercise yard',
@@ -154,6 +168,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57185',
         },
         {
+          id: '208698',
           code: 'External roof',
           active: false,
           label: 'External roof',
@@ -162,6 +177,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57185',
         },
         {
+          id: '208699',
           code: 'Gate',
           active: false,
           label: 'Gate',
@@ -170,6 +186,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57185',
         },
         {
+          id: '208700',
           code: 'Near cell window',
           active: false,
           label: 'Near cell window',
@@ -178,6 +195,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57185',
         },
         {
+          id: '208701',
           code: 'Sports Field',
           active: true,
           label: 'Sports Field',
@@ -186,6 +204,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57185',
         },
         {
+          id: '208702',
           code: 'Within Perimeter',
           active: true,
           label: 'Within Perimeter',
@@ -194,6 +213,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57185',
         },
         {
+          id: '208703',
           code: 'Other (Please Specify)',
           active: true,
           label: 'Other (Please Specify)',
@@ -211,6 +231,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208704',
           code: 'Not applicable',
           active: true,
           label: 'Not applicable',
@@ -219,6 +240,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57186',
         },
         {
+          id: '208705',
           code: '0 to less than 10 metres',
           active: true,
           label: '0 to less than 10 metres',
@@ -227,6 +249,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57186',
         },
         {
+          id: '208706',
           code: '10 to less than 100 metres',
           active: true,
           label: '10 to less than 100 metres',
@@ -235,6 +258,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57186',
         },
         {
+          id: '208707',
           code: '100 to less than 200 metres',
           active: true,
           label: '100 to less than 200 metres',
@@ -243,6 +267,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57186',
         },
         {
+          id: '208708',
           code: '200 metres or more',
           active: true,
           label: '200 metres or more',
@@ -260,6 +285,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208709',
           code: 'Static',
           active: false,
           label: 'Static',
@@ -268,6 +294,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57187',
         },
         {
+          id: '208710',
           code: 'Walking pace',
           active: false,
           label: 'Walking pace',
@@ -276,6 +303,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57187',
         },
         {
+          id: '208711',
           code: 'Running pace',
           active: false,
           label: 'Running pace',
@@ -284,6 +312,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57187',
         },
         {
+          id: '208712',
           code: 'Faster than running',
           active: false,
           label: 'Faster than running',
@@ -292,6 +321,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57187',
         },
         {
+          id: '208713',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -309,6 +339,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208714',
           code: 'Hovering',
           active: false,
           label: 'Hovering',
@@ -317,6 +348,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57188',
         },
         {
+          id: '208715',
           code: 'Circling a point',
           active: false,
           label: 'Circling a point',
@@ -325,6 +357,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57188',
         },
         {
+          id: '208716',
           code: 'Straight flight',
           active: false,
           label: 'Straight flight',
@@ -333,6 +366,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57188',
         },
         {
+          id: '208717',
           code: 'Direct attack',
           active: false,
           label: 'Direct attack',
@@ -341,6 +375,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57188',
         },
         {
+          id: '208718',
           code: 'Other (Please Specify)',
           active: false,
           label: 'Other (Please Specify)',
@@ -358,6 +393,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208719',
           code: 'Not believed to have been seen before',
           active: false,
           label: 'Not believed to have been seen before',
@@ -366,6 +402,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57189',
         },
         {
+          id: '208720',
           code: '1',
           active: false,
           label: '1',
@@ -374,6 +411,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57189',
         },
         {
+          id: '208721',
           code: '2',
           active: false,
           label: '2',
@@ -382,6 +420,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57189',
         },
         {
+          id: '208722',
           code: '3',
           active: false,
           label: '3',
@@ -390,6 +429,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57189',
         },
         {
+          id: '208723',
           code: '4',
           active: false,
           label: '4',
@@ -398,6 +438,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57189',
         },
         {
+          id: '208724',
           code: '5',
           active: false,
           label: '5',
@@ -406,6 +447,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57189',
         },
         {
+          id: '208725',
           code: '6 or more (please Specify)',
           active: false,
           label: '6 or more (please Specify)',
@@ -423,6 +465,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208726',
           code: 'Clear visibility',
           active: false,
           label: 'Clear visibility',
@@ -431,6 +474,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57192',
         },
         {
+          id: '208727',
           code: 'Poor visibility',
           active: false,
           label: 'Poor visibility',
@@ -439,6 +483,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57192',
         },
         {
+          id: '208728',
           code: 'Light',
           active: false,
           label: 'Light',
@@ -447,6 +492,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57192',
         },
         {
+          id: '208729',
           code: 'Dark',
           active: false,
           label: 'Dark',
@@ -455,6 +501,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57192',
         },
         {
+          id: '208730',
           code: 'Rain',
           active: false,
           label: 'Rain',
@@ -463,6 +510,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57192',
         },
         {
+          id: '208731',
           code: 'High wind',
           active: false,
           label: 'High wind',
@@ -471,6 +519,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57192',
         },
         {
+          id: '208732',
           code: 'Low wind',
           active: false,
           label: 'Low wind',
@@ -479,6 +528,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57192',
         },
         {
+          id: '208733',
           code: 'Calm',
           active: false,
           label: 'Calm',
@@ -496,6 +546,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208734',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -504,6 +555,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57194',
         },
         {
+          id: '208735',
           code: 'No',
           active: false,
           label: 'No',
@@ -521,6 +573,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208736',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -529,6 +582,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57194',
         },
         {
+          id: '208737',
           code: 'No',
           active: false,
           label: 'No',
@@ -546,6 +600,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208738',
           code: '1',
           active: false,
           label: '1',
@@ -554,6 +609,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57197',
         },
         {
+          id: '208739',
           code: '2',
           active: false,
           label: '2',
@@ -562,6 +618,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57197',
         },
         {
+          id: '208740',
           code: '3',
           active: false,
           label: '3',
@@ -570,6 +627,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57197',
         },
         {
+          id: '208741',
           code: '4',
           active: false,
           label: '4',
@@ -578,6 +636,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57197',
         },
         {
+          id: '208742',
           code: '5',
           active: false,
           label: '5',
@@ -586,6 +645,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57197',
         },
         {
+          id: '208743',
           code: '6+',
           active: false,
           label: '6+',
@@ -603,6 +663,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208744',
           code: 'Exercise yard',
           active: false,
           label: 'Exercise yard',
@@ -611,6 +672,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57198',
         },
         {
+          id: '208745',
           code: 'External roof',
           active: false,
           label: 'External roof',
@@ -619,6 +681,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57198',
         },
         {
+          id: '208746',
           code: 'Gate',
           active: false,
           label: 'Gate',
@@ -627,6 +690,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57198',
         },
         {
+          id: '208747',
           code: 'Near cell window',
           active: false,
           label: 'Near cell window',
@@ -635,6 +699,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57198',
         },
         {
+          id: '208748',
           code: 'External perimeter border',
           active: false,
           label: 'External perimeter border',
@@ -643,6 +708,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57198',
         },
         {
+          id: '208749',
           code: 'Sports field',
           active: false,
           label: 'Sports field',
@@ -651,6 +717,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57198',
         },
         {
+          id: '208750',
           code: 'Within perimeter',
           active: false,
           label: 'Within perimeter',
@@ -659,6 +726,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57198',
         },
         {
+          id: '208751',
           code: 'Other (please specify)',
           active: false,
           label: 'Other (please specify)',
@@ -676,6 +744,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208752',
           code: 'Multicopter Square',
           active: false,
           label: 'Multicopter Square',
@@ -684,6 +753,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57199',
         },
         {
+          id: '208753',
           code: 'Multicopter Circular',
           active: false,
           label: 'Multicopter Circular',
@@ -692,6 +762,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57199',
         },
         {
+          id: '208754',
           code: 'Multicopter X-Shape',
           active: false,
           label: 'Multicopter X-Shape',
@@ -700,6 +771,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57199',
         },
         {
+          id: '208755',
           code: 'Multicopter Hourglass',
           active: false,
           label: 'Multicopter Hourglass',
@@ -708,6 +780,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57199',
         },
         {
+          id: '208756',
           code: 'Multicopter Other',
           active: false,
           label: 'Multicopter Other',
@@ -716,6 +789,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57199',
         },
         {
+          id: '208757',
           code: 'Fixed wing Standard aircraft',
           active: false,
           label: 'Fixed wing Standard aircraft',
@@ -724,6 +798,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57199',
         },
         {
+          id: '208758',
           code: 'Fixed wing Delta-wing',
           active: false,
           label: 'Fixed wing Delta-wing',
@@ -732,6 +807,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57199',
         },
         {
+          id: '208759',
           code: 'Fixed wing Other',
           active: false,
           label: 'Fixed wing Other',
@@ -740,6 +816,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57199',
         },
         {
+          id: '208760',
           code: 'Other (Please Specify)',
           active: false,
           label: 'Other (Please Specify)',
@@ -748,6 +825,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57199',
         },
         {
+          id: '208761',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -765,6 +843,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208762',
           code: 'DJI Phantom',
           active: false,
           label: 'DJI Phantom',
@@ -773,6 +852,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57200',
         },
         {
+          id: '208763',
           code: 'Syma X8C Venture',
           active: false,
           label: 'Syma X8C Venture',
@@ -781,6 +861,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57200',
         },
         {
+          id: '208764',
           code: 'DIY Racing UAV',
           active: false,
           label: 'DIY Racing UAV',
@@ -789,6 +870,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57200',
         },
         {
+          id: '208765',
           code: 'T600 Inspire 1',
           active: false,
           label: 'T600 Inspire 1',
@@ -797,6 +879,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57200',
         },
         {
+          id: '208766',
           code: 'Century NEO660',
           active: false,
           label: 'Century NEO660',
@@ -805,6 +888,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57200',
         },
         {
+          id: '208767',
           code: 'X-8 Flyingwing',
           active: false,
           label: 'X-8 Flyingwing',
@@ -813,6 +897,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57200',
         },
         {
+          id: '208768',
           code: 'TALON X-UAV',
           active: false,
           label: 'TALON X-UAV',
@@ -821,6 +906,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57200',
         },
         {
+          id: '208769',
           code: 'Sky Hunter',
           active: false,
           label: 'Sky Hunter',
@@ -829,6 +915,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57200',
         },
         {
+          id: '208770',
           code: 'Piper model aircraft',
           active: false,
           label: 'Piper model aircraft',
@@ -837,6 +924,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57200',
         },
         {
+          id: '208771',
           code: 'Other (Please Specify)',
           active: false,
           label: 'Other (Please Specify)',
@@ -845,6 +933,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57200',
         },
         {
+          id: '208772',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -862,6 +951,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208773',
           code: '1',
           active: false,
           label: '1',
@@ -870,6 +960,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57201',
         },
         {
+          id: '208774',
           code: '2',
           active: false,
           label: '2',
@@ -878,6 +969,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57201',
         },
         {
+          id: '208775',
           code: '3',
           active: false,
           label: '3',
@@ -886,6 +978,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57201',
         },
         {
+          id: '208776',
           code: '4',
           active: false,
           label: '4',
@@ -894,6 +987,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57201',
         },
         {
+          id: '208777',
           code: '5',
           active: false,
           label: '5',
@@ -902,6 +996,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57201',
         },
         {
+          id: '208778',
           code: '6',
           active: false,
           label: '6',
@@ -910,6 +1005,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57201',
         },
         {
+          id: '208779',
           code: '7',
           active: false,
           label: '7',
@@ -918,6 +1014,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57201',
         },
         {
+          id: '208780',
           code: '8+',
           active: false,
           label: '8+',
@@ -926,6 +1023,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57201',
         },
         {
+          id: '208781',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -934,6 +1032,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57201',
         },
         {
+          id: '208787',
           code: '8+',
           active: false,
           label: '8+',
@@ -942,6 +1041,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57201',
         },
         {
+          id: '208788',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -959,6 +1059,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208782',
           code: '0 to less than 1m',
           active: false,
           label: '0 to less than 1m',
@@ -967,6 +1068,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57202',
         },
         {
+          id: '208783',
           code: '1m to less than 2m',
           active: false,
           label: '1m to less than 2m',
@@ -975,6 +1077,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57202',
         },
         {
+          id: '208784',
           code: '2m to less than 3m',
           active: false,
           label: '2m to less than 3m',
@@ -983,6 +1086,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57202',
         },
         {
+          id: '208785',
           code: '3m or longer',
           active: false,
           label: '3m or longer',
@@ -991,6 +1095,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57202',
         },
         {
+          id: '208786',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -1008,6 +1113,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208789',
           code: '0 to less than 1m',
           active: false,
           label: '0 to less than 1m',
@@ -1016,6 +1122,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57203',
         },
         {
+          id: '208790',
           code: '1m to less than 2m',
           active: false,
           label: '1m to less than 2m',
@@ -1024,6 +1131,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57203',
         },
         {
+          id: '208791',
           code: '2m to less than 3m',
           active: false,
           label: '2m to less than 3m',
@@ -1032,6 +1140,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57203',
         },
         {
+          id: '208792',
           code: '3m or longer',
           active: false,
           label: '3m or longer',
@@ -1040,6 +1149,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57203',
         },
         {
+          id: '208793',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -1057,6 +1167,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208794',
           code: 'Painted black',
           active: false,
           label: 'Painted black',
@@ -1065,6 +1176,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57204',
         },
         {
+          id: '208795',
           code: 'Removed camera',
           active: false,
           label: 'Removed camera',
@@ -1073,6 +1185,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57204',
         },
         {
+          id: '208796',
           code: 'Added hook',
           active: false,
           label: 'Added hook',
@@ -1081,6 +1194,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57204',
         },
         {
+          id: '208797',
           code: 'Covered lights',
           active: false,
           label: 'Covered lights',
@@ -1089,6 +1203,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57204',
         },
         {
+          id: '208798',
           code: 'Other (please specify)',
           active: false,
           label: 'Other (please specify)',
@@ -1097,6 +1212,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57204',
         },
         {
+          id: '208799',
           code: 'None',
           active: false,
           label: 'None',
@@ -1114,6 +1230,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208800',
           code: 'Intercepted',
           active: false,
           label: 'Intercepted',
@@ -1122,6 +1239,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57205',
         },
         {
+          id: '208801',
           code: 'Crashed',
           active: false,
           label: 'Crashed',
@@ -1139,6 +1257,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208802',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1147,6 +1266,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57206',
         },
         {
+          id: '208803',
           code: 'No',
           active: false,
           label: 'No',
@@ -1164,6 +1284,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208804',
           code: 'Yes (please enter the Finds Report incident number)',
           active: false,
           label: 'Yes (please enter the Finds Report incident number)',
@@ -1172,6 +1293,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57207',
         },
         {
+          id: '208805',
           code: 'No',
           active: false,
           label: 'No',
@@ -1189,6 +1311,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208806',
           code: '0 to less than 100g',
           active: false,
           label: '0 to less than 100g',
@@ -1197,6 +1320,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208807',
           code: '100g to less than 200g',
           active: false,
           label: '100g to less than 200g',
@@ -1205,6 +1329,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208808',
           code: '200g to less than 300g',
           active: false,
           label: '200g to less than 300g',
@@ -1213,6 +1338,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208809',
           code: '300g to less than 400g',
           active: false,
           label: '300g to less than 400g',
@@ -1221,6 +1347,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208810',
           code: '400g to less than 500g',
           active: false,
           label: '400g to less than 500g',
@@ -1229,6 +1356,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208811',
           code: '500g to less than 1kg',
           active: false,
           label: '500g to less than 1kg',
@@ -1237,6 +1365,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208812',
           code: '1kg to less than 2kg',
           active: false,
           label: '1kg to less than 2kg',
@@ -1245,6 +1374,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208813',
           code: '2kg to less than 3kg',
           active: false,
           label: '2kg to less than 3kg',
@@ -1253,6 +1383,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208814',
           code: '3kg to less than 4kg',
           active: false,
           label: '3kg to less than 4kg',
@@ -1261,6 +1392,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208815',
           code: '4kg to less than 5kg',
           active: false,
           label: '4kg to less than 5kg',
@@ -1269,6 +1401,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208816',
           code: '5kg to less than 6kg',
           active: false,
           label: '5kg to less than 6kg',
@@ -1277,6 +1410,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208817',
           code: '6kg to less than 7kg',
           active: false,
           label: '6kg to less than 7kg',
@@ -1285,6 +1419,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208818',
           code: '7kg to less than 8kg',
           active: false,
           label: '7kg to less than 8kg',
@@ -1293,6 +1428,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208819',
           code: '8kg to less than 9kg',
           active: false,
           label: '8kg to less than 9kg',
@@ -1301,6 +1437,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208820',
           code: '9kg to less than 10kg',
           active: false,
           label: '9kg to less than 10kg',
@@ -1309,6 +1446,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208821',
           code: 'More than 10kg',
           active: false,
           label: 'More than 10kg',
@@ -1317,6 +1455,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57208',
         },
         {
+          id: '208822',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -1334,6 +1473,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208823',
           code: 'Cameras',
           active: false,
           label: 'Cameras',
@@ -1342,6 +1482,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57209',
         },
         {
+          id: '208824',
           code: 'Mobile phone devices',
           active: false,
           label: 'Mobile phone devices',
@@ -1350,6 +1491,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57209',
         },
         {
+          id: '208825',
           code: 'Drugs',
           active: false,
           label: 'Drugs',
@@ -1358,6 +1500,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57209',
         },
         {
+          id: '208826',
           code: 'Weapons',
           active: false,
           label: 'Weapons',
@@ -1366,6 +1509,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57209',
         },
         {
+          id: '208827',
           code: 'Alcohol/hooch',
           active: false,
           label: 'Alcohol/hooch',
@@ -1374,6 +1518,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57209',
         },
         {
+          id: '208828',
           code: 'Tobacco',
           active: false,
           label: 'Tobacco',
@@ -1382,6 +1527,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57209',
         },
         {
+          id: '208829',
           code: 'Other (please specify)',
           active: false,
           label: 'Other (please specify)',
@@ -1399,6 +1545,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208830',
           code: 'Please specify',
           active: false,
           label: 'Please specify',
@@ -1416,6 +1563,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208831',
           code: 'Yes (specify where sent)',
           active: false,
           label: 'Yes (specify where sent)',
@@ -1424,6 +1572,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57211',
         },
         {
+          id: '208832',
           code: 'No',
           active: false,
           label: 'No',
@@ -1441,6 +1590,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208833',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1449,6 +1599,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57212',
         },
         {
+          id: '208834',
           code: 'No',
           active: false,
           label: 'No',
@@ -1466,6 +1617,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208835',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1474,6 +1626,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57213',
         },
         {
+          id: '208836',
           code: 'No',
           active: false,
           label: 'No',
@@ -1491,6 +1644,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208837',
           code: '0 to less than 10 metres',
           active: false,
           label: '0 to less than 10 metres',
@@ -1499,6 +1653,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208838',
           code: '10 to less than 100 metres',
           active: false,
           label: '10 to less than 100 metres',
@@ -1507,6 +1662,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208839',
           code: '100 to less than 200 metres',
           active: false,
           label: '100 to less than 200 metres',
@@ -1515,6 +1671,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208840',
           code: '200 metres or more',
           active: false,
           label: '200 metres or more',
@@ -1523,6 +1680,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208851',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1531,6 +1689,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57214',
         },
         {
+          id: '208852',
           code: 'No',
           active: false,
           label: 'No',
@@ -1548,6 +1707,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208841',
           code: '0 to less than 10 metres',
           active: false,
           label: '0 to less than 10 metres',
@@ -1556,6 +1716,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57215',
         },
         {
+          id: '208842',
           code: '10 to less than 100 metres',
           active: false,
           label: '10 to less than 100 metres',
@@ -1564,6 +1725,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57215',
         },
         {
+          id: '208843',
           code: '100 to less than 200 metres',
           active: false,
           label: '100 to less than 200 metres',
@@ -1572,6 +1734,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57215',
         },
         {
+          id: '208844',
           code: '200 metres or more',
           active: false,
           label: '200 metres or more',
@@ -1589,6 +1752,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208845',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1597,6 +1761,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57216',
         },
         {
+          id: '208846',
           code: 'No',
           active: false,
           label: 'No',
@@ -1614,6 +1779,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208847',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1622,6 +1788,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208848',
           code: 'No',
           active: false,
           label: 'No',
@@ -1639,6 +1806,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208849',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -1647,6 +1815,7 @@ const OLD_DRONE_SIGHTING: IncidentTypeConfiguration = {
           nextQuestionId: '57214',
         },
         {
+          id: '208850',
           code: 'No',
           active: true,
           label: 'No',

--- a/server/reportConfiguration/types/OLD_DRONE_SIGHTING1.ts
+++ b/server/reportConfiguration/types/OLD_DRONE_SIGHTING1.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:58.919Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:25.372Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208950',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -23,6 +24,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57254',
         },
         {
+          id: '208951',
           code: 'No',
           active: true,
           label: 'No',
@@ -40,6 +42,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208952',
           code: '12am to 6am',
           active: true,
           label: '12am to 6am',
@@ -48,6 +51,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57255',
         },
         {
+          id: '208953',
           code: '6am to 12pm',
           active: true,
           label: '6am to 12pm',
@@ -56,6 +60,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57255',
         },
         {
+          id: '208954',
           code: '12pm to 6pm',
           active: true,
           label: '12pm to 6pm',
@@ -64,6 +69,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57255',
         },
         {
+          id: '208955',
           code: '6pm to 12am',
           active: true,
           label: '6pm to 12am',
@@ -81,6 +87,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208956',
           code: '1',
           active: true,
           label: '1',
@@ -89,6 +96,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57256',
         },
         {
+          id: '208957',
           code: '2',
           active: true,
           label: '2',
@@ -97,6 +105,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57256',
         },
         {
+          id: '208958',
           code: '3',
           active: true,
           label: '3',
@@ -105,6 +114,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57256',
         },
         {
+          id: '208959',
           code: '4',
           active: true,
           label: '4',
@@ -113,6 +123,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57256',
         },
         {
+          id: '208960',
           code: '5',
           active: true,
           label: '5',
@@ -121,6 +132,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57256',
         },
         {
+          id: '208961',
           code: '6+',
           active: true,
           label: '6+',
@@ -138,6 +150,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208962',
           code: 'Beyond the external perimeter border',
           active: true,
           label: 'Beyond the external perimeter border',
@@ -146,6 +159,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57257',
         },
         {
+          id: '208963',
           code: 'Exercise yard',
           active: true,
           label: 'Exercise yard',
@@ -154,6 +168,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57257',
         },
         {
+          id: '208964',
           code: 'External Roof',
           active: true,
           label: 'External Roof',
@@ -162,6 +177,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57257',
         },
         {
+          id: '208965',
           code: 'Gate',
           active: true,
           label: 'Gate',
@@ -170,6 +186,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57257',
         },
         {
+          id: '208966',
           code: 'Near Cell window',
           active: true,
           label: 'Near Cell window',
@@ -178,6 +195,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57257',
         },
         {
+          id: '208967',
           code: 'Sports Field',
           active: true,
           label: 'Sports Field',
@@ -186,6 +204,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57257',
         },
         {
+          id: '208968',
           code: 'Within Perimeter',
           active: true,
           label: 'Within Perimeter',
@@ -194,6 +213,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57257',
         },
         {
+          id: '208969',
           code: 'Other (Please Specify)',
           active: true,
           label: 'Other (Please Specify)',
@@ -211,6 +231,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208970',
           code: 'Not applicable',
           active: true,
           label: 'Not applicable',
@@ -219,6 +240,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57258',
         },
         {
+          id: '208971',
           code: '0 to less than 10 metres',
           active: true,
           label: '0 to less than 10 metres',
@@ -227,6 +249,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57258',
         },
         {
+          id: '208972',
           code: '10 to less than 100 metres',
           active: true,
           label: '10 to less than 100 metres',
@@ -235,6 +258,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57258',
         },
         {
+          id: '208973',
           code: '100 to less than 200 metres',
           active: true,
           label: '100 to less than 200 metres',
@@ -243,6 +267,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57258',
         },
         {
+          id: '208974',
           code: '200 metres or more',
           active: true,
           label: '200 metres or more',
@@ -260,6 +285,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208975',
           code: 'Static',
           active: true,
           label: 'Static',
@@ -268,6 +294,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57259',
         },
         {
+          id: '208976',
           code: 'Walking pace',
           active: true,
           label: 'Walking pace',
@@ -276,6 +303,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57259',
         },
         {
+          id: '208977',
           code: 'Running pace',
           active: true,
           label: 'Running pace',
@@ -284,6 +312,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57259',
         },
         {
+          id: '208978',
           code: 'Faster than running',
           active: true,
           label: 'Faster than running',
@@ -292,6 +321,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57259',
         },
         {
+          id: '208979',
           code: 'Unknown',
           active: true,
           label: 'Unknown',
@@ -309,6 +339,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208980',
           code: 'Hovering',
           active: true,
           label: 'Hovering',
@@ -317,6 +348,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57260',
         },
         {
+          id: '208981',
           code: 'Circling a point',
           active: true,
           label: 'Circling a point',
@@ -325,6 +357,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57260',
         },
         {
+          id: '208982',
           code: 'Straight flight',
           active: true,
           label: 'Straight flight',
@@ -333,6 +366,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57260',
         },
         {
+          id: '208983',
           code: 'Direct attack',
           active: true,
           label: 'Direct attack',
@@ -341,6 +375,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57260',
         },
         {
+          id: '208984',
           code: 'Other (Please Specify)',
           active: true,
           label: 'Other (Please Specify)',
@@ -358,6 +393,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208985',
           code: 'Not believed to have been seen before',
           active: true,
           label: 'Not believed to have been seen before',
@@ -366,6 +402,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57261',
         },
         {
+          id: '208986',
           code: '1',
           active: true,
           label: '1',
@@ -374,6 +411,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57261',
         },
         {
+          id: '208987',
           code: '2',
           active: true,
           label: '2',
@@ -382,6 +420,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57261',
         },
         {
+          id: '208988',
           code: '3',
           active: true,
           label: '3',
@@ -390,6 +429,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57261',
         },
         {
+          id: '208989',
           code: '5',
           active: true,
           label: '5',
@@ -398,6 +438,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57261',
         },
         {
+          id: '208990',
           code: '6 or more (Please specify)',
           active: true,
           label: '6 or more (Please specify)',
@@ -415,6 +456,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208991',
           code: 'Clear visibility',
           active: true,
           label: 'Clear visibility',
@@ -423,6 +465,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57262',
         },
         {
+          id: '208992',
           code: 'Poor visibility',
           active: true,
           label: 'Poor visibility',
@@ -431,6 +474,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57262',
         },
         {
+          id: '208993',
           code: 'Light',
           active: true,
           label: 'Light',
@@ -439,6 +483,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57262',
         },
         {
+          id: '208994',
           code: 'Dark',
           active: true,
           label: 'Dark',
@@ -447,6 +492,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57262',
         },
         {
+          id: '208995',
           code: 'Rain',
           active: true,
           label: 'Rain',
@@ -455,6 +501,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57262',
         },
         {
+          id: '208996',
           code: 'High wind',
           active: true,
           label: 'High wind',
@@ -463,6 +510,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57262',
         },
         {
+          id: '208997',
           code: 'Low wind',
           active: true,
           label: 'Low wind',
@@ -471,6 +519,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57262',
         },
         {
+          id: '208998',
           code: 'Calm',
           active: true,
           label: 'Calm',
@@ -488,6 +537,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208999',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -496,6 +546,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57264',
         },
         {
+          id: '209000',
           code: 'No',
           active: true,
           label: 'No',
@@ -513,6 +564,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209001',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -521,6 +573,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57264',
         },
         {
+          id: '209002',
           code: 'No',
           active: true,
           label: 'No',
@@ -538,6 +591,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209003',
           code: '1',
           active: true,
           label: '1',
@@ -546,6 +600,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57265',
         },
         {
+          id: '209004',
           code: '2',
           active: true,
           label: '2',
@@ -554,6 +609,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57265',
         },
         {
+          id: '209005',
           code: '3',
           active: true,
           label: '3',
@@ -562,6 +618,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57265',
         },
         {
+          id: '209006',
           code: '4',
           active: true,
           label: '4',
@@ -570,6 +627,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57265',
         },
         {
+          id: '209007',
           code: '5',
           active: true,
           label: '5',
@@ -578,6 +636,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57265',
         },
         {
+          id: '209008',
           code: '6+',
           active: true,
           label: '6+',
@@ -595,6 +654,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209009',
           code: 'Exercise yard',
           active: true,
           label: 'Exercise yard',
@@ -603,6 +663,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57266',
         },
         {
+          id: '209010',
           code: 'External Roof',
           active: true,
           label: 'External Roof',
@@ -611,6 +672,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57266',
         },
         {
+          id: '209011',
           code: 'Gate',
           active: true,
           label: 'Gate',
@@ -619,6 +681,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57266',
         },
         {
+          id: '209012',
           code: 'Near Cell window',
           active: true,
           label: 'Near Cell window',
@@ -627,6 +690,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57266',
         },
         {
+          id: '209013',
           code: 'External perimeter border',
           active: true,
           label: 'External perimeter border',
@@ -635,6 +699,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57266',
         },
         {
+          id: '209014',
           code: 'Sports Field',
           active: true,
           label: 'Sports Field',
@@ -643,6 +708,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57266',
         },
         {
+          id: '209015',
           code: 'Within Perimeter',
           active: true,
           label: 'Within Perimeter',
@@ -651,6 +717,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57266',
         },
         {
+          id: '209016',
           code: 'Other (Please Specify)',
           active: true,
           label: 'Other (Please Specify)',
@@ -668,6 +735,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209017',
           code: 'Multicopter: Square',
           active: true,
           label: 'Multicopter: Square',
@@ -676,6 +744,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57267',
         },
         {
+          id: '209018',
           code: 'Multicopter: Circular',
           active: true,
           label: 'Multicopter: Circular',
@@ -684,6 +753,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57267',
         },
         {
+          id: '209019',
           code: 'Multicopter: X-Shape',
           active: true,
           label: 'Multicopter: X-Shape',
@@ -692,6 +762,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57267',
         },
         {
+          id: '209020',
           code: 'Multicopter: Hourglass',
           active: true,
           label: 'Multicopter: Hourglass',
@@ -700,6 +771,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57267',
         },
         {
+          id: '209021',
           code: 'Multicopter: Other',
           active: true,
           label: 'Multicopter: Other',
@@ -708,6 +780,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57267',
         },
         {
+          id: '209022',
           code: 'Fixed wing: Standard aircraft',
           active: true,
           label: 'Fixed wing: Standard aircraft',
@@ -716,6 +789,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57267',
         },
         {
+          id: '209023',
           code: 'Fixed wing: Delta-wing',
           active: true,
           label: 'Fixed wing: Delta-wing',
@@ -724,6 +798,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57267',
         },
         {
+          id: '209024',
           code: 'Fixed wing: Other',
           active: true,
           label: 'Fixed wing: Other',
@@ -732,6 +807,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57267',
         },
         {
+          id: '209025',
           code: 'Other (Please Specify)',
           active: true,
           label: 'Other (Please Specify)',
@@ -740,6 +816,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57267',
         },
         {
+          id: '209026',
           code: 'Unknown',
           active: true,
           label: 'Unknown',
@@ -757,6 +834,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209027',
           code: 'DJI Phantom',
           active: true,
           label: 'DJI Phantom',
@@ -765,6 +843,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57268',
         },
         {
+          id: '209028',
           code: 'Syma X8C Venture',
           active: true,
           label: 'Syma X8C Venture',
@@ -773,6 +852,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57268',
         },
         {
+          id: '209029',
           code: 'DIY Racing UAV',
           active: true,
           label: 'DIY Racing UAV',
@@ -781,6 +861,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57268',
         },
         {
+          id: '209030',
           code: 'T600 Inspire 1',
           active: true,
           label: 'T600 Inspire 1',
@@ -789,6 +870,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57268',
         },
         {
+          id: '209031',
           code: 'Century NEO660',
           active: true,
           label: 'Century NEO660',
@@ -797,6 +879,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57268',
         },
         {
+          id: '209032',
           code: 'X-8 Flyingwing',
           active: true,
           label: 'X-8 Flyingwing',
@@ -805,6 +888,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57268',
         },
         {
+          id: '209033',
           code: 'TALON X-UAV',
           active: true,
           label: 'TALON X-UAV',
@@ -813,6 +897,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57268',
         },
         {
+          id: '209034',
           code: 'Sky Hunter',
           active: true,
           label: 'Sky Hunter',
@@ -821,6 +906,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57268',
         },
         {
+          id: '209035',
           code: 'Piper model aircraft',
           active: true,
           label: 'Piper model aircraft',
@@ -829,6 +915,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57268',
         },
         {
+          id: '209036',
           code: 'Other (Please Specify)',
           active: true,
           label: 'Other (Please Specify)',
@@ -837,6 +924,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57268',
         },
         {
+          id: '209037',
           code: 'Unknown',
           active: true,
           label: 'Unknown',
@@ -854,6 +942,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209038',
           code: '1',
           active: true,
           label: '1',
@@ -862,6 +951,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57269',
         },
         {
+          id: '209039',
           code: '2',
           active: true,
           label: '2',
@@ -870,6 +960,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57269',
         },
         {
+          id: '209040',
           code: '3',
           active: true,
           label: '3',
@@ -878,6 +969,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57269',
         },
         {
+          id: '209041',
           code: '4',
           active: true,
           label: '4',
@@ -886,6 +978,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57269',
         },
         {
+          id: '209042',
           code: '5',
           active: true,
           label: '5',
@@ -894,6 +987,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57269',
         },
         {
+          id: '209043',
           code: '6',
           active: true,
           label: '6',
@@ -902,6 +996,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57269',
         },
         {
+          id: '209044',
           code: '7',
           active: true,
           label: '7',
@@ -910,6 +1005,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57269',
         },
         {
+          id: '209045',
           code: '8+',
           active: true,
           label: '8+',
@@ -918,6 +1014,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57269',
         },
         {
+          id: '209046',
           code: 'Unknown',
           active: true,
           label: 'Unknown',
@@ -935,6 +1032,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209047',
           code: '0 to less than 1m',
           active: true,
           label: '0 to less than 1m',
@@ -943,6 +1041,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57270',
         },
         {
+          id: '209048',
           code: '1m to less than 2m',
           active: true,
           label: '1m to less than 2m',
@@ -951,6 +1050,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57270',
         },
         {
+          id: '209049',
           code: '2m to less than 3m',
           active: true,
           label: '2m to less than 3m',
@@ -959,6 +1059,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57270',
         },
         {
+          id: '209050',
           code: '3m or longer',
           active: true,
           label: '3m or longer',
@@ -967,6 +1068,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57270',
         },
         {
+          id: '209051',
           code: 'Unknown',
           active: true,
           label: 'Unknown',
@@ -984,6 +1086,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209052',
           code: '0 to less than 1m',
           active: true,
           label: '0 to less than 1m',
@@ -992,6 +1095,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57271',
         },
         {
+          id: '209053',
           code: '1m to less than 2m',
           active: true,
           label: '1m to less than 2m',
@@ -1000,6 +1104,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57271',
         },
         {
+          id: '209054',
           code: '2m to less than 3m',
           active: true,
           label: '2m to less than 3m',
@@ -1008,6 +1113,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57271',
         },
         {
+          id: '209055',
           code: '3m or longer',
           active: true,
           label: '3m or longer',
@@ -1016,6 +1122,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57271',
         },
         {
+          id: '209056',
           code: 'Unknown',
           active: true,
           label: 'Unknown',
@@ -1033,6 +1140,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209057',
           code: 'Painted black',
           active: true,
           label: 'Painted black',
@@ -1041,6 +1149,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57272',
         },
         {
+          id: '209058',
           code: 'Removed camera',
           active: true,
           label: 'Removed camera',
@@ -1049,6 +1158,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57272',
         },
         {
+          id: '209059',
           code: 'Added hook',
           active: true,
           label: 'Added hook',
@@ -1057,6 +1167,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57272',
         },
         {
+          id: '209060',
           code: 'Covered lights',
           active: true,
           label: 'Covered lights',
@@ -1065,6 +1176,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57272',
         },
         {
+          id: '209061',
           code: 'Other (Please specify)',
           active: true,
           label: 'Other (Please specify)',
@@ -1073,6 +1185,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57272',
         },
         {
+          id: '209062',
           code: 'None',
           active: true,
           label: 'None',
@@ -1090,6 +1203,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209063',
           code: 'Intercepted',
           active: true,
           label: 'Intercepted',
@@ -1098,6 +1212,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57273',
         },
         {
+          id: '209064',
           code: 'Crashed',
           active: true,
           label: 'Crashed',
@@ -1115,6 +1230,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209065',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -1123,6 +1239,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57274',
         },
         {
+          id: '209066',
           code: 'No',
           active: true,
           label: 'No',
@@ -1140,6 +1257,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209067',
           code: 'Yes (please enter the Finds report incident number)',
           active: true,
           label: 'Yes (please enter the Finds report incident number)',
@@ -1148,6 +1266,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57275',
         },
         {
+          id: '209068',
           code: 'No',
           active: true,
           label: 'No',
@@ -1165,6 +1284,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209069',
           code: '0 to less than 100g',
           active: true,
           label: '0 to less than 100g',
@@ -1173,6 +1293,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209070',
           code: '100g to less than 200g',
           active: true,
           label: '100g to less than 200g',
@@ -1181,6 +1302,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209071',
           code: '200g to less than 300g',
           active: true,
           label: '200g to less than 300g',
@@ -1189,6 +1311,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209072',
           code: '300g to less than 400g',
           active: true,
           label: '300g to less than 400g',
@@ -1197,6 +1320,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209073',
           code: '400g to less than 500g',
           active: true,
           label: '400g to less than 500g',
@@ -1205,6 +1329,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209074',
           code: '500g to less than 1kg',
           active: true,
           label: '500g to less than 1kg',
@@ -1213,6 +1338,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209075',
           code: '1kg to less than 2kg',
           active: true,
           label: '1kg to less than 2kg',
@@ -1221,6 +1347,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209076',
           code: '2kg to less than 3kg',
           active: true,
           label: '2kg to less than 3kg',
@@ -1229,6 +1356,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209077',
           code: '3kg to less than 4kg',
           active: true,
           label: '3kg to less than 4kg',
@@ -1237,6 +1365,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209078',
           code: '4kg to less than 5kg',
           active: true,
           label: '4kg to less than 5kg',
@@ -1245,6 +1374,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209079',
           code: '5kg to less than 6kg',
           active: true,
           label: '5kg to less than 6kg',
@@ -1253,6 +1383,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209080',
           code: '6kg to less than 7kg',
           active: true,
           label: '6kg to less than 7kg',
@@ -1261,6 +1392,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209081',
           code: '7kg to less than 8kg',
           active: true,
           label: '7kg to less than 8kg',
@@ -1269,6 +1401,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209082',
           code: '8kg to less than 9kg',
           active: true,
           label: '8kg to less than 9kg',
@@ -1277,6 +1410,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209083',
           code: '9kg to less than 10kg',
           active: true,
           label: '9kg to less than 10kg',
@@ -1285,6 +1419,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209084',
           code: 'More than 10kg',
           active: true,
           label: 'More than 10kg',
@@ -1293,6 +1428,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57276',
         },
         {
+          id: '209085',
           code: 'Unknown',
           active: true,
           label: 'Unknown',
@@ -1310,6 +1446,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209086',
           code: 'Cameras',
           active: true,
           label: 'Cameras',
@@ -1318,6 +1455,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57277',
         },
         {
+          id: '209087',
           code: 'Mobile phone devices',
           active: true,
           label: 'Mobile phone devices',
@@ -1326,6 +1464,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57277',
         },
         {
+          id: '209088',
           code: 'Drugs',
           active: true,
           label: 'Drugs',
@@ -1334,6 +1473,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57277',
         },
         {
+          id: '209089',
           code: 'Weapons',
           active: true,
           label: 'Weapons',
@@ -1342,6 +1482,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57277',
         },
         {
+          id: '209090',
           code: 'Alcohol/hooch',
           active: true,
           label: 'Alcohol/hooch',
@@ -1350,6 +1491,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57277',
         },
         {
+          id: '209091',
           code: 'Tobacco',
           active: true,
           label: 'Tobacco',
@@ -1358,6 +1500,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57277',
         },
         {
+          id: '209092',
           code: 'Other (please specify)',
           active: true,
           label: 'Other (please specify)',
@@ -1375,6 +1518,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209093',
           code: 'Yes (specify where sent)',
           active: true,
           label: 'Yes (specify where sent)',
@@ -1383,6 +1527,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57278',
         },
         {
+          id: '209094',
           code: 'No',
           active: true,
           label: 'No',
@@ -1400,6 +1545,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209095',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -1408,6 +1554,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57279',
         },
         {
+          id: '209096',
           code: 'No',
           active: true,
           label: 'No',
@@ -1425,6 +1572,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209097',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -1433,6 +1581,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57280',
         },
         {
+          id: '209098',
           code: 'No',
           active: true,
           label: 'No',
@@ -1450,6 +1599,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209099',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -1458,6 +1608,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57281',
         },
         {
+          id: '209100',
           code: 'No',
           active: true,
           label: 'No',
@@ -1475,6 +1626,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209101',
           code: '0 to less than 10 metres',
           active: true,
           label: '0 to less than 10 metres',
@@ -1483,6 +1635,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57282',
         },
         {
+          id: '209102',
           code: '10 to less than 100 metres',
           active: true,
           label: '10 to less than 100 metres',
@@ -1491,6 +1644,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57282',
         },
         {
+          id: '209103',
           code: '100 to less than 200 metres',
           active: true,
           label: '100 to less than 200 metres',
@@ -1499,6 +1653,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57282',
         },
         {
+          id: '209104',
           code: '200 metres or more',
           active: true,
           label: '200 metres or more',
@@ -1516,6 +1671,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209105',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -1524,6 +1680,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: '57283',
         },
         {
+          id: '209106',
           code: 'No',
           active: true,
           label: 'No',
@@ -1541,6 +1698,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209107',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -1549,6 +1707,7 @@ const OLD_DRONE_SIGHTING1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209108',
           code: 'No',
           active: true,
           label: 'No',

--- a/server/reportConfiguration/types/OLD_DRUGS.ts
+++ b/server/reportConfiguration/types/OLD_DRUGS.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:00.679Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:27.023Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179087',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -23,6 +24,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44899',
         },
         {
+          id: '179088',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -40,6 +42,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179174',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -48,6 +51,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44682',
         },
         {
+          id: '179173',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -65,6 +69,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179181',
           code: 'HEROIN',
           active: false,
           label: 'HEROIN',
@@ -73,6 +78,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44821',
         },
         {
+          id: '179179',
           code: 'COCAINE',
           active: false,
           label: 'COCAINE',
@@ -81,6 +87,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44821',
         },
         {
+          id: '179182',
           code: 'LSD',
           active: false,
           label: 'LSD',
@@ -89,6 +96,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44821',
         },
         {
+          id: '179175',
           code: 'AMPHETAMINES',
           active: false,
           label: 'AMPHETAMINES',
@@ -97,6 +105,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44821',
         },
         {
+          id: '179176',
           code: 'BARBITURATES',
           active: false,
           label: 'BARBITURATES',
@@ -105,6 +114,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44821',
         },
         {
+          id: '179177',
           code: 'CANNABIS',
           active: false,
           label: 'CANNABIS',
@@ -113,6 +123,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44821',
         },
         {
+          id: '179178',
           code: 'CANNABIS PLANT',
           active: false,
           label: 'CANNABIS PLANT',
@@ -121,6 +132,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44821',
         },
         {
+          id: '179180',
           code: 'CRACK',
           active: false,
           label: 'CRACK',
@@ -129,6 +141,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44821',
         },
         {
+          id: '179184',
           code: 'TRANQUILISERS',
           active: false,
           label: 'TRANQUILISERS',
@@ -137,6 +150,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44821',
         },
         {
+          id: '179183',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -154,6 +168,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179211',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -162,6 +177,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45057',
         },
         {
+          id: '179212',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -179,6 +195,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179222',
           code: 'AUTHENTIC SYRINGE',
           active: false,
           label: 'AUTHENTIC SYRINGE',
@@ -187,6 +204,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44818',
         },
         {
+          id: '179224',
           code: 'IMPROVISED SYRINGE',
           active: false,
           label: 'IMPROVISED SYRINGE',
@@ -195,6 +213,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44818',
         },
         {
+          id: '179221',
           code: 'AUTHENTIC NEEDLE',
           active: false,
           label: 'AUTHENTIC NEEDLE',
@@ -203,6 +222,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44818',
         },
         {
+          id: '179223',
           code: 'IMPROVISED NEEDLE',
           active: false,
           label: 'IMPROVISED NEEDLE',
@@ -211,6 +231,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44818',
         },
         {
+          id: '179226',
           code: 'PIPE(S)',
           active: false,
           label: 'PIPE(S)',
@@ -219,6 +240,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44818',
         },
         {
+          id: '179227',
           code: 'ROACH',
           active: false,
           label: 'ROACH',
@@ -227,6 +249,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44818',
         },
         {
+          id: '179225',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -244,6 +267,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179300',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -252,6 +276,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44502',
         },
         {
+          id: '179301',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -269,6 +294,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179549',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -277,6 +303,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44700',
         },
         {
+          id: '179550',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -294,6 +321,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179835',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -302,6 +330,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44649',
         },
         {
+          id: '179836',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -319,6 +348,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179873',
           code: 'SPECIAL SEARCH',
           active: false,
           label: 'SPECIAL SEARCH',
@@ -327,6 +357,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45097',
         },
         {
+          id: '179874',
           code: 'STRIP SEARCH',
           active: false,
           label: 'STRIP SEARCH',
@@ -335,6 +366,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45097',
         },
         {
+          id: '179866',
           code: 'CELL SEARCH',
           active: false,
           label: 'CELL SEARCH',
@@ -343,6 +375,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45097',
         },
         {
+          id: '179867',
           code: 'DOG SEARCH',
           active: false,
           label: 'DOG SEARCH',
@@ -351,6 +384,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45097',
         },
         {
+          id: '179870',
           code: 'OTHER SEARCH (INMATE)',
           active: false,
           label: 'OTHER SEARCH (INMATE)',
@@ -359,6 +393,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45097',
         },
         {
+          id: '179872',
           code: 'OTHER SEARCH (VISITOR)',
           active: true,
           label: 'OTHER SEARCH (VISITOR)',
@@ -367,6 +402,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45097',
         },
         {
+          id: '179871',
           code: 'OTHER SEARCH (PREMISES)',
           active: false,
           label: 'OTHER SEARCH (PREMISES)',
@@ -375,6 +411,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45097',
         },
         {
+          id: '179868',
           code: 'INFORMATION RECEIVED',
           active: false,
           label: 'INFORMATION RECEIVED',
@@ -383,6 +420,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45097',
         },
         {
+          id: '179875',
           code: 'SUBSTANCE OBSERVED',
           active: false,
           label: 'SUBSTANCE OBSERVED',
@@ -391,6 +429,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45097',
         },
         {
+          id: '179876',
           code: 'UNUSUAL BEHAVIOUR',
           active: false,
           label: 'UNUSUAL BEHAVIOUR',
@@ -399,6 +438,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45097',
         },
         {
+          id: '179869',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -416,6 +456,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180009',
           code: 'COMPASSIONATE',
           active: false,
           label: 'COMPASSIONATE',
@@ -424,6 +465,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '180010',
           code: 'FACILITY',
           active: false,
           label: 'FACILITY',
@@ -432,6 +474,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '180011',
           code: 'RESETTLEMENT',
           active: false,
           label: 'RESETTLEMENT',
@@ -440,6 +483,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '180008',
           code: 'COMMUNITY VISIT',
           active: false,
           label: 'COMMUNITY VISIT',
@@ -457,6 +501,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180231',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -465,6 +510,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44557',
         },
         {
+          id: '180230',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -482,6 +528,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180249',
           code: 'OFFICER',
           active: false,
           label: 'OFFICER',
@@ -490,6 +537,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44316',
         },
         {
+          id: '180251',
           code: 'PRISONER',
           active: false,
           label: 'PRISONER',
@@ -498,6 +546,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44316',
         },
         {
+          id: '180247',
           code: 'CIVILIAN GRADES',
           active: false,
           label: 'CIVILIAN GRADES',
@@ -506,6 +555,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44316',
         },
         {
+          id: '180250',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -514,6 +564,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44316',
         },
         {
+          id: '180248',
           code: 'EXTERNAL CIVILIANS',
           active: false,
           label: 'EXTERNAL CIVILIANS',
@@ -531,6 +582,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180458',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -539,6 +591,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44664',
         },
         {
+          id: '180457',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -556,6 +609,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180710',
           code: 'LOCAL WITH BDH KIT OR SIMILAR',
           active: false,
           label: 'LOCAL WITH BDH KIT OR SIMILAR',
@@ -564,6 +618,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44982',
         },
         {
+          id: '180709',
           code: 'FORENSIC LABORATORY',
           active: false,
           label: 'FORENSIC LABORATORY',
@@ -581,6 +636,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180746',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -589,6 +645,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44635',
         },
         {
+          id: '180747',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -606,6 +663,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180804',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -614,6 +672,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44204',
         },
         {
+          id: '180803',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -631,6 +690,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180851',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -639,6 +699,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44792',
         },
         {
+          id: '180850',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -656,6 +717,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180922',
           code: 'ADMINISTRATION',
           active: false,
           label: 'ADMINISTRATION',
@@ -664,6 +726,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180923',
           code: 'ASSOCIATION AREA',
           active: false,
           label: 'ASSOCIATION AREA',
@@ -672,6 +735,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180924',
           code: 'CELL',
           active: false,
           label: 'CELL',
@@ -680,6 +744,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180925',
           code: 'CHAPEL',
           active: false,
           label: 'CHAPEL',
@@ -688,6 +753,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180927',
           code: 'DINING ROOM',
           active: false,
           label: 'DINING ROOM',
@@ -696,6 +762,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180928',
           code: 'DORMITORY',
           active: false,
           label: 'DORMITORY',
@@ -704,6 +771,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180929',
           code: 'EDUCATION',
           active: false,
           label: 'EDUCATION',
@@ -712,6 +780,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180931',
           code: 'EXERCISE YARD',
           active: false,
           label: 'EXERCISE YARD',
@@ -720,6 +789,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180933',
           code: 'GATE',
           active: false,
           label: 'GATE',
@@ -728,6 +798,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180934',
           code: 'GYM',
           active: false,
           label: 'GYM',
@@ -736,6 +807,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180935',
           code: 'HEALTH CARE CENTRE',
           active: false,
           label: 'HEALTH CARE CENTRE',
@@ -744,6 +816,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180938',
           code: 'KITCHEN',
           active: false,
           label: 'KITCHEN',
@@ -752,6 +825,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180940',
           code: 'OFFICE',
           active: false,
           label: 'OFFICE',
@@ -760,6 +834,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180942',
           code: 'RECEPTION',
           active: false,
           label: 'RECEPTION',
@@ -768,6 +843,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180943',
           code: 'RECESS',
           active: false,
           label: 'RECESS',
@@ -776,6 +852,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180944',
           code: 'SEGREGATION UNIT',
           active: false,
           label: 'SEGREGATION UNIT',
@@ -784,6 +861,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180946',
           code: 'SPECIAL UNIT',
           active: false,
           label: 'SPECIAL UNIT',
@@ -792,6 +870,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180945',
           code: 'SHOWERS/CHANGING ROOM',
           active: false,
           label: 'SHOWERS/CHANGING ROOM',
@@ -800,6 +879,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180949',
           code: 'VISITS',
           active: false,
           label: 'VISITS',
@@ -808,6 +888,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180951',
           code: 'WING',
           active: false,
           label: 'WING',
@@ -816,6 +897,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180953',
           code: 'WORKS DEPARTMENT',
           active: false,
           label: 'WORKS DEPARTMENT',
@@ -824,6 +906,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180954',
           code: 'WORKSHOP',
           active: false,
           label: 'WORKSHOP',
@@ -832,6 +915,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180952',
           code: 'WITHIN PERIMETER',
           active: false,
           label: 'WITHIN PERIMETER',
@@ -840,6 +924,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180930',
           code: 'ELSEWHERE',
           active: false,
           label: 'ELSEWHERE',
@@ -848,6 +933,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180932',
           code: 'FUNERAL',
           active: false,
           label: 'FUNERAL',
@@ -856,6 +942,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180936',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: false,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -864,6 +951,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180937',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: false,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -872,6 +960,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180941',
           code: 'OUTSIDE WORKING PARTY',
           active: false,
           label: 'OUTSIDE WORKING PARTY',
@@ -880,6 +969,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180947',
           code: 'SPORTS FIELD',
           active: false,
           label: 'SPORTS FIELD',
@@ -888,6 +978,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180948',
           code: 'VEHICLE',
           active: false,
           label: 'VEHICLE',
@@ -896,6 +987,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180950',
           code: 'WEDDINGS',
           active: false,
           label: 'WEDDINGS',
@@ -904,6 +996,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180939',
           code: 'MAGISTRATES COURT',
           active: false,
           label: 'MAGISTRATES COURT',
@@ -912,6 +1005,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44179',
         },
         {
+          id: '180926',
           code: 'CROWN COURT',
           active: false,
           label: 'CROWN COURT',
@@ -929,6 +1023,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181144',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -937,6 +1032,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44219',
         },
         {
+          id: '181143',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -954,6 +1050,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181237',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -962,6 +1059,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44765',
         },
         {
+          id: '181236',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -979,6 +1077,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181246',
           code: 'PRISONER',
           active: false,
           label: 'PRISONER',
@@ -987,6 +1086,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45008',
         },
         {
+          id: '181245',
           code: 'VISITOR',
           active: false,
           label: 'VISITOR',
@@ -995,6 +1095,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45168',
         },
         {
+          id: '181248',
           code: 'THROWN IN',
           active: false,
           label: 'THROWN IN',
@@ -1003,6 +1104,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '181247',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1020,6 +1122,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181274',
           code: 'SPECIFY',
           active: false,
           label: 'SPECIFY',
@@ -1037,6 +1140,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181299',
           code: 'NAME',
           active: false,
           label: 'NAME',
@@ -1054,6 +1158,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181304',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1062,6 +1167,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44224',
         },
         {
+          id: '181305',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1079,6 +1185,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181335',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1087,6 +1194,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44243',
         },
         {
+          id: '181336',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1104,6 +1212,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181579',
           code: 'BEFORE ENTERING PRISON',
           active: false,
           label: 'BEFORE ENTERING PRISON',
@@ -1112,6 +1221,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44807',
         },
         {
+          id: '181578',
           code: 'AFTER ENTERING PRISON',
           active: false,
           label: 'AFTER ENTERING PRISON',
@@ -1129,6 +1239,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181908',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1137,6 +1248,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44205',
         },
         {
+          id: '181909',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1154,6 +1266,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181976',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1162,6 +1275,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44458',
         },
         {
+          id: '181977',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1179,6 +1293,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182213',
           code: 'SPECIFY',
           active: false,
           label: 'SPECIFY',
@@ -1196,6 +1311,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182335',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1204,6 +1320,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '44795',
         },
         {
+          id: '182336',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1221,6 +1338,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182620',
           code: 'RELATIVE',
           active: false,
           label: 'RELATIVE',
@@ -1229,6 +1347,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45008',
         },
         {
+          id: '182618',
           code: 'FRIEND',
           active: false,
           label: 'FRIEND',
@@ -1237,6 +1356,7 @@ const OLD_DRUGS: IncidentTypeConfiguration = {
           nextQuestionId: '45008',
         },
         {
+          id: '182619',
           code: 'OFFICIAL VISITOR',
           active: false,
           label: 'OFFICIAL VISITOR',

--- a/server/reportConfiguration/types/OLD_FINDS.ts
+++ b/server/reportConfiguration/types/OLD_FINDS.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:07.251Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:33.546Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194955',
           code: 'No Further Action',
           active: false,
           label: 'No Further Action',
@@ -23,6 +24,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49258',
         },
         {
+          id: '194956',
           code: 'IEP Regression',
           active: false,
           label: 'IEP Regression',
@@ -31,6 +33,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49258',
         },
         {
+          id: '194957',
           code: 'Placed on Report ./ Adjudication Referral',
           active: false,
           label: 'Placed on Report ./ Adjudication Referral',
@@ -39,6 +42,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49258',
         },
         {
+          id: '194958',
           code: 'Police Referral',
           active: false,
           label: 'Police Referral',
@@ -47,6 +51,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49258',
         },
         {
+          id: '194959',
           code: 'Police And Prosecution Referral',
           active: false,
           label: 'Police And Prosecution Referral',
@@ -64,6 +69,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194960',
           code: 'No',
           active: false,
           label: 'No',
@@ -72,6 +78,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49259',
         },
         {
+          id: '194961',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -89,6 +96,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194962',
           code: 'No',
           active: false,
           label: 'No',
@@ -97,6 +105,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49260',
         },
         {
+          id: '194963',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -114,6 +123,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194964',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -122,6 +132,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49261',
         },
         {
+          id: '194965',
           code: 'No',
           active: false,
           label: 'No',
@@ -139,6 +150,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194966',
           code: 'Specify',
           active: false,
           label: 'Specify',
@@ -156,6 +168,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194972',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -164,6 +177,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49264',
         },
         {
+          id: '194973',
           code: 'No',
           active: false,
           label: 'No',
@@ -181,6 +195,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '194974',
           code: 'Administration',
           active: false,
           label: 'Administration',
@@ -189,6 +204,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194975',
           code: 'Association Area',
           active: false,
           label: 'Association Area',
@@ -197,6 +213,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194976',
           code: 'Cell',
           active: false,
           label: 'Cell',
@@ -205,6 +222,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194977',
           code: 'Chapel',
           active: false,
           label: 'Chapel',
@@ -213,6 +231,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194978',
           code: 'Crown Court',
           active: false,
           label: 'Crown Court',
@@ -221,6 +240,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194979',
           code: 'Dining Room',
           active: false,
           label: 'Dining Room',
@@ -229,6 +249,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194980',
           code: 'Dormitory',
           active: false,
           label: 'Dormitory',
@@ -237,6 +258,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194981',
           code: 'Education',
           active: false,
           label: 'Education',
@@ -245,6 +267,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194982',
           code: 'Elsewhere (Specify)',
           active: false,
           label: 'Elsewhere (Specify)',
@@ -253,6 +276,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194983',
           code: 'Exercise Yard',
           active: false,
           label: 'Exercise Yard',
@@ -261,6 +285,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194984',
           code: 'Funeral',
           active: false,
           label: 'Funeral',
@@ -269,6 +294,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194985',
           code: 'Gate',
           active: false,
           label: 'Gate',
@@ -277,6 +303,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194986',
           code: 'Gym',
           active: false,
           label: 'Gym',
@@ -285,6 +312,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194987',
           code: 'Health Care Centre',
           active: false,
           label: 'Health Care Centre',
@@ -293,6 +321,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194988',
           code: 'Hospital Outside (Patient)',
           active: false,
           label: 'Hospital Outside (Patient)',
@@ -301,6 +330,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194989',
           code: 'Hospital Outside (Visiting)',
           active: false,
           label: 'Hospital Outside (Visiting)',
@@ -309,6 +339,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194990',
           code: 'Kitchen',
           active: false,
           label: 'Kitchen',
@@ -317,6 +348,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194991',
           code: 'Magistrates Court',
           active: false,
           label: 'Magistrates Court',
@@ -325,6 +357,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194992',
           code: 'Office',
           active: false,
           label: 'Office',
@@ -333,6 +366,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194993',
           code: 'Outside Working Party',
           active: false,
           label: 'Outside Working Party',
@@ -341,6 +375,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194994',
           code: 'Reception',
           active: false,
           label: 'Reception',
@@ -349,6 +384,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194995',
           code: 'Recess',
           active: false,
           label: 'Recess',
@@ -357,6 +393,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194996',
           code: 'Segregation Unit',
           active: false,
           label: 'Segregation Unit',
@@ -365,6 +402,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194997',
           code: 'Showers / Changing Room',
           active: false,
           label: 'Showers / Changing Room',
@@ -373,6 +411,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194998',
           code: 'Special Unit',
           active: false,
           label: 'Special Unit',
@@ -381,6 +420,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '194999',
           code: 'Sports Field',
           active: false,
           label: 'Sports Field',
@@ -389,6 +429,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195000',
           code: 'Vehicle',
           active: false,
           label: 'Vehicle',
@@ -397,6 +438,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195001',
           code: 'Visits',
           active: false,
           label: 'Visits',
@@ -405,6 +447,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195002',
           code: 'Weddings',
           active: false,
           label: 'Weddings',
@@ -413,6 +456,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195003',
           code: 'Wing',
           active: false,
           label: 'Wing',
@@ -421,6 +465,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195004',
           code: 'Within Perimeter',
           active: false,
           label: 'Within Perimeter',
@@ -429,6 +474,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195005',
           code: 'Works Department',
           active: false,
           label: 'Works Department',
@@ -437,6 +483,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195006',
           code: 'Workshop',
           active: false,
           label: 'Workshop',
@@ -445,6 +492,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195007',
           code: 'Induction / 1st Night Centre',
           active: false,
           label: 'Induction / 1st Night Centre',
@@ -453,6 +501,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195008',
           code: 'Mail Room',
           active: false,
           label: 'Mail Room',
@@ -461,6 +510,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195009',
           code: 'External Roof',
           active: false,
           label: 'External Roof',
@@ -469,6 +519,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49265',
         },
         {
+          id: '195010',
           code: 'Vulnerable Prisoners Unit (VPU)',
           active: false,
           label: 'Vulnerable Prisoners Unit (VPU)',
@@ -486,6 +537,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195011',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -494,6 +546,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49267',
         },
         {
+          id: '195012',
           code: 'No',
           active: false,
           label: 'No',
@@ -511,6 +564,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '194967',
           code: 'External Civilians',
           active: false,
           label: 'External Civilians',
@@ -519,6 +573,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49263',
         },
         {
+          id: '194968',
           code: 'Officer',
           active: false,
           label: 'Officer',
@@ -527,6 +582,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49263',
         },
         {
+          id: '194969',
           code: 'Police',
           active: false,
           label: 'Police',
@@ -535,6 +591,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49263',
         },
         {
+          id: '194970',
           code: 'Prisoner',
           active: false,
           label: 'Prisoner',
@@ -543,6 +600,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49263',
         },
         {
+          id: '194971',
           code: 'Civilian Grades',
           active: false,
           label: 'Civilian Grades',
@@ -560,6 +618,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195013',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -568,6 +627,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49268',
         },
         {
+          id: '195014',
           code: 'No',
           active: false,
           label: 'No',
@@ -585,6 +645,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195015',
           code: 'Forensic Laboratory',
           active: false,
           label: 'Forensic Laboratory',
@@ -593,6 +654,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49269',
         },
         {
+          id: '195016',
           code: 'Local With BDH Kit Or Similar',
           active: false,
           label: 'Local With BDH Kit Or Similar',
@@ -610,6 +672,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195017',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -618,6 +681,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49270',
         },
         {
+          id: '195018',
           code: 'No',
           active: false,
           label: 'No',
@@ -626,6 +690,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195019',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -643,6 +708,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195020',
           code: 'Amphetamines',
           active: false,
           label: 'Amphetamines',
@@ -651,6 +717,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195021',
           code: 'Barbiturates',
           active: false,
           label: 'Barbiturates',
@@ -659,6 +726,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195022',
           code: 'Cannabis',
           active: false,
           label: 'Cannabis',
@@ -667,6 +735,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195023',
           code: 'Cannabis Plant',
           active: false,
           label: 'Cannabis Plant',
@@ -675,6 +744,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195024',
           code: 'Cocaine',
           active: false,
           label: 'Cocaine',
@@ -683,6 +753,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195025',
           code: 'Crack',
           active: false,
           label: 'Crack',
@@ -691,6 +762,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195026',
           code: 'Heroin',
           active: false,
           label: 'Heroin',
@@ -699,6 +771,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195027',
           code: 'LSD',
           active: false,
           label: 'LSD',
@@ -707,6 +780,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195028',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -715,6 +789,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195029',
           code: 'Tranquilisers',
           active: false,
           label: 'Tranquilisers',
@@ -723,6 +798,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195030',
           code: 'Tramadol',
           active: false,
           label: 'Tramadol',
@@ -731,6 +807,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195031',
           code: 'Gabapentin',
           active: false,
           label: 'Gabapentin',
@@ -739,6 +816,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195032',
           code: 'NPS: Spice',
           active: false,
           label: 'NPS: Spice',
@@ -747,6 +825,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195033',
           code: 'NPS: Black Mamba',
           active: false,
           label: 'NPS: Black Mamba',
@@ -755,6 +834,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49271',
         },
         {
+          id: '195034',
           code: 'NPS: Other',
           active: false,
           label: 'NPS: Other',
@@ -772,6 +852,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195035',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -780,6 +861,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49272',
         },
         {
+          id: '195036',
           code: 'No',
           active: false,
           label: 'No',
@@ -797,6 +879,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195037',
           code: 'Authentic Needle',
           active: false,
           label: 'Authentic Needle',
@@ -805,6 +888,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49273',
         },
         {
+          id: '195038',
           code: 'Authentic Syringe',
           active: false,
           label: 'Authentic Syringe',
@@ -813,6 +897,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49273',
         },
         {
+          id: '195039',
           code: 'Improvised Needle',
           active: false,
           label: 'Improvised Needle',
@@ -821,6 +906,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49273',
         },
         {
+          id: '195040',
           code: 'Improvised Syringe',
           active: false,
           label: 'Improvised Syringe',
@@ -829,6 +915,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49273',
         },
         {
+          id: '195041',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -837,6 +924,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49273',
         },
         {
+          id: '195042',
           code: 'Pipe(s)',
           active: false,
           label: 'Pipe(s)',
@@ -845,6 +933,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49273',
         },
         {
+          id: '195043',
           code: 'Roach',
           active: false,
           label: 'Roach',
@@ -862,6 +951,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195044',
           code: 'Name',
           active: false,
           label: 'Name',
@@ -879,6 +969,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195045',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -887,6 +978,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49275',
         },
         {
+          id: '195046',
           code: 'No',
           active: false,
           label: 'No',
@@ -904,6 +996,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195047',
           code: 'Mobile',
           active: false,
           label: 'Mobile',
@@ -912,6 +1005,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49276',
         },
         {
+          id: '195048',
           code: 'SIM Card',
           active: false,
           label: 'SIM Card',
@@ -920,6 +1014,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49276',
         },
         {
+          id: '195049',
           code: 'Charger',
           active: false,
           label: 'Charger',
@@ -928,6 +1023,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49276',
         },
         {
+          id: '195050',
           code: 'Other (Please Specify)',
           active: false,
           label: 'Other (Please Specify)',
@@ -945,6 +1041,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195051',
           code: 'Yes (Please Specify)',
           active: false,
           label: 'Yes (Please Specify)',
@@ -953,6 +1050,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49279',
         },
         {
+          id: '195052',
           code: 'No',
           active: false,
           label: 'No',
@@ -970,6 +1068,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195053',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -978,6 +1077,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49280',
         },
         {
+          id: '195054',
           code: 'Evidence Bag Number',
           active: false,
           label: 'Evidence Bag Number',
@@ -986,6 +1086,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49280',
         },
         {
+          id: '195055',
           code: 'No: Please State Why',
           active: false,
           label: 'No: Please State Why',
@@ -1003,6 +1104,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195056',
           code: 'Name',
           active: false,
           label: 'Name',
@@ -1011,6 +1113,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49281',
         },
         {
+          id: '195057',
           code: 'Grade',
           active: false,
           label: 'Grade',
@@ -1028,6 +1131,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195058',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -1036,6 +1140,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49282',
         },
         {
+          id: '195059',
           code: 'Police Incident Number',
           active: false,
           label: 'Police Incident Number',
@@ -1044,6 +1149,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49282',
         },
         {
+          id: '195060',
           code: 'No',
           active: false,
           label: 'No',
@@ -1061,6 +1167,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195061',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -1069,6 +1176,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49283',
         },
         {
+          id: '195062',
           code: 'Police Reference Number',
           active: false,
           label: 'Police Reference Number',
@@ -1077,6 +1185,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49283',
         },
         {
+          id: '195063',
           code: 'No',
           active: false,
           label: 'No',
@@ -1094,6 +1203,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195064',
           code: '1',
           active: false,
           label: '1',
@@ -1102,6 +1212,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49284',
         },
         {
+          id: '195065',
           code: '2',
           active: false,
           label: '2',
@@ -1110,6 +1221,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49284',
         },
         {
+          id: '195066',
           code: 'Urgent',
           active: false,
           label: 'Urgent',
@@ -1118,6 +1230,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49284',
         },
         {
+          id: '195067',
           code: 'N/A Not Applicable',
           active: false,
           label: 'N/A Not Applicable',
@@ -1135,6 +1248,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195068',
           code: 'Yes (Only Required For Staff, Visitors Or Contractors)',
           active: false,
           label: 'Yes (Only Required For Staff, Visitors Or Contractors)',
@@ -1143,6 +1257,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49285',
         },
         {
+          id: '195069',
           code: 'No (Please State Why)',
           active: false,
           label: 'No (Please State Why)',
@@ -1151,6 +1266,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49285',
         },
         {
+          id: '195070',
           code: 'N/A Not Applicable',
           active: false,
           label: 'N/A Not Applicable',
@@ -1168,6 +1284,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195071',
           code: 'No',
           active: false,
           label: 'No',
@@ -1176,6 +1293,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49286',
         },
         {
+          id: '195072',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1193,6 +1311,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195073',
           code: 'Yes (Date)',
           active: false,
           label: 'Yes (Date)',
@@ -1201,6 +1320,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49287',
         },
         {
+          id: '195074',
           code: 'No',
           active: false,
           label: 'No',
@@ -1218,6 +1338,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195075',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1226,6 +1347,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49288',
         },
         {
+          id: '195076',
           code: 'No',
           active: false,
           label: 'No',
@@ -1243,6 +1365,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195077',
           code: 'Blunt Instrument',
           active: false,
           label: 'Blunt Instrument',
@@ -1251,6 +1374,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49289',
         },
         {
+          id: '195078',
           code: 'Chemical Incapacitant',
           active: false,
           label: 'Chemical Incapacitant',
@@ -1259,6 +1383,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49289',
         },
         {
+          id: '195079',
           code: 'Firearm',
           active: false,
           label: 'Firearm',
@@ -1267,6 +1392,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49289',
         },
         {
+          id: '195080',
           code: 'Item In Sock',
           active: false,
           label: 'Item In Sock',
@@ -1275,6 +1401,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49289',
         },
         {
+          id: '195081',
           code: 'Knife / Blade',
           active: false,
           label: 'Knife / Blade',
@@ -1283,6 +1410,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49289',
         },
         {
+          id: '195082',
           code: 'Other Sharp Instrument',
           active: false,
           label: 'Other Sharp Instrument',
@@ -1291,6 +1419,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49289',
         },
         {
+          id: '195083',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -1308,6 +1437,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195084',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1316,6 +1446,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49290',
         },
         {
+          id: '195085',
           code: 'No',
           active: false,
           label: 'No',
@@ -1333,6 +1464,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195086',
           code: '< 1 Litre',
           active: false,
           label: '< 1 Litre',
@@ -1341,6 +1473,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49291',
         },
         {
+          id: '195087',
           code: '2 Litres',
           active: false,
           label: '2 Litres',
@@ -1349,6 +1482,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49291',
         },
         {
+          id: '195088',
           code: '3 Litres',
           active: false,
           label: '3 Litres',
@@ -1357,6 +1491,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49291',
         },
         {
+          id: '195089',
           code: '4 Litres',
           active: false,
           label: '4 Litres',
@@ -1365,6 +1500,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49291',
         },
         {
+          id: '195090',
           code: '5 Litres',
           active: false,
           label: '5 Litres',
@@ -1373,6 +1509,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49291',
         },
         {
+          id: '195091',
           code: '6 to 10 Litres',
           active: false,
           label: '6 to 10 Litres',
@@ -1381,6 +1518,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49291',
         },
         {
+          id: '195092',
           code: '11 to 20 Litres',
           active: false,
           label: '11 to 20 Litres',
@@ -1389,6 +1527,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49291',
         },
         {
+          id: '195093',
           code: '> 20 Litres',
           active: false,
           label: '> 20 Litres',
@@ -1406,6 +1545,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195094',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1414,6 +1554,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49292',
         },
         {
+          id: '195095',
           code: 'No',
           active: false,
           label: 'No',
@@ -1431,6 +1572,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195096',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1439,6 +1581,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49293',
         },
         {
+          id: '195097',
           code: 'No',
           active: false,
           label: 'No',
@@ -1456,6 +1599,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195098',
           code: 'Enter Details',
           active: false,
           label: 'Enter Details',
@@ -1473,6 +1617,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195099',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1481,6 +1626,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49295',
         },
         {
+          id: '195100',
           code: 'No',
           active: false,
           label: 'No',
@@ -1498,6 +1644,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195101',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1506,6 +1653,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49296',
         },
         {
+          id: '195102',
           code: 'No',
           active: false,
           label: 'No',
@@ -1523,6 +1671,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195103',
           code: 'After Entering Prison',
           active: false,
           label: 'After Entering Prison',
@@ -1531,6 +1680,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49297',
         },
         {
+          id: '195104',
           code: 'Before Entering Prison',
           active: false,
           label: 'Before Entering Prison',
@@ -1548,6 +1698,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195105',
           code: 'Specify',
           active: false,
           label: 'Specify',
@@ -1565,6 +1716,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195106',
           code: 'Prisoner',
           active: false,
           label: 'Prisoner',
@@ -1573,6 +1725,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195107',
           code: 'Visitor (Friend)',
           active: false,
           label: 'Visitor (Friend)',
@@ -1581,6 +1734,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195108',
           code: 'Visitor (Official)',
           active: false,
           label: 'Visitor (Official)',
@@ -1589,6 +1743,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195109',
           code: 'Visitor (Relative)',
           active: false,
           label: 'Visitor (Relative)',
@@ -1597,6 +1752,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195110',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -1605,6 +1761,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195111',
           code: 'Contractor',
           active: false,
           label: 'Contractor',
@@ -1613,6 +1770,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195112',
           code: 'Post (Rule 39)',
           active: false,
           label: 'Post (Rule 39)',
@@ -1621,6 +1779,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195113',
           code: 'Post (Other)',
           active: false,
           label: 'Post (Other)',
@@ -1629,6 +1788,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195114',
           code: 'Thrown In',
           active: false,
           label: 'Thrown In',
@@ -1637,6 +1797,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195115',
           code: 'Drone/UAV',
           active: false,
           label: 'Drone/UAV',
@@ -1645,6 +1806,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195116',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -1653,6 +1815,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49301',
         },
         {
+          id: '195117',
           code: 'Unknown / Not Attributable',
           active: false,
           label: 'Unknown / Not Attributable',
@@ -1670,6 +1833,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195118',
           code: 'BOSS Chair',
           active: false,
           label: 'BOSS Chair',
@@ -1678,6 +1842,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195119',
           code: 'Cell Search',
           active: false,
           label: 'Cell Search',
@@ -1686,6 +1851,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195120',
           code: 'Dog Search',
           active: false,
           label: 'Dog Search',
@@ -1694,6 +1860,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195121',
           code: 'High Intensitivity Wand',
           active: false,
           label: 'High Intensitivity Wand',
@@ -1702,6 +1869,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195122',
           code: 'Information Received',
           active: false,
           label: 'Information Received',
@@ -1710,6 +1878,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195123',
           code: 'Item Observed',
           active: false,
           label: 'Item Observed',
@@ -1718,6 +1887,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195124',
           code: 'Mobile Phone Detector',
           active: false,
           label: 'Mobile Phone Detector',
@@ -1726,6 +1896,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195125',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -1734,6 +1905,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195126',
           code: 'Other Search (Inmate)',
           active: false,
           label: 'Other Search (Inmate)',
@@ -1742,6 +1914,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195127',
           code: 'Other Search (Premises)',
           active: false,
           label: 'Other Search (Premises)',
@@ -1750,6 +1923,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195128',
           code: 'Other Search (Visitor)',
           active: false,
           label: 'Other Search (Visitor)',
@@ -1758,6 +1932,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195129',
           code: 'Pre-Occupation Search',
           active: false,
           label: 'Pre-Occupation Search',
@@ -1766,6 +1941,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49302',
         },
         {
+          id: '195130',
           code: 'Unusual Behaviour',
           active: false,
           label: 'Unusual Behaviour',
@@ -1783,6 +1959,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195131',
           code: 'Prisoner',
           active: false,
           label: 'Prisoner',
@@ -1791,6 +1968,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49303',
         },
         {
+          id: '195132',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -1799,6 +1977,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49303',
         },
         {
+          id: '195133',
           code: 'Contractor',
           active: false,
           label: 'Contractor',
@@ -1807,6 +1986,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49303',
         },
         {
+          id: '195134',
           code: 'Visitor (Friend)',
           active: false,
           label: 'Visitor (Friend)',
@@ -1815,6 +1995,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49303',
         },
         {
+          id: '195135',
           code: 'Visitor (Official)',
           active: false,
           label: 'Visitor (Official)',
@@ -1823,6 +2004,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49303',
         },
         {
+          id: '195136',
           code: 'Visitor (Relative)',
           active: false,
           label: 'Visitor (Relative)',
@@ -1831,6 +2013,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49303',
         },
         {
+          id: '195137',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -1848,6 +2031,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195138',
           code: 'Specify',
           active: false,
           label: 'Specify',
@@ -1865,6 +2049,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195139',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1873,6 +2058,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49305',
         },
         {
+          id: '195140',
           code: 'No',
           active: false,
           label: 'No',
@@ -1890,6 +2076,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195141',
           code: 'Yes; Please State Why',
           active: false,
           label: 'Yes; Please State Why',
@@ -1898,6 +2085,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49306',
         },
         {
+          id: '195142',
           code: 'No',
           active: false,
           label: 'No',
@@ -1915,6 +2103,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195143',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1923,6 +2112,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49307',
         },
         {
+          id: '195144',
           code: 'No',
           active: false,
           label: 'No',
@@ -1931,6 +2121,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: '49307',
         },
         {
+          id: '195145',
           code: 'Unknown / Not Attributable',
           active: false,
           label: 'Unknown / Not Attributable',
@@ -1948,6 +2139,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195146',
           code: 'Community Visit',
           active: false,
           label: 'Community Visit',
@@ -1956,6 +2148,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '195147',
           code: 'Compassionate',
           active: false,
           label: 'Compassionate',
@@ -1964,6 +2157,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '195148',
           code: 'Facility',
           active: false,
           label: 'Facility',
@@ -1972,6 +2166,7 @@ const OLD_FINDS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '195149',
           code: 'Resettlement',
           active: false,
           label: 'Resettlement',

--- a/server/reportConfiguration/types/OLD_FINDS1.ts
+++ b/server/reportConfiguration/types/OLD_FINDS1.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:03.589Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:29.902Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '198684',
           code: 'NO FURTHER ACTION',
           active: false,
           label: 'NO FURTHER ACTION',
@@ -23,6 +24,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51231',
         },
         {
+          id: '198685',
           code: 'IEP REGRESSION',
           active: false,
           label: 'IEP REGRESSION',
@@ -31,6 +33,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51231',
         },
         {
+          id: '198686',
           code: 'PLACED ON REPORT/ADJUDICATION REFERRAL',
           active: false,
           label: 'PLACED ON REPORT/ADJUDICATION REFERRAL',
@@ -39,6 +42,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51231',
         },
         {
+          id: '198687',
           code: 'POLICE REFERRAL',
           active: false,
           label: 'POLICE REFERRAL',
@@ -47,6 +51,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51231',
         },
         {
+          id: '198688',
           code: 'CPS REFERRAL',
           active: false,
           label: 'CPS REFERRAL',
@@ -55,6 +60,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51231',
         },
         {
+          id: '198689',
           code: 'PROSECUTION REFERRAL',
           active: false,
           label: 'PROSECUTION REFERRAL',
@@ -72,6 +78,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198690',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -80,6 +87,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51232',
         },
         {
+          id: '198691',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -97,6 +105,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198692',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -105,6 +114,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51233',
         },
         {
+          id: '198693',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -122,6 +132,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198694',
           code: 'ADMINISTRATION',
           active: false,
           label: 'ADMINISTRATION',
@@ -130,6 +141,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198695',
           code: 'ASSOCIATION AREA',
           active: false,
           label: 'ASSOCIATION AREA',
@@ -138,6 +150,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198696',
           code: 'CELL',
           active: false,
           label: 'CELL',
@@ -146,6 +159,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198697',
           code: 'CHAPEL',
           active: false,
           label: 'CHAPEL',
@@ -154,6 +168,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198698',
           code: 'CROWN COURT',
           active: false,
           label: 'CROWN COURT',
@@ -162,6 +177,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198699',
           code: 'DINING ROOM',
           active: false,
           label: 'DINING ROOM',
@@ -170,6 +186,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198700',
           code: 'DORMITORY',
           active: false,
           label: 'DORMITORY',
@@ -178,6 +195,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198701',
           code: 'EDUCATION',
           active: false,
           label: 'EDUCATION',
@@ -186,6 +204,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198702',
           code: 'ELSEWHERE',
           active: false,
           label: 'ELSEWHERE',
@@ -194,6 +213,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198703',
           code: 'EXERCISE YARD',
           active: false,
           label: 'EXERCISE YARD',
@@ -202,6 +222,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198704',
           code: 'FUNERAL',
           active: false,
           label: 'FUNERAL',
@@ -210,6 +231,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198705',
           code: 'GATE',
           active: false,
           label: 'GATE',
@@ -218,6 +240,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198706',
           code: 'GYM',
           active: false,
           label: 'GYM',
@@ -226,6 +249,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198707',
           code: 'HEALTH CARE CENTRE',
           active: false,
           label: 'HEALTH CARE CENTRE',
@@ -234,6 +258,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198708',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: false,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -242,6 +267,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198709',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: false,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -250,6 +276,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198710',
           code: 'KITCHEN',
           active: false,
           label: 'KITCHEN',
@@ -258,6 +285,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198711',
           code: 'MAGISTRATES COURT',
           active: false,
           label: 'MAGISTRATES COURT',
@@ -266,6 +294,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198712',
           code: 'OFFICE',
           active: false,
           label: 'OFFICE',
@@ -274,6 +303,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198713',
           code: 'OUTSIDE WORKING PARTY',
           active: false,
           label: 'OUTSIDE WORKING PARTY',
@@ -282,6 +312,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198714',
           code: 'RECEPTION',
           active: false,
           label: 'RECEPTION',
@@ -290,6 +321,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198715',
           code: 'RECESS',
           active: false,
           label: 'RECESS',
@@ -298,6 +330,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198716',
           code: 'SEGREGATION UNIT',
           active: false,
           label: 'SEGREGATION UNIT',
@@ -306,6 +339,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198717',
           code: 'SHOWERS/CHANGING ROOM',
           active: false,
           label: 'SHOWERS/CHANGING ROOM',
@@ -314,6 +348,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198718',
           code: 'SPECIAL UNIT',
           active: false,
           label: 'SPECIAL UNIT',
@@ -322,6 +357,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198719',
           code: 'SPORTS FIELD',
           active: false,
           label: 'SPORTS FIELD',
@@ -330,6 +366,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198720',
           code: 'VEHICLE',
           active: false,
           label: 'VEHICLE',
@@ -338,6 +375,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198721',
           code: 'VISITS',
           active: false,
           label: 'VISITS',
@@ -346,6 +384,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198722',
           code: 'WEDDINGS',
           active: false,
           label: 'WEDDINGS',
@@ -354,6 +393,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198723',
           code: 'WING',
           active: false,
           label: 'WING',
@@ -362,6 +402,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198724',
           code: 'WITHIN PERIMETER',
           active: false,
           label: 'WITHIN PERIMETER',
@@ -370,6 +411,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198725',
           code: 'WORKS DEPARTMENT',
           active: false,
           label: 'WORKS DEPARTMENT',
@@ -378,6 +420,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198726',
           code: 'WORKSHOP',
           active: false,
           label: 'WORKSHOP',
@@ -386,6 +429,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198727',
           code: 'INDUCTION/FIRST NIGHT CENTRE',
           active: false,
           label: 'INDUCTION/FIRST NIGHT CENTRE',
@@ -394,6 +438,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198728',
           code: 'MAIL ROOM',
           active: false,
           label: 'MAIL ROOM',
@@ -402,6 +447,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198729',
           code: 'EXTERNAL ROOF',
           active: false,
           label: 'EXTERNAL ROOF',
@@ -410,6 +456,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51234',
         },
         {
+          id: '198730',
           code: 'VULNERABLE PRISONERS UNIT (VPU)',
           active: false,
           label: 'VULNERABLE PRISONERS UNIT (VPU)',
@@ -427,6 +474,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198731',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -435,6 +483,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51235',
         },
         {
+          id: '198732',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -452,6 +501,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '198733',
           code: 'AMPHETAMINES',
           active: false,
           label: 'AMPHETAMINES',
@@ -460,6 +510,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198734',
           code: 'BARBITURATES',
           active: false,
           label: 'BARBITURATES',
@@ -468,6 +519,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198735',
           code: 'BENZODIAZEPINES',
           active: false,
           label: 'BENZODIAZEPINES',
@@ -476,6 +528,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198736',
           code: 'BUPRENORPHINE/SUBUTEX',
           active: false,
           label: 'BUPRENORPHINE/SUBUTEX',
@@ -484,6 +537,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198737',
           code: 'CANNABIS',
           active: false,
           label: 'CANNABIS',
@@ -492,6 +546,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198738',
           code: 'CANNABIS PLANT',
           active: false,
           label: 'CANNABIS PLANT',
@@ -500,6 +555,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198739',
           code: 'COCAINE',
           active: false,
           label: 'COCAINE',
@@ -508,6 +564,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198740',
           code: 'CRACK',
           active: false,
           label: 'CRACK',
@@ -516,6 +573,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198741',
           code: 'HEROIN',
           active: false,
           label: 'HEROIN',
@@ -524,6 +582,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198742',
           code: 'LSD',
           active: false,
           label: 'LSD',
@@ -532,6 +591,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198743',
           code: 'METHADONE',
           active: false,
           label: 'METHADONE',
@@ -540,6 +600,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198744',
           code: 'PREGABALIN',
           active: false,
           label: 'PREGABALIN',
@@ -548,6 +609,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198745',
           code: 'TRANQUILISERS',
           active: false,
           label: 'TRANQUILISERS',
@@ -556,6 +618,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198746',
           code: 'TRAMADOL',
           active: false,
           label: 'TRAMADOL',
@@ -564,6 +627,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198747',
           code: 'GABAPENTIN',
           active: false,
           label: 'GABAPENTIN',
@@ -572,6 +636,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198748',
           code: 'NPS: SPICE',
           active: false,
           label: 'NPS: SPICE',
@@ -580,6 +645,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198749',
           code: 'NPS: BLACK MAMBA',
           active: false,
           label: 'NPS: BLACK MAMBA',
@@ -588,6 +654,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198750',
           code: 'NPS: OTHER',
           active: false,
           label: 'NPS: OTHER',
@@ -596,6 +663,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198751',
           code: 'STEROIDS',
           active: false,
           label: 'STEROIDS',
@@ -604,6 +672,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198752',
           code: 'OTHER (PLEASE SPECIFY)',
           active: false,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -612,6 +681,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51236',
         },
         {
+          id: '198753',
           code: 'UNKNOWN',
           active: false,
           label: 'UNKNOWN',
@@ -629,6 +699,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198754',
           code: '<1G',
           active: false,
           label: '<1G',
@@ -637,6 +708,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198755',
           code: '2G TO 5G',
           active: false,
           label: '2G TO 5G',
@@ -645,6 +717,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198756',
           code: '6G TO 10G',
           active: false,
           label: '6G TO 10G',
@@ -653,6 +726,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198757',
           code: '11G TO 20G',
           active: false,
           label: '11G TO 20G',
@@ -661,6 +735,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198758',
           code: '21G TO 30G',
           active: false,
           label: '21G TO 30G',
@@ -669,6 +744,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198759',
           code: '31G TO 40G',
           active: false,
           label: '31G TO 40G',
@@ -677,6 +753,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198760',
           code: '41G TO 50G',
           active: false,
           label: '41G TO 50G',
@@ -685,6 +762,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198761',
           code: '50G TO 100G',
           active: false,
           label: '50G TO 100G',
@@ -693,6 +771,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198762',
           code: '101G TO 200G',
           active: false,
           label: '101G TO 200G',
@@ -701,6 +780,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198763',
           code: '201G TO 300G',
           active: false,
           label: '201G TO 300G',
@@ -709,6 +789,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198764',
           code: '301G TO 400G',
           active: false,
           label: '301G TO 400G',
@@ -717,6 +798,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198765',
           code: '401G TO 500G',
           active: false,
           label: '401G TO 500G',
@@ -725,6 +807,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198766',
           code: '501G TO 1,000G',
           active: false,
           label: '501G TO 1,000G',
@@ -733,6 +816,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198767',
           code: 'MORE THAN 1KG',
           active: false,
           label: 'MORE THAN 1KG',
@@ -741,6 +825,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51237',
         },
         {
+          id: '198768',
           code: 'UNKNOWN',
           active: false,
           label: 'UNKNOWN',
@@ -758,6 +843,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198769',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -766,6 +852,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51238',
         },
         {
+          id: '198770',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -783,6 +870,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198771',
           code: 'FORENSIC LABORATORY',
           active: false,
           label: 'FORENSIC LABORATORY',
@@ -791,6 +879,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51239',
         },
         {
+          id: '198772',
           code: 'LOCAL WITH BDH KIT OR SIMILAR',
           active: false,
           label: 'LOCAL WITH BDH KIT OR SIMILAR',
@@ -808,6 +897,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198773',
           code: 'NAME',
           active: false,
           label: 'NAME',
@@ -825,6 +915,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198774',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -833,6 +924,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51241',
         },
         {
+          id: '198775',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -850,6 +942,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '198776',
           code: 'AUTHENTIC NEEDLE',
           active: false,
           label: 'AUTHENTIC NEEDLE',
@@ -858,6 +951,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51242',
         },
         {
+          id: '198777',
           code: 'AUTHENTIC SYRINGE',
           active: false,
           label: 'AUTHENTIC SYRINGE',
@@ -866,6 +960,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51242',
         },
         {
+          id: '198778',
           code: 'IMPROVISED NEEDLE',
           active: false,
           label: 'IMPROVISED NEEDLE',
@@ -874,6 +969,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51242',
         },
         {
+          id: '198779',
           code: 'IMPROVISED SYRINGE',
           active: false,
           label: 'IMPROVISED SYRINGE',
@@ -882,6 +978,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51242',
         },
         {
+          id: '198780',
           code: 'PIPE(S)',
           active: false,
           label: 'PIPE(S)',
@@ -890,6 +987,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51242',
         },
         {
+          id: '198781',
           code: 'ROACH',
           active: false,
           label: 'ROACH',
@@ -898,6 +996,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51242',
         },
         {
+          id: '198782',
           code: 'OTHER (PLEASE SPECIFY)',
           active: false,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -915,6 +1014,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198783',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -923,6 +1023,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51243',
         },
         {
+          id: '198784',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -940,6 +1041,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198785',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -948,6 +1050,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51244',
         },
         {
+          id: '198786',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -965,6 +1068,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198787',
           code: '0',
           active: false,
           label: '0',
@@ -973,6 +1077,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198788',
           code: '1',
           active: false,
           label: '1',
@@ -981,6 +1086,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198789',
           code: '2',
           active: false,
           label: '2',
@@ -989,6 +1095,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198790',
           code: '4',
           active: false,
           label: '4',
@@ -997,6 +1104,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198791',
           code: '5',
           active: false,
           label: '5',
@@ -1005,6 +1113,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198792',
           code: '6',
           active: false,
           label: '6',
@@ -1013,6 +1122,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198793',
           code: '7',
           active: false,
           label: '7',
@@ -1021,6 +1131,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198794',
           code: '8',
           active: false,
           label: '8',
@@ -1029,6 +1140,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198795',
           code: '9',
           active: false,
           label: '9',
@@ -1037,6 +1149,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198796',
           code: '10',
           active: false,
           label: '10',
@@ -1045,6 +1158,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198797',
           code: '11',
           active: false,
           label: '11',
@@ -1053,6 +1167,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198798',
           code: '12',
           active: false,
           label: '12',
@@ -1061,6 +1176,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198799',
           code: '13',
           active: false,
           label: '13',
@@ -1069,6 +1185,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198800',
           code: '14',
           active: false,
           label: '14',
@@ -1077,6 +1194,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198801',
           code: '15',
           active: false,
           label: '15',
@@ -1085,6 +1203,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198802',
           code: '16',
           active: false,
           label: '16',
@@ -1093,6 +1212,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198803',
           code: '17',
           active: false,
           label: '17',
@@ -1101,6 +1221,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198804',
           code: '18',
           active: false,
           label: '18',
@@ -1109,6 +1230,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198805',
           code: '19',
           active: false,
           label: '19',
@@ -1117,6 +1239,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198806',
           code: '20',
           active: false,
           label: '20',
@@ -1125,6 +1248,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198807',
           code: 'MORE THAN 20',
           active: false,
           label: 'MORE THAN 20',
@@ -1133,6 +1257,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '198808',
           code: 'UNKNOWN',
           active: false,
           label: 'UNKNOWN',
@@ -1141,6 +1266,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51245',
         },
         {
+          id: '200684',
           code: '3',
           active: false,
           label: '3',
@@ -1158,6 +1284,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198809',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1166,6 +1293,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51246',
         },
         {
+          id: '198810',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1183,6 +1311,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198811',
           code: '0',
           active: false,
           label: '0',
@@ -1191,6 +1320,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198812',
           code: '1',
           active: false,
           label: '1',
@@ -1199,6 +1329,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198813',
           code: '2',
           active: false,
           label: '2',
@@ -1207,6 +1338,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198814',
           code: '3',
           active: false,
           label: '3',
@@ -1215,6 +1347,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198815',
           code: '4',
           active: false,
           label: '4',
@@ -1223,6 +1356,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198816',
           code: '5',
           active: false,
           label: '5',
@@ -1231,6 +1365,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198817',
           code: '6',
           active: false,
           label: '6',
@@ -1239,6 +1374,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198818',
           code: '7',
           active: false,
           label: '7',
@@ -1247,6 +1383,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198819',
           code: '8',
           active: false,
           label: '8',
@@ -1255,6 +1392,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198820',
           code: '9',
           active: false,
           label: '9',
@@ -1263,6 +1401,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198821',
           code: '10',
           active: false,
           label: '10',
@@ -1271,6 +1410,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198822',
           code: '11',
           active: false,
           label: '11',
@@ -1279,6 +1419,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198823',
           code: '12',
           active: false,
           label: '12',
@@ -1287,6 +1428,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198824',
           code: '13',
           active: false,
           label: '13',
@@ -1295,6 +1437,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198825',
           code: '14',
           active: false,
           label: '14',
@@ -1303,6 +1446,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198826',
           code: '15',
           active: false,
           label: '15',
@@ -1311,6 +1455,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198827',
           code: '16',
           active: false,
           label: '16',
@@ -1319,6 +1464,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198828',
           code: '17',
           active: false,
           label: '17',
@@ -1327,6 +1473,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198829',
           code: '18',
           active: false,
           label: '18',
@@ -1335,6 +1482,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198830',
           code: '19',
           active: false,
           label: '19',
@@ -1343,6 +1491,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198831',
           code: '20',
           active: false,
           label: '20',
@@ -1351,6 +1500,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198832',
           code: 'MORE THAN 20',
           active: false,
           label: 'MORE THAN 20',
@@ -1359,6 +1509,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51247',
         },
         {
+          id: '198833',
           code: 'UNKNOWN',
           active: false,
           label: 'UNKNOWN',
@@ -1376,6 +1527,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198834',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1384,6 +1536,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51248',
         },
         {
+          id: '198835',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1401,6 +1554,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198836',
           code: '0',
           active: false,
           label: '0',
@@ -1409,6 +1563,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198837',
           code: '1',
           active: false,
           label: '1',
@@ -1417,6 +1572,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198838',
           code: '2',
           active: false,
           label: '2',
@@ -1425,6 +1581,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198839',
           code: '3',
           active: false,
           label: '3',
@@ -1433,6 +1590,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198840',
           code: '4',
           active: false,
           label: '4',
@@ -1441,6 +1599,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198841',
           code: '5',
           active: false,
           label: '5',
@@ -1449,6 +1608,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198842',
           code: '6',
           active: false,
           label: '6',
@@ -1457,6 +1617,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198843',
           code: '7',
           active: false,
           label: '7',
@@ -1465,6 +1626,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198844',
           code: '8',
           active: false,
           label: '8',
@@ -1473,6 +1635,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198845',
           code: '9',
           active: false,
           label: '9',
@@ -1481,6 +1644,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198846',
           code: '10',
           active: false,
           label: '10',
@@ -1489,6 +1653,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198847',
           code: '11',
           active: false,
           label: '11',
@@ -1497,6 +1662,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198848',
           code: '12',
           active: false,
           label: '12',
@@ -1505,6 +1671,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198849',
           code: '13',
           active: false,
           label: '13',
@@ -1513,6 +1680,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198850',
           code: '14',
           active: false,
           label: '14',
@@ -1521,6 +1689,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198851',
           code: '15',
           active: false,
           label: '15',
@@ -1529,6 +1698,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198852',
           code: '16',
           active: false,
           label: '16',
@@ -1537,6 +1707,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198853',
           code: '17',
           active: false,
           label: '17',
@@ -1545,6 +1716,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198854',
           code: '18',
           active: false,
           label: '18',
@@ -1553,6 +1725,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198855',
           code: '19',
           active: false,
           label: '19',
@@ -1561,6 +1734,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198856',
           code: '20',
           active: false,
           label: '20',
@@ -1569,6 +1743,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198857',
           code: 'MORE THAN 20',
           active: false,
           label: 'MORE THAN 20',
@@ -1577,6 +1752,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51249',
         },
         {
+          id: '198858',
           code: 'UNKNOWN',
           active: false,
           label: 'UNKNOWN',
@@ -1594,6 +1770,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198859',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1602,6 +1779,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51250',
         },
         {
+          id: '198860',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1619,6 +1797,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198861',
           code: 'YES: PLEASE SPECIFY',
           active: false,
           label: 'YES: PLEASE SPECIFY',
@@ -1627,6 +1806,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51251',
         },
         {
+          id: '198862',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1644,6 +1824,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '198863',
           code: 'YES: DATE',
           active: false,
           label: 'YES: DATE',
@@ -1652,6 +1833,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51252',
         },
         {
+          id: '198864',
           code: 'EVIDENCE BAG NUMBER',
           active: false,
           label: 'EVIDENCE BAG NUMBER',
@@ -1660,6 +1842,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51252',
         },
         {
+          id: '198865',
           code: 'NO: PLEASE STATE WHY',
           active: false,
           label: 'NO: PLEASE STATE WHY',
@@ -1677,6 +1860,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198866',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1685,6 +1869,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51253',
         },
         {
+          id: '198867',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1702,6 +1887,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198868',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1710,6 +1896,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51254',
         },
         {
+          id: '198869',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1727,6 +1914,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '198870',
           code: 'BLUNT INSTRUMENT (COSH, ITEM IN SOCK ETC)',
           active: false,
           label: 'BLUNT INSTRUMENT (COSH, ITEM IN SOCK ETC)',
@@ -1735,6 +1923,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51255',
         },
         {
+          id: '198871',
           code: 'KNIFE/BLADED ARTICLE',
           active: false,
           label: 'KNIFE/BLADED ARTICLE',
@@ -1743,6 +1932,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51255',
         },
         {
+          id: '198872',
           code: 'FIREARM (FAKE GUNS, AMMUNITION, CHEMICAL INCAPACITANT ETC)',
           active: false,
           label: 'FIREARM (FAKE GUNS, AMMUNITION, CHEMICAL INCAPACITANT ETC)',
@@ -1751,6 +1941,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51255',
         },
         {
+          id: '198873',
           code: 'OTHER (PLEASE SPECIFY)',
           active: false,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -1768,6 +1959,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198874',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1776,6 +1968,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51256',
         },
         {
+          id: '198875',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1793,6 +1986,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198876',
           code: '< 1 LITRE',
           active: false,
           label: '< 1 LITRE',
@@ -1801,6 +1995,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51257',
         },
         {
+          id: '198877',
           code: '1 TO 2 LITRES',
           active: false,
           label: '1 TO 2 LITRES',
@@ -1809,6 +2004,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51257',
         },
         {
+          id: '198878',
           code: '2 TO 3 LITRES',
           active: false,
           label: '2 TO 3 LITRES',
@@ -1817,6 +2013,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51257',
         },
         {
+          id: '198879',
           code: '3 TO 4 LITRES',
           active: false,
           label: '3 TO 4 LITRES',
@@ -1825,6 +2022,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51257',
         },
         {
+          id: '198880',
           code: '4 TO 5 LITRES',
           active: false,
           label: '4 TO 5 LITRES',
@@ -1833,6 +2031,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51257',
         },
         {
+          id: '198881',
           code: '6 TO 10 LITRES',
           active: false,
           label: '6 TO 10 LITRES',
@@ -1841,6 +2040,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51257',
         },
         {
+          id: '198882',
           code: '11 TO 20 LITRES',
           active: false,
           label: '11 TO 20 LITRES',
@@ -1849,6 +2049,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51257',
         },
         {
+          id: '198883',
           code: 'MORE THAN 20 LITRES',
           active: false,
           label: 'MORE THAN 20 LITRES',
@@ -1857,6 +2058,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51257',
         },
         {
+          id: '198884',
           code: 'UNKNOWN',
           active: false,
           label: 'UNKNOWN',
@@ -1874,6 +2076,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198885',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1882,6 +2085,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51258',
         },
         {
+          id: '198886',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1899,6 +2103,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198887',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1907,6 +2112,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51259',
         },
         {
+          id: '198888',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1924,6 +2130,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198889',
           code: 'PLEASE SPECIFY',
           active: true,
           label: 'PLEASE SPECIFY',
@@ -1941,6 +2148,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '198890',
           code: 'BOSS CHAIR',
           active: true,
           label: 'BOSS CHAIR',
@@ -1949,6 +2157,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198891',
           code: 'CELL SEARCH',
           active: true,
           label: 'CELL SEARCH',
@@ -1957,6 +2166,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198892',
           code: 'CRIME SCENE',
           active: true,
           label: 'CRIME SCENE',
@@ -1965,6 +2175,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198893',
           code: 'DOG SEARCH',
           active: true,
           label: 'DOG SEARCH',
@@ -1973,6 +2184,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198894',
           code: 'HIGH SENSITIVITY WAND',
           active: true,
           label: 'HIGH SENSITIVITY WAND',
@@ -1981,6 +2193,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198895',
           code: 'INFORMATION RECEIVED',
           active: true,
           label: 'INFORMATION RECEIVED',
@@ -1989,6 +2202,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198896',
           code: 'INTELLIGENCE LED SEARCH',
           active: true,
           label: 'INTELLIGENCE LED SEARCH',
@@ -1997,6 +2211,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198897',
           code: 'ITEM OBSERVED',
           active: true,
           label: 'ITEM OBSERVED',
@@ -2005,6 +2220,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198898',
           code: 'MOBILE PHONE SIGNAL DETECTOR',
           active: true,
           label: 'MOBILE PHONE SIGNAL DETECTOR',
@@ -2013,6 +2229,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198899',
           code: 'MOBILE PHONE ROD',
           active: true,
           label: 'MOBILE PHONE ROD',
@@ -2021,6 +2238,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198900',
           code: 'OTHER SEARCH (INMATE)',
           active: true,
           label: 'OTHER SEARCH (INMATE)',
@@ -2029,6 +2247,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198901',
           code: 'OTHER SEARCH (PREMISES)',
           active: true,
           label: 'OTHER SEARCH (PREMISES)',
@@ -2037,6 +2256,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198902',
           code: 'OTHER SEARCH (VISITOR)',
           active: true,
           label: 'OTHER SEARCH (VISITOR)',
@@ -2045,6 +2265,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198903',
           code: 'PRE-OCCUPATION SEARCH',
           active: true,
           label: 'PRE-OCCUPATION SEARCH',
@@ -2053,6 +2274,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198904',
           code: 'UNUSUAL BEHAVIOUR',
           active: true,
           label: 'UNUSUAL BEHAVIOUR',
@@ -2061,6 +2283,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '198905',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -2069,6 +2292,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51261',
         },
         {
+          id: '208853',
           code: 'DRONE RECOVERY',
           active: true,
           label: 'DRONE RECOVERY',
@@ -2086,6 +2310,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '198906',
           code: 'PRISONER',
           active: true,
           label: 'PRISONER',
@@ -2094,6 +2319,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198907',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -2102,6 +2328,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198908',
           code: 'VISITOR (FRIEND)',
           active: true,
           label: 'VISITOR (FRIEND)',
@@ -2110,6 +2337,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198909',
           code: 'VISITOR (OFFICIAL)',
           active: true,
           label: 'VISITOR (OFFICIAL)',
@@ -2118,6 +2346,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198910',
           code: 'VISITOR (RELATIVE)',
           active: true,
           label: 'VISITOR (RELATIVE)',
@@ -2126,6 +2355,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198911',
           code: 'CONTRACTOR',
           active: true,
           label: 'CONTRACTOR',
@@ -2134,6 +2364,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198912',
           code: 'POST (RULE 39)',
           active: true,
           label: 'POST (RULE 39)',
@@ -2142,6 +2373,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198913',
           code: 'POST (OTHER)',
           active: true,
           label: 'POST (OTHER)',
@@ -2150,6 +2382,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198914',
           code: 'THROWN IN',
           active: true,
           label: 'THROWN IN',
@@ -2158,6 +2391,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198915',
           code: 'DRONE/UAV',
           active: true,
           label: 'DRONE/UAV',
@@ -2166,6 +2400,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198916',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -2174,6 +2409,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51262',
         },
         {
+          id: '198917',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2191,6 +2427,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198918',
           code: 'PRISONER',
           active: true,
           label: 'PRISONER',
@@ -2199,6 +2436,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51263',
         },
         {
+          id: '198919',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -2207,6 +2445,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51263',
         },
         {
+          id: '198920',
           code: 'VISITOR (FRIEND)',
           active: true,
           label: 'VISITOR (FRIEND)',
@@ -2215,6 +2454,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51263',
         },
         {
+          id: '198921',
           code: 'VISITOR (OFFICIAL)',
           active: true,
           label: 'VISITOR (OFFICIAL)',
@@ -2223,6 +2463,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51263',
         },
         {
+          id: '198922',
           code: 'VISITOR (RELATIVE)',
           active: true,
           label: 'VISITOR (RELATIVE)',
@@ -2231,6 +2472,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51263',
         },
         {
+          id: '198923',
           code: 'CONTRACTOR',
           active: true,
           label: 'CONTRACTOR',
@@ -2239,6 +2481,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51263',
         },
         {
+          id: '198924',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -2247,6 +2490,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51263',
         },
         {
+          id: '198925',
           code: 'NOT APPLICABLE',
           active: true,
           label: 'NOT APPLICABLE',
@@ -2264,6 +2508,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198926',
           code: 'NOT CONCEALED',
           active: true,
           label: 'NOT CONCEALED',
@@ -2272,6 +2517,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198927',
           code: 'BED/BEDDING',
           active: true,
           label: 'BED/BEDDING',
@@ -2280,6 +2526,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198928',
           code: 'BOOK/PAPERS',
           active: true,
           label: 'BOOK/PAPERS',
@@ -2288,6 +2535,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198929',
           code: 'CELL/BUILDING FABRIC',
           active: true,
           label: 'CELL/BUILDING FABRIC',
@@ -2296,6 +2544,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198930',
           code: 'FOOD/CONTAINER',
           active: true,
           label: 'FOOD/CONTAINER',
@@ -2304,6 +2553,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198931',
           code: 'IN CLOTHING',
           active: true,
           label: 'IN CLOTHING',
@@ -2312,6 +2562,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198932',
           code: 'IN HAND',
           active: true,
           label: 'IN HAND',
@@ -2320,6 +2571,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198933',
           code: 'IN MOUTH',
           active: true,
           label: 'IN MOUTH',
@@ -2328,6 +2580,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198934',
           code: 'INTERNALLY/PLUGGED',
           active: true,
           label: 'INTERNALLY/PLUGGED',
@@ -2336,6 +2589,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198935',
           code: 'LETTER/PARCEL',
           active: true,
           label: 'LETTER/PARCEL',
@@ -2344,6 +2598,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198936',
           code: 'LIGHT FITTINGS',
           active: true,
           label: 'LIGHT FITTINGS',
@@ -2352,6 +2607,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198937',
           code: 'PIPEWORK',
           active: true,
           label: 'PIPEWORK',
@@ -2360,6 +2616,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198938',
           code: 'RULE 39/LEGAL PAPERS',
           active: true,
           label: 'RULE 39/LEGAL PAPERS',
@@ -2368,6 +2625,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198939',
           code: 'TV/RADIO/DVD/CONSOLES ETC',
           active: true,
           label: 'TV/RADIO/DVD/CONSOLES ETC',
@@ -2376,6 +2634,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51264',
         },
         {
+          id: '198940',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -2393,6 +2652,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198941',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2401,6 +2661,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51265',
         },
         {
+          id: '198942',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2418,6 +2679,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198943',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2426,6 +2688,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51266',
         },
         {
+          id: '198944',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2443,6 +2706,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198945',
           code: 'AFTER ENTERING PRISON',
           active: true,
           label: 'AFTER ENTERING PRISON',
@@ -2451,6 +2715,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51267',
         },
         {
+          id: '198946',
           code: 'BEFORE ENTERING PRISON',
           active: true,
           label: 'BEFORE ENTERING PRISON',
@@ -2468,6 +2733,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198947',
           code: 'PLEASE SPECIFY',
           active: true,
           label: 'PLEASE SPECIFY',
@@ -2485,6 +2751,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198948',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2493,6 +2760,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51269',
         },
         {
+          id: '198949',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2501,6 +2769,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51270',
         },
         {
+          id: '198950',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2518,6 +2787,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198951',
           code: 'COMMUNITY VISIT',
           active: true,
           label: 'COMMUNITY VISIT',
@@ -2526,6 +2796,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51270',
         },
         {
+          id: '198952',
           code: 'COMPASSIONATE',
           active: true,
           label: 'COMPASSIONATE',
@@ -2534,6 +2805,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51270',
         },
         {
+          id: '198953',
           code: 'FACILITY',
           active: true,
           label: 'FACILITY',
@@ -2542,6 +2814,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51270',
         },
         {
+          id: '198954',
           code: 'RESETTLEMENT',
           active: true,
           label: 'RESETTLEMENT',
@@ -2550,6 +2823,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '51270',
         },
         {
+          id: '198955',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2567,6 +2841,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '198956',
           code: '£0',
           active: true,
           label: '£0',
@@ -2575,6 +2850,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198957',
           code: '£1 TO £100',
           active: true,
           label: '£1 TO £100',
@@ -2583,6 +2859,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198958',
           code: '£101 TO £200',
           active: true,
           label: '£101 TO £200',
@@ -2591,6 +2868,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198959',
           code: '£201 TO £300',
           active: true,
           label: '£201 TO £300',
@@ -2599,6 +2877,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198960',
           code: '£301 TO £400',
           active: true,
           label: '£301 TO £400',
@@ -2607,6 +2886,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198961',
           code: '£401 TO £500',
           active: true,
           label: '£401 TO £500',
@@ -2615,6 +2895,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198962',
           code: '£501 TO £1000',
           active: true,
           label: '£501 TO £1000',
@@ -2623,6 +2904,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198963',
           code: '£1001 TO £5000',
           active: true,
           label: '£1001 TO £5000',
@@ -2631,6 +2913,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198964',
           code: '£5001 TO £10,000',
           active: true,
           label: '£5001 TO £10,000',
@@ -2639,6 +2922,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198965',
           code: '£10,001 TO £20,000',
           active: true,
           label: '£10,001 TO £20,000',
@@ -2647,6 +2931,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198966',
           code: '£20,001 TO £30,000',
           active: true,
           label: '£20,001 TO £30,000',
@@ -2655,6 +2940,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198967',
           code: '£30,001 TO £40,000',
           active: true,
           label: '£30,001 TO £40,000',
@@ -2663,6 +2949,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198968',
           code: '£40,001 TO £50,000',
           active: true,
           label: '£40,001 TO £50,000',
@@ -2671,6 +2958,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198969',
           code: 'MORE THAN £50,000',
           active: true,
           label: 'MORE THAN £50,000',
@@ -2679,6 +2967,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '198970',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2696,6 +2985,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208855',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -2704,6 +2994,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57224',
         },
         {
+          id: '208856',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -2721,6 +3012,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208857',
           code: 'LOOSE TOBACCO',
           active: false,
           label: 'LOOSE TOBACCO',
@@ -2729,6 +3021,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57225',
         },
         {
+          id: '208872',
           code: 'CIGARETTES/CIGARS',
           active: false,
           label: 'CIGARETTES/CIGARS',
@@ -2737,6 +3030,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57225',
         },
         {
+          id: '208873',
           code: 'OTHER (including packaging and roaches)',
           active: false,
           label: 'OTHER (including packaging and roaches)',
@@ -2754,6 +3048,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208858',
           code: 'UP TO 1 GRAMME',
           active: false,
           label: 'UP TO 1 GRAMME',
@@ -2762,6 +3057,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57226',
         },
         {
+          id: '208874',
           code: '2g TO 5g',
           active: false,
           label: '2g TO 5g',
@@ -2770,6 +3066,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57226',
         },
         {
+          id: '208875',
           code: '6g to 10g',
           active: false,
           label: '6g to 10g',
@@ -2778,6 +3075,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57226',
         },
         {
+          id: '208876',
           code: '10g +',
           active: false,
           label: '10g +',
@@ -2795,6 +3093,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208859',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -2803,6 +3102,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57227',
         },
         {
+          id: '208877',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -2820,6 +3120,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208860',
           code: 'PLEASE SPECIFY',
           active: false,
           label: 'PLEASE SPECIFY',
@@ -2837,6 +3138,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208861',
           code: 'BOSS CHAIR',
           active: false,
           label: 'BOSS CHAIR',
@@ -2845,6 +3147,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57229',
         },
         {
+          id: '208878',
           code: 'CELL SEARCH',
           active: false,
           label: 'CELL SEARCH',
@@ -2853,6 +3156,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57229',
         },
         {
+          id: '208879',
           code: 'CRIME SCENE',
           active: false,
           label: 'CRIME SCENE',
@@ -2861,6 +3165,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57229',
         },
         {
+          id: '208880',
           code: 'DOG SEARCH',
           active: false,
           label: 'DOG SEARCH',
@@ -2869,6 +3174,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57229',
         },
         {
+          id: '208881',
           code: 'DRONE RECOVERY',
           active: false,
           label: 'DRONE RECOVERY',
@@ -2877,6 +3183,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57229',
         },
         {
+          id: '208882',
           code: 'HIGH SENSITIVITY WAND',
           active: false,
           label: 'HIGH SENSITIVITY WAND',
@@ -2885,6 +3192,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208883',
           code: 'INFORMATION RECEIVED',
           active: false,
           label: 'INFORMATION RECEIVED',
@@ -2893,6 +3201,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208884',
           code: 'NTELLIGENCE LED SEARCH',
           active: false,
           label: 'NTELLIGENCE LED SEARCH',
@@ -2901,6 +3210,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208885',
           code: 'ITEM OBSERVED',
           active: false,
           label: 'ITEM OBSERVED',
@@ -2909,6 +3219,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208886',
           code: 'MOBILE PHONE SIGNAL DETECTOR',
           active: false,
           label: 'MOBILE PHONE SIGNAL DETECTOR',
@@ -2917,6 +3228,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208887',
           code: 'MOBILE PHONE ROD',
           active: false,
           label: 'MOBILE PHONE ROD',
@@ -2925,6 +3237,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208888',
           code: 'OTHER SEARCH (INMATE)',
           active: false,
           label: 'OTHER SEARCH (INMATE)',
@@ -2933,6 +3246,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208889',
           code: 'OTHER SEARCH (PREMISES)',
           active: false,
           label: 'OTHER SEARCH (PREMISES)',
@@ -2941,6 +3255,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208890',
           code: 'OTHER SEARCH (VISITOR)',
           active: false,
           label: 'OTHER SEARCH (VISITOR)',
@@ -2949,6 +3264,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208891',
           code: 'PRE-OCCUPATION SEARCH',
           active: false,
           label: 'PRE-OCCUPATION SEARCH',
@@ -2957,6 +3273,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208892',
           code: 'UNUSUAL BEHAVIOUR',
           active: false,
           label: 'UNUSUAL BEHAVIOUR',
@@ -2965,6 +3282,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208893',
           code: 'OTHER (PLEASE SPECIFY)',
           active: false,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -2982,6 +3300,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '208862',
           code: 'PRISONER',
           active: false,
           label: 'PRISONER',
@@ -2990,6 +3309,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208894',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -2998,6 +3318,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208895',
           code: 'VISITOR (FRIEND)',
           active: false,
           label: 'VISITOR (FRIEND)',
@@ -3006,6 +3327,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208896',
           code: 'VISITOR (RELATIVE)',
           active: false,
           label: 'VISITOR (RELATIVE)',
@@ -3014,6 +3336,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208897',
           code: 'VISITOR (OFFICIAL)',
           active: false,
           label: 'VISITOR (OFFICIAL)',
@@ -3022,6 +3345,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208898',
           code: 'CONTRACTOR',
           active: false,
           label: 'CONTRACTOR',
@@ -3030,6 +3354,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208899',
           code: 'POST (RULE39)',
           active: false,
           label: 'POST (RULE39)',
@@ -3038,6 +3363,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208900',
           code: 'POST (OTHER)',
           active: false,
           label: 'POST (OTHER)',
@@ -3046,6 +3372,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208901',
           code: 'DRONE/UAV',
           active: false,
           label: 'DRONE/UAV',
@@ -3054,6 +3381,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208902',
           code: 'OTHER (PLEASE SPECIFY',
           active: false,
           label: 'OTHER (PLEASE SPECIFY',
@@ -3062,6 +3390,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208903',
           code: 'UNKNOWN',
           active: false,
           label: 'UNKNOWN',
@@ -3070,6 +3399,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57230',
         },
         {
+          id: '208904',
           code: 'THROWN IN',
           active: false,
           label: 'THROWN IN',
@@ -3087,6 +3417,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208863',
           code: 'PRISONER',
           active: false,
           label: 'PRISONER',
@@ -3095,6 +3426,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57231',
         },
         {
+          id: '208905',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -3103,6 +3435,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57231',
         },
         {
+          id: '208906',
           code: 'VISITOR (FRIEND)',
           active: false,
           label: 'VISITOR (FRIEND)',
@@ -3111,6 +3444,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57231',
         },
         {
+          id: '208907',
           code: 'VISITOR (OFFICIAL)',
           active: false,
           label: 'VISITOR (OFFICIAL)',
@@ -3119,6 +3453,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57231',
         },
         {
+          id: '208908',
           code: 'VISITOR (RELATIVE)',
           active: false,
           label: 'VISITOR (RELATIVE)',
@@ -3127,6 +3462,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57231',
         },
         {
+          id: '208909',
           code: 'CONTRACTOR',
           active: false,
           label: 'CONTRACTOR',
@@ -3135,6 +3471,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57231',
         },
         {
+          id: '208910',
           code: 'OTHER (PLEASE SPECIFY)',
           active: false,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -3143,6 +3480,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57231',
         },
         {
+          id: '208911',
           code: 'NOT APPLICABLE',
           active: false,
           label: 'NOT APPLICABLE',
@@ -3160,6 +3498,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208864',
           code: 'NOT CONCEALED',
           active: false,
           label: 'NOT CONCEALED',
@@ -3168,6 +3507,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208912',
           code: 'NOT CONCEALED',
           active: false,
           label: 'NOT CONCEALED',
@@ -3176,6 +3516,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208913',
           code: 'BED/BEDDING',
           active: false,
           label: 'BED/BEDDING',
@@ -3184,6 +3525,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208914',
           code: 'BOOK/PAPERS',
           active: false,
           label: 'BOOK/PAPERS',
@@ -3192,6 +3534,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208915',
           code: 'CELL/BUILDING FABRIC',
           active: false,
           label: 'CELL/BUILDING FABRIC',
@@ -3200,6 +3543,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208916',
           code: 'FOOD/CONTAINER',
           active: false,
           label: 'FOOD/CONTAINER',
@@ -3208,6 +3552,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208917',
           code: 'IN CLOTHING',
           active: false,
           label: 'IN CLOTHING',
@@ -3216,6 +3561,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208918',
           code: 'IN HAND',
           active: false,
           label: 'IN HAND',
@@ -3224,6 +3570,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208919',
           code: 'IN MOUTH',
           active: false,
           label: 'IN MOUTH',
@@ -3232,6 +3579,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208920',
           code: 'INTERNALLY/PLUGGED',
           active: false,
           label: 'INTERNALLY/PLUGGED',
@@ -3240,6 +3588,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208921',
           code: 'LETTER/PARCEL',
           active: false,
           label: 'LETTER/PARCEL',
@@ -3248,6 +3597,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208922',
           code: 'LIGHT FITTINGS',
           active: false,
           label: 'LIGHT FITTINGS',
@@ -3256,6 +3606,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208923',
           code: 'PIPEWORK',
           active: false,
           label: 'PIPEWORK',
@@ -3264,6 +3615,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208924',
           code: 'RULE 39/LEGAL PAPERS',
           active: false,
           label: 'RULE 39/LEGAL PAPERS',
@@ -3272,6 +3624,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208925',
           code: 'TV/RADIO/DVD/CONSOLES ETC.',
           active: false,
           label: 'TV/RADIO/DVD/CONSOLES ETC.',
@@ -3280,6 +3633,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57232',
         },
         {
+          id: '208926',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -3297,6 +3651,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208865',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -3305,6 +3660,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57233',
         },
         {
+          id: '208927',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -3322,6 +3678,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208866',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -3330,6 +3687,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57234',
         },
         {
+          id: '208928',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -3347,6 +3705,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208867',
           code: 'AFTER ENTERING PRISON',
           active: false,
           label: 'AFTER ENTERING PRISON',
@@ -3355,6 +3714,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57235',
         },
         {
+          id: '208929',
           code: 'BEFORE ENTERING PRISON',
           active: false,
           label: 'BEFORE ENTERING PRISON',
@@ -3372,6 +3732,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208868',
           code: 'SPECIFY',
           active: false,
           label: 'SPECIFY',
@@ -3389,6 +3750,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208869',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -3397,6 +3759,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57237',
         },
         {
+          id: '208930',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -3405,6 +3768,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57238',
         },
         {
+          id: '208931',
           code: 'UNKNOWN',
           active: false,
           label: 'UNKNOWN',
@@ -3422,6 +3786,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208870',
           code: 'COMMUNITY VISIT',
           active: false,
           label: 'COMMUNITY VISIT',
@@ -3430,6 +3795,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57238',
         },
         {
+          id: '208932',
           code: 'COMPASSIONATE',
           active: false,
           label: 'COMPASSIONATE',
@@ -3438,6 +3804,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57238',
         },
         {
+          id: '208933',
           code: 'FACILTY',
           active: false,
           label: 'FACILTY',
@@ -3446,6 +3813,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57238',
         },
         {
+          id: '208934',
           code: 'RESETTLEMENT',
           active: false,
           label: 'RESETTLEMENT',
@@ -3454,6 +3822,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: '57238',
         },
         {
+          id: '208935',
           code: 'UNKNOWN',
           active: false,
           label: 'UNKNOWN',
@@ -3471,6 +3840,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '208871',
           code: '£0',
           active: false,
           label: '£0',
@@ -3479,6 +3849,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208936',
           code: '£1 to £100',
           active: false,
           label: '£1 to £100',
@@ -3487,6 +3858,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208937',
           code: '£101 to £200',
           active: false,
           label: '£101 to £200',
@@ -3495,6 +3867,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208938',
           code: '£201 to £300',
           active: false,
           label: '£201 to £300',
@@ -3503,6 +3876,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208939',
           code: '£301 to £400',
           active: false,
           label: '£301 to £400',
@@ -3511,6 +3885,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208940',
           code: '£401 to £500',
           active: false,
           label: '£401 to £500',
@@ -3519,6 +3894,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208941',
           code: '£501 to £1,000',
           active: false,
           label: '£501 to £1,000',
@@ -3527,6 +3903,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208942',
           code: '£1,001 to £5,000',
           active: false,
           label: '£1,001 to £5,000',
@@ -3535,6 +3912,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208943',
           code: '£5,001 to £10,000',
           active: false,
           label: '£5,001 to £10,000',
@@ -3543,6 +3921,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208944',
           code: '£10,001 to £20,000',
           active: false,
           label: '£10,001 to £20,000',
@@ -3551,6 +3930,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208945',
           code: '£20,001 to £30,000',
           active: false,
           label: '£20,001 to £30,000',
@@ -3559,6 +3939,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208946',
           code: '£30,001 to £40,000',
           active: false,
           label: '£30,001 to £40,000',
@@ -3567,6 +3948,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208947',
           code: '£40,001 to £50,000',
           active: false,
           label: '£40,001 to £50,000',
@@ -3575,6 +3957,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208948',
           code: 'More than £50,000',
           active: false,
           label: 'More than £50,000',
@@ -3583,6 +3966,7 @@ const OLD_FINDS1: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '208949',
           code: 'UNKNOWN',
           active: false,
           label: 'UNKNOWN',

--- a/server/reportConfiguration/types/OLD_FINDS2.ts
+++ b/server/reportConfiguration/types/OLD_FINDS2.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:06.406Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:32.658Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '196684',
           code: 'No Further Action',
           active: false,
           label: 'No Further Action',
@@ -23,6 +24,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51185',
         },
         {
+          id: '196685',
           code: 'IEP Regression',
           active: false,
           label: 'IEP Regression',
@@ -31,6 +33,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51185',
         },
         {
+          id: '196686',
           code: 'Placed on report/adjudication referral',
           active: false,
           label: 'Placed on report/adjudication referral',
@@ -39,6 +42,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51185',
         },
         {
+          id: '196687',
           code: 'Police referral',
           active: false,
           label: 'Police referral',
@@ -47,6 +51,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51185',
         },
         {
+          id: '196688',
           code: 'CPS referral',
           active: false,
           label: 'CPS referral',
@@ -55,6 +60,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51185',
         },
         {
+          id: '196689',
           code: 'Prosecution referral',
           active: false,
           label: 'Prosecution referral',
@@ -72,6 +78,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196690',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -80,6 +87,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51186',
         },
         {
+          id: '196691',
           code: 'No',
           active: false,
           label: 'No',
@@ -97,6 +105,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196692',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -105,6 +114,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51187',
         },
         {
+          id: '196693',
           code: 'No',
           active: false,
           label: 'No',
@@ -122,6 +132,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196694',
           code: 'Administration',
           active: false,
           label: 'Administration',
@@ -130,6 +141,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196695',
           code: 'Association Area',
           active: false,
           label: 'Association Area',
@@ -138,6 +150,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196696',
           code: 'Cell',
           active: false,
           label: 'Cell',
@@ -146,6 +159,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196697',
           code: 'Chapel',
           active: false,
           label: 'Chapel',
@@ -154,6 +168,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196698',
           code: 'Crown Court',
           active: false,
           label: 'Crown Court',
@@ -162,6 +177,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196699',
           code: 'Dining Room',
           active: false,
           label: 'Dining Room',
@@ -170,6 +186,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196700',
           code: 'Dormitory',
           active: false,
           label: 'Dormitory',
@@ -178,6 +195,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196701',
           code: 'Education',
           active: false,
           label: 'Education',
@@ -186,6 +204,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196702',
           code: 'Elsewhere',
           active: false,
           label: 'Elsewhere',
@@ -194,6 +213,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196703',
           code: 'Exercise Yard',
           active: false,
           label: 'Exercise Yard',
@@ -202,6 +222,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196704',
           code: 'Funeral',
           active: false,
           label: 'Funeral',
@@ -210,6 +231,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196705',
           code: 'Gate',
           active: false,
           label: 'Gate',
@@ -218,6 +240,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196706',
           code: 'Gym',
           active: false,
           label: 'Gym',
@@ -226,6 +249,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196707',
           code: 'Health Care Centre',
           active: false,
           label: 'Health Care Centre',
@@ -234,6 +258,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196708',
           code: 'Hospital Outside (Patient)',
           active: false,
           label: 'Hospital Outside (Patient)',
@@ -242,6 +267,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196709',
           code: 'Hospital Outside (Visiting)',
           active: false,
           label: 'Hospital Outside (Visiting)',
@@ -250,6 +276,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196710',
           code: 'Kitchen',
           active: false,
           label: 'Kitchen',
@@ -258,6 +285,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196711',
           code: 'Magistrates Court',
           active: false,
           label: 'Magistrates Court',
@@ -266,6 +294,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196712',
           code: 'Office',
           active: false,
           label: 'Office',
@@ -274,6 +303,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196713',
           code: 'Outside Working Party',
           active: false,
           label: 'Outside Working Party',
@@ -282,6 +312,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196714',
           code: 'Reception',
           active: false,
           label: 'Reception',
@@ -290,6 +321,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196715',
           code: 'Recess',
           active: false,
           label: 'Recess',
@@ -298,6 +330,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196716',
           code: 'Segregation Unit',
           active: false,
           label: 'Segregation Unit',
@@ -306,6 +339,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196717',
           code: 'Showers/Changing Room',
           active: false,
           label: 'Showers/Changing Room',
@@ -314,6 +348,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196718',
           code: 'Special Unit',
           active: false,
           label: 'Special Unit',
@@ -322,6 +357,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196719',
           code: 'Sports Field',
           active: false,
           label: 'Sports Field',
@@ -330,6 +366,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196720',
           code: 'Vehicle',
           active: false,
           label: 'Vehicle',
@@ -338,6 +375,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196721',
           code: 'Visits',
           active: false,
           label: 'Visits',
@@ -346,6 +384,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196722',
           code: 'Weddings',
           active: false,
           label: 'Weddings',
@@ -354,6 +393,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196723',
           code: 'Wing',
           active: false,
           label: 'Wing',
@@ -362,6 +402,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196724',
           code: 'Within Perimeter',
           active: false,
           label: 'Within Perimeter',
@@ -370,6 +411,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196725',
           code: 'Works Department',
           active: false,
           label: 'Works Department',
@@ -378,6 +420,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196726',
           code: 'Workshop',
           active: false,
           label: 'Workshop',
@@ -386,6 +429,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196727',
           code: 'Induction / 1st Night Centre',
           active: false,
           label: 'Induction / 1st Night Centre',
@@ -394,6 +438,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196728',
           code: 'Mail Room',
           active: false,
           label: 'Mail Room',
@@ -402,6 +447,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196729',
           code: 'External Roof',
           active: false,
           label: 'External Roof',
@@ -410,6 +456,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51188',
         },
         {
+          id: '196730',
           code: 'Vulnerable Prisoners Unit (VPU)',
           active: false,
           label: 'Vulnerable Prisoners Unit (VPU)',
@@ -427,6 +474,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196731',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -435,6 +483,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51189',
         },
         {
+          id: '196732',
           code: 'No',
           active: false,
           label: 'No',
@@ -452,6 +501,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '196733',
           code: 'Amphetamines',
           active: false,
           label: 'Amphetamines',
@@ -460,6 +510,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196734',
           code: 'Barbiturates',
           active: false,
           label: 'Barbiturates',
@@ -468,6 +519,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196735',
           code: 'Benzodiazepines',
           active: false,
           label: 'Benzodiazepines',
@@ -476,6 +528,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196736',
           code: 'Buprenorphine/Subutex',
           active: false,
           label: 'Buprenorphine/Subutex',
@@ -484,6 +537,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196737',
           code: 'Cannabis',
           active: false,
           label: 'Cannabis',
@@ -492,6 +546,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196738',
           code: 'Cannabis Plant',
           active: false,
           label: 'Cannabis Plant',
@@ -500,6 +555,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196739',
           code: 'Cocaine',
           active: false,
           label: 'Cocaine',
@@ -508,6 +564,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196740',
           code: 'Crack',
           active: false,
           label: 'Crack',
@@ -516,6 +573,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196741',
           code: 'Heroin',
           active: false,
           label: 'Heroin',
@@ -524,6 +582,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196742',
           code: 'LSD',
           active: false,
           label: 'LSD',
@@ -532,6 +591,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196743',
           code: 'Methadone',
           active: false,
           label: 'Methadone',
@@ -540,6 +600,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196744',
           code: 'Pregabalin',
           active: false,
           label: 'Pregabalin',
@@ -548,6 +609,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196745',
           code: 'Tranquilisers',
           active: false,
           label: 'Tranquilisers',
@@ -556,6 +618,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196746',
           code: 'Tramadol',
           active: false,
           label: 'Tramadol',
@@ -564,6 +627,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196747',
           code: 'Gabapentin',
           active: false,
           label: 'Gabapentin',
@@ -572,6 +636,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196748',
           code: 'NPS: Spice',
           active: false,
           label: 'NPS: Spice',
@@ -580,6 +645,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196749',
           code: 'NPS: Black Mamba',
           active: false,
           label: 'NPS: Black Mamba',
@@ -588,6 +654,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196750',
           code: 'NPS: Other',
           active: false,
           label: 'NPS: Other',
@@ -596,6 +663,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196751',
           code: 'Steroids',
           active: false,
           label: 'Steroids',
@@ -604,6 +672,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196752',
           code: 'Other (please specify)',
           active: false,
           label: 'Other (please specify)',
@@ -612,6 +681,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51190',
         },
         {
+          id: '196753',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -629,6 +699,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196754',
           code: '<1g',
           active: false,
           label: '<1g',
@@ -637,6 +708,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196755',
           code: '2g to 5g',
           active: false,
           label: '2g to 5g',
@@ -645,6 +717,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196756',
           code: '6g to 10g',
           active: false,
           label: '6g to 10g',
@@ -653,6 +726,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196757',
           code: '11g to 20g',
           active: false,
           label: '11g to 20g',
@@ -661,6 +735,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196758',
           code: '21g to 30g',
           active: false,
           label: '21g to 30g',
@@ -669,6 +744,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196759',
           code: '31g to 40g',
           active: false,
           label: '31g to 40g',
@@ -677,6 +753,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196760',
           code: '41g to 50g',
           active: false,
           label: '41g to 50g',
@@ -685,6 +762,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196761',
           code: '51g to 100g',
           active: false,
           label: '51g to 100g',
@@ -693,6 +771,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196762',
           code: '101g to 200g',
           active: false,
           label: '101g to 200g',
@@ -701,6 +780,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196763',
           code: '201g to 300g',
           active: false,
           label: '201g to 300g',
@@ -709,6 +789,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196764',
           code: '301g to 400g',
           active: false,
           label: '301g to 400g',
@@ -717,6 +798,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196765',
           code: '401g to 500g',
           active: false,
           label: '401g to 500g',
@@ -725,6 +807,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196766',
           code: '501g to 1000g',
           active: false,
           label: '501g to 1000g',
@@ -733,6 +816,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196767',
           code: 'More than 1Kg',
           active: false,
           label: 'More than 1Kg',
@@ -741,6 +825,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51191',
         },
         {
+          id: '196768',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -758,6 +843,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196769',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -766,6 +852,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51192',
         },
         {
+          id: '196770',
           code: 'No',
           active: false,
           label: 'No',
@@ -783,6 +870,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196771',
           code: 'Forensic laboratory',
           active: false,
           label: 'Forensic laboratory',
@@ -791,6 +879,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51193',
         },
         {
+          id: '196772',
           code: 'Local with BDH kit or similar',
           active: false,
           label: 'Local with BDH kit or similar',
@@ -808,6 +897,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196773',
           code: 'Name',
           active: false,
           label: 'Name',
@@ -825,6 +915,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196774',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -833,6 +924,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51195',
         },
         {
+          id: '196775',
           code: 'No',
           active: false,
           label: 'No',
@@ -850,6 +942,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '196776',
           code: 'Authentic needle',
           active: false,
           label: 'Authentic needle',
@@ -858,6 +951,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51196',
         },
         {
+          id: '196777',
           code: 'Authentic syringe',
           active: false,
           label: 'Authentic syringe',
@@ -866,6 +960,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51196',
         },
         {
+          id: '196778',
           code: 'Improvised needle',
           active: false,
           label: 'Improvised needle',
@@ -874,6 +969,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51196',
         },
         {
+          id: '196779',
           code: 'Improvised syringe',
           active: false,
           label: 'Improvised syringe',
@@ -882,6 +978,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51196',
         },
         {
+          id: '196780',
           code: 'Pipe(s)',
           active: false,
           label: 'Pipe(s)',
@@ -890,6 +987,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51196',
         },
         {
+          id: '196781',
           code: 'Roach',
           active: false,
           label: 'Roach',
@@ -898,6 +996,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51196',
         },
         {
+          id: '196782',
           code: 'Other (please specify)',
           active: false,
           label: 'Other (please specify)',
@@ -915,6 +1014,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196783',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -923,6 +1023,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51197',
         },
         {
+          id: '196784',
           code: 'No',
           active: false,
           label: 'No',
@@ -940,6 +1041,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196785',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -948,6 +1050,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51198',
         },
         {
+          id: '196786',
           code: 'No',
           active: false,
           label: 'No',
@@ -965,6 +1068,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196787',
           code: '0',
           active: false,
           label: '0',
@@ -973,6 +1077,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196788',
           code: '1',
           active: false,
           label: '1',
@@ -981,6 +1086,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196789',
           code: '2',
           active: false,
           label: '2',
@@ -989,6 +1095,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196790',
           code: '3',
           active: false,
           label: '3',
@@ -997,6 +1104,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196791',
           code: '4',
           active: false,
           label: '4',
@@ -1005,6 +1113,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196792',
           code: '5',
           active: false,
           label: '5',
@@ -1013,6 +1122,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196793',
           code: '6',
           active: false,
           label: '6',
@@ -1021,6 +1131,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196794',
           code: '7',
           active: false,
           label: '7',
@@ -1029,6 +1140,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196795',
           code: '8',
           active: false,
           label: '8',
@@ -1037,6 +1149,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196796',
           code: '9',
           active: false,
           label: '9',
@@ -1045,6 +1158,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196797',
           code: '10',
           active: false,
           label: '10',
@@ -1053,6 +1167,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196798',
           code: '11',
           active: false,
           label: '11',
@@ -1061,6 +1176,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196799',
           code: '12',
           active: false,
           label: '12',
@@ -1069,6 +1185,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196800',
           code: '13',
           active: false,
           label: '13',
@@ -1077,6 +1194,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196801',
           code: '14',
           active: false,
           label: '14',
@@ -1085,6 +1203,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196802',
           code: '15',
           active: false,
           label: '15',
@@ -1093,6 +1212,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196803',
           code: '16',
           active: false,
           label: '16',
@@ -1101,6 +1221,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196804',
           code: '17',
           active: false,
           label: '17',
@@ -1109,6 +1230,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196805',
           code: '18',
           active: false,
           label: '18',
@@ -1117,6 +1239,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196806',
           code: '20',
           active: false,
           label: '20',
@@ -1125,6 +1248,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196807',
           code: 'More than 20',
           active: false,
           label: 'More than 20',
@@ -1133,6 +1257,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51199',
         },
         {
+          id: '196808',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -1150,6 +1275,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196809',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1158,6 +1284,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51200',
         },
         {
+          id: '196810',
           code: 'No',
           active: false,
           label: 'No',
@@ -1166,6 +1293,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51200',
         },
         {
+          id: '196812',
           code: 'No',
           active: false,
           label: 'No',
@@ -1183,6 +1311,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196811',
           code: '0',
           active: false,
           label: '0',
@@ -1191,6 +1320,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196813',
           code: '1',
           active: false,
           label: '1',
@@ -1199,6 +1329,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196814',
           code: '2',
           active: false,
           label: '2',
@@ -1207,6 +1338,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196815',
           code: '3',
           active: false,
           label: '3',
@@ -1215,6 +1347,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196816',
           code: '4',
           active: false,
           label: '4',
@@ -1223,6 +1356,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196817',
           code: '5',
           active: false,
           label: '5',
@@ -1231,6 +1365,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196818',
           code: '6',
           active: false,
           label: '6',
@@ -1239,6 +1374,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196819',
           code: '7',
           active: false,
           label: '7',
@@ -1247,6 +1383,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196820',
           code: '8',
           active: false,
           label: '8',
@@ -1255,6 +1392,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196821',
           code: '9',
           active: false,
           label: '9',
@@ -1263,6 +1401,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196822',
           code: '10',
           active: false,
           label: '10',
@@ -1271,6 +1410,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196823',
           code: '11',
           active: false,
           label: '11',
@@ -1279,6 +1419,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196824',
           code: '12',
           active: false,
           label: '12',
@@ -1287,6 +1428,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196825',
           code: '13',
           active: false,
           label: '13',
@@ -1295,6 +1437,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196826',
           code: '14',
           active: false,
           label: '14',
@@ -1303,6 +1446,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196827',
           code: '15',
           active: false,
           label: '15',
@@ -1311,6 +1455,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196828',
           code: '16',
           active: false,
           label: '16',
@@ -1319,6 +1464,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196829',
           code: '17',
           active: false,
           label: '17',
@@ -1327,6 +1473,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196830',
           code: '18',
           active: false,
           label: '18',
@@ -1335,6 +1482,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196831',
           code: '19',
           active: false,
           label: '19',
@@ -1343,6 +1491,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196832',
           code: '20',
           active: false,
           label: '20',
@@ -1351,6 +1500,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196833',
           code: 'More than 20',
           active: false,
           label: 'More than 20',
@@ -1359,6 +1509,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51201',
         },
         {
+          id: '196834',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -1376,6 +1527,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196835',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1384,6 +1536,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51202',
         },
         {
+          id: '196836',
           code: 'No',
           active: false,
           label: 'No',
@@ -1401,6 +1554,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196837',
           code: '0',
           active: false,
           label: '0',
@@ -1409,6 +1563,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196838',
           code: '1',
           active: false,
           label: '1',
@@ -1417,6 +1572,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196839',
           code: '2',
           active: false,
           label: '2',
@@ -1425,6 +1581,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196840',
           code: '3',
           active: false,
           label: '3',
@@ -1433,6 +1590,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196841',
           code: '4',
           active: false,
           label: '4',
@@ -1441,6 +1599,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196842',
           code: '5',
           active: false,
           label: '5',
@@ -1449,6 +1608,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196843',
           code: '6',
           active: false,
           label: '6',
@@ -1457,6 +1617,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196844',
           code: '7',
           active: false,
           label: '7',
@@ -1465,6 +1626,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196845',
           code: '8',
           active: false,
           label: '8',
@@ -1473,6 +1635,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196846',
           code: '9',
           active: false,
           label: '9',
@@ -1481,6 +1644,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196847',
           code: '10',
           active: false,
           label: '10',
@@ -1489,6 +1653,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196848',
           code: '11',
           active: false,
           label: '11',
@@ -1497,6 +1662,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196849',
           code: '12',
           active: false,
           label: '12',
@@ -1505,6 +1671,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196850',
           code: '13',
           active: false,
           label: '13',
@@ -1513,6 +1680,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196851',
           code: '14',
           active: false,
           label: '14',
@@ -1521,6 +1689,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196852',
           code: '15',
           active: false,
           label: '15',
@@ -1529,6 +1698,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196853',
           code: '16',
           active: false,
           label: '16',
@@ -1537,6 +1707,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196854',
           code: '17',
           active: false,
           label: '17',
@@ -1545,6 +1716,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196855',
           code: '18',
           active: false,
           label: '18',
@@ -1553,6 +1725,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196856',
           code: '19',
           active: false,
           label: '19',
@@ -1561,6 +1734,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196857',
           code: '20',
           active: false,
           label: '20',
@@ -1569,6 +1743,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196858',
           code: 'More than 20',
           active: false,
           label: 'More than 20',
@@ -1577,6 +1752,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51203',
         },
         {
+          id: '196859',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -1594,6 +1770,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196860',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1602,6 +1779,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51204',
         },
         {
+          id: '196861',
           code: 'No',
           active: false,
           label: 'No',
@@ -1619,6 +1797,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196862',
           code: 'Yes (please specify)',
           active: false,
           label: 'Yes (please specify)',
@@ -1627,6 +1806,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51205',
         },
         {
+          id: '196863',
           code: 'No',
           active: false,
           label: 'No',
@@ -1644,6 +1824,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '196864',
           code: 'Yes (Date)',
           active: false,
           label: 'Yes (Date)',
@@ -1652,6 +1833,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51206',
         },
         {
+          id: '196865',
           code: 'Evidence Bag Number',
           active: false,
           label: 'Evidence Bag Number',
@@ -1660,6 +1842,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51206',
         },
         {
+          id: '196866',
           code: 'No (please state why)',
           active: false,
           label: 'No (please state why)',
@@ -1677,6 +1860,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196867',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1685,6 +1869,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51207',
         },
         {
+          id: '196868',
           code: 'No',
           active: false,
           label: 'No',
@@ -1702,6 +1887,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196869',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1710,6 +1896,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51208',
         },
         {
+          id: '196870',
           code: 'No',
           active: false,
           label: 'No',
@@ -1727,6 +1914,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '196871',
           code: 'Blunt Instrument (Cosh, Item in Sock, etc)',
           active: false,
           label: 'Blunt Instrument (Cosh, Item in Sock, etc)',
@@ -1735,6 +1923,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51209',
         },
         {
+          id: '196872',
           code: 'Knife / Bladed Article',
           active: false,
           label: 'Knife / Bladed Article',
@@ -1743,6 +1932,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51209',
         },
         {
+          id: '196873',
           code: 'Firearm (Fake guns, ammunition, chemical incapacitant etc)',
           active: false,
           label: 'Firearm (Fake guns, ammunition, chemical incapacitant etc)',
@@ -1751,6 +1941,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51209',
         },
         {
+          id: '196874',
           code: 'Other (Please specify',
           active: false,
           label: 'Other (Please specify',
@@ -1768,6 +1959,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196875',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1776,6 +1968,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51210',
         },
         {
+          id: '196876',
           code: 'No',
           active: false,
           label: 'No',
@@ -1793,6 +1986,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196877',
           code: '< 1 Litre',
           active: false,
           label: '< 1 Litre',
@@ -1801,6 +1995,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51211',
         },
         {
+          id: '196878',
           code: '1 to 2 Litres',
           active: false,
           label: '1 to 2 Litres',
@@ -1809,6 +2004,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51211',
         },
         {
+          id: '196879',
           code: '2 to 3 Litres',
           active: false,
           label: '2 to 3 Litres',
@@ -1817,6 +2013,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51211',
         },
         {
+          id: '196880',
           code: '3 to 4 Litres',
           active: false,
           label: '3 to 4 Litres',
@@ -1825,6 +2022,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51211',
         },
         {
+          id: '196881',
           code: '4 to 5 Litres',
           active: false,
           label: '4 to 5 Litres',
@@ -1833,6 +2031,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51211',
         },
         {
+          id: '196882',
           code: '6 to 10 Litres',
           active: false,
           label: '6 to 10 Litres',
@@ -1841,6 +2040,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51211',
         },
         {
+          id: '196883',
           code: '11 to 20 Litres',
           active: false,
           label: '11 to 20 Litres',
@@ -1849,6 +2049,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51211',
         },
         {
+          id: '196884',
           code: 'More than 20 Litres',
           active: false,
           label: 'More than 20 Litres',
@@ -1857,6 +2058,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51211',
         },
         {
+          id: '196885',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -1874,6 +2076,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196886',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1882,6 +2085,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51213',
         },
         {
+          id: '196887',
           code: 'No',
           active: false,
           label: 'No',
@@ -1890,6 +2094,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51214',
         },
         {
+          id: '196888',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1898,6 +2103,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51212',
         },
         {
+          id: '196889',
           code: 'No',
           active: false,
           label: 'No',
@@ -1915,6 +2121,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196890',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1923,6 +2130,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51213',
         },
         {
+          id: '196891',
           code: 'No',
           active: false,
           label: 'No',
@@ -1940,6 +2148,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196892',
           code: 'Please specify',
           active: false,
           label: 'Please specify',
@@ -1957,6 +2166,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '196893',
           code: 'BOSS Chair',
           active: false,
           label: 'BOSS Chair',
@@ -1965,6 +2175,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196894',
           code: 'Cell Search',
           active: false,
           label: 'Cell Search',
@@ -1973,6 +2184,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196895',
           code: 'Crime scene',
           active: false,
           label: 'Crime scene',
@@ -1981,6 +2193,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196896',
           code: 'Dog search',
           active: false,
           label: 'Dog search',
@@ -1989,6 +2202,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196897',
           code: 'High Sensitivity Wand',
           active: false,
           label: 'High Sensitivity Wand',
@@ -1997,6 +2211,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196898',
           code: 'Information received',
           active: false,
           label: 'Information received',
@@ -2005,6 +2220,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196899',
           code: 'Intelligence led search',
           active: false,
           label: 'Intelligence led search',
@@ -2013,6 +2229,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196900',
           code: 'Item observed',
           active: false,
           label: 'Item observed',
@@ -2021,6 +2238,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196901',
           code: 'Mobile phone signal detector',
           active: false,
           label: 'Mobile phone signal detector',
@@ -2029,6 +2247,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196902',
           code: 'Mobile phone rod',
           active: false,
           label: 'Mobile phone rod',
@@ -2037,6 +2256,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196903',
           code: 'Other search (inmate)',
           active: false,
           label: 'Other search (inmate)',
@@ -2045,6 +2265,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196904',
           code: 'Other search (premises)',
           active: false,
           label: 'Other search (premises)',
@@ -2053,6 +2274,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196905',
           code: 'Other search (visitor)',
           active: false,
           label: 'Other search (visitor)',
@@ -2061,6 +2283,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196906',
           code: 'Pre-occupation search',
           active: false,
           label: 'Pre-occupation search',
@@ -2069,6 +2292,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196907',
           code: 'Unusual behaviour',
           active: false,
           label: 'Unusual behaviour',
@@ -2077,6 +2301,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51215',
         },
         {
+          id: '196908',
           code: 'Other (please specify)',
           active: false,
           label: 'Other (please specify)',
@@ -2094,6 +2319,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '196909',
           code: 'Prisoner',
           active: false,
           label: 'Prisoner',
@@ -2102,6 +2328,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196910',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -2110,6 +2337,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196911',
           code: 'Visitor (friend)',
           active: false,
           label: 'Visitor (friend)',
@@ -2118,6 +2346,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196912',
           code: 'Viistor (official)',
           active: false,
           label: 'Viistor (official)',
@@ -2126,6 +2355,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196913',
           code: 'Visitor (relative)',
           active: false,
           label: 'Visitor (relative)',
@@ -2134,6 +2364,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196914',
           code: 'Contractor',
           active: false,
           label: 'Contractor',
@@ -2142,6 +2373,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196915',
           code: 'Post (Rule 39)',
           active: false,
           label: 'Post (Rule 39)',
@@ -2150,6 +2382,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196916',
           code: 'Post (Other)',
           active: false,
           label: 'Post (Other)',
@@ -2158,6 +2391,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196917',
           code: 'Thrown in',
           active: false,
           label: 'Thrown in',
@@ -2166,6 +2400,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196918',
           code: 'Drone / UAV',
           active: false,
           label: 'Drone / UAV',
@@ -2174,6 +2409,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196919',
           code: 'Other (please specify)',
           active: false,
           label: 'Other (please specify)',
@@ -2182,6 +2418,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51216',
         },
         {
+          id: '196920',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -2199,6 +2436,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196921',
           code: 'Prisoner',
           active: false,
           label: 'Prisoner',
@@ -2207,6 +2445,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51217',
         },
         {
+          id: '196922',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -2215,6 +2454,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51217',
         },
         {
+          id: '196923',
           code: 'Visitor (Friend)',
           active: false,
           label: 'Visitor (Friend)',
@@ -2223,6 +2463,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51217',
         },
         {
+          id: '196924',
           code: 'Visitor (Official)',
           active: false,
           label: 'Visitor (Official)',
@@ -2231,6 +2472,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51217',
         },
         {
+          id: '196925',
           code: 'Visitor (Relative)',
           active: false,
           label: 'Visitor (Relative)',
@@ -2239,6 +2481,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51217',
         },
         {
+          id: '196926',
           code: 'Contractor',
           active: false,
           label: 'Contractor',
@@ -2247,6 +2490,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51217',
         },
         {
+          id: '196927',
           code: 'Other (please specify)',
           active: false,
           label: 'Other (please specify)',
@@ -2255,6 +2499,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51217',
         },
         {
+          id: '196928',
           code: 'Not Applicable',
           active: false,
           label: 'Not Applicable',
@@ -2272,6 +2517,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196929',
           code: 'Not concealed',
           active: false,
           label: 'Not concealed',
@@ -2280,6 +2526,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196930',
           code: 'Bed / bedding',
           active: false,
           label: 'Bed / bedding',
@@ -2288,6 +2535,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196931',
           code: 'Book / Papers',
           active: false,
           label: 'Book / Papers',
@@ -2296,6 +2544,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196932',
           code: 'Cell / Building Fabric',
           active: false,
           label: 'Cell / Building Fabric',
@@ -2304,6 +2553,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196933',
           code: 'Food / Container',
           active: false,
           label: 'Food / Container',
@@ -2312,6 +2562,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196934',
           code: 'In Clothing',
           active: false,
           label: 'In Clothing',
@@ -2320,6 +2571,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196935',
           code: 'In Hand',
           active: false,
           label: 'In Hand',
@@ -2328,6 +2580,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196936',
           code: 'In Mouth',
           active: false,
           label: 'In Mouth',
@@ -2336,6 +2589,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196937',
           code: 'Internally / Plugged',
           active: false,
           label: 'Internally / Plugged',
@@ -2344,6 +2598,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196938',
           code: 'Letter / Parcel',
           active: false,
           label: 'Letter / Parcel',
@@ -2352,6 +2607,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196939',
           code: 'Light Fittings',
           active: false,
           label: 'Light Fittings',
@@ -2360,6 +2616,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196940',
           code: 'Pipework',
           active: false,
           label: 'Pipework',
@@ -2368,6 +2625,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196941',
           code: 'Rule 39 / Legal Papers',
           active: false,
           label: 'Rule 39 / Legal Papers',
@@ -2376,6 +2634,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196942',
           code: 'TV / Radio / DVD / Consoles etc',
           active: false,
           label: 'TV / Radio / DVD / Consoles etc',
@@ -2384,6 +2643,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51218',
         },
         {
+          id: '196943',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -2401,6 +2661,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196944',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2409,6 +2670,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51219',
         },
         {
+          id: '196945',
           code: 'No',
           active: false,
           label: 'No',
@@ -2426,6 +2688,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196946',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2434,6 +2697,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51220',
         },
         {
+          id: '196947',
           code: 'No',
           active: false,
           label: 'No',
@@ -2451,6 +2715,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196948',
           code: 'After entering prison',
           active: false,
           label: 'After entering prison',
@@ -2459,6 +2724,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51221',
         },
         {
+          id: '196949',
           code: 'Before entering prison',
           active: false,
           label: 'Before entering prison',
@@ -2476,6 +2742,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196950',
           code: 'Specify',
           active: false,
           label: 'Specify',
@@ -2493,6 +2760,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196951',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -2501,6 +2769,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51223',
         },
         {
+          id: '196952',
           code: 'No',
           active: false,
           label: 'No',
@@ -2509,6 +2778,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51224',
         },
         {
+          id: '196953',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -2526,6 +2796,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196954',
           code: 'Communtiy Visit',
           active: false,
           label: 'Communtiy Visit',
@@ -2534,6 +2805,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51224',
         },
         {
+          id: '196955',
           code: 'Compassionate',
           active: false,
           label: 'Compassionate',
@@ -2542,6 +2814,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51224',
         },
         {
+          id: '196956',
           code: 'Facility',
           active: false,
           label: 'Facility',
@@ -2550,6 +2823,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51224',
         },
         {
+          id: '196957',
           code: 'Resettlement',
           active: false,
           label: 'Resettlement',
@@ -2558,6 +2832,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: '51224',
         },
         {
+          id: '196958',
           code: 'Unknown',
           active: false,
           label: 'Unknown',
@@ -2575,6 +2850,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '196959',
           code: '£0',
           active: false,
           label: '£0',
@@ -2583,6 +2859,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196960',
           code: '£1 to £100',
           active: false,
           label: '£1 to £100',
@@ -2591,6 +2868,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196961',
           code: '£101 to £200',
           active: false,
           label: '£101 to £200',
@@ -2599,6 +2877,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196962',
           code: '£201 to £300',
           active: false,
           label: '£201 to £300',
@@ -2607,6 +2886,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196963',
           code: '£301 to £400',
           active: false,
           label: '£301 to £400',
@@ -2615,6 +2895,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196964',
           code: '£401 to £500',
           active: false,
           label: '£401 to £500',
@@ -2623,6 +2904,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196965',
           code: '£501 to £1,000',
           active: false,
           label: '£501 to £1,000',
@@ -2631,6 +2913,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196966',
           code: '£1,001 to £5,000',
           active: false,
           label: '£1,001 to £5,000',
@@ -2639,6 +2922,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196967',
           code: '£5,001 to £10,000',
           active: false,
           label: '£5,001 to £10,000',
@@ -2647,6 +2931,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196968',
           code: '£10,001 to £20,000',
           active: false,
           label: '£10,001 to £20,000',
@@ -2655,6 +2940,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196969',
           code: '£20,001 to £30,000',
           active: false,
           label: '£20,001 to £30,000',
@@ -2663,6 +2949,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196970',
           code: '£30,001 to £40,000',
           active: false,
           label: '£30,001 to £40,000',
@@ -2671,6 +2958,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196971',
           code: '£40,001 to £50,000',
           active: false,
           label: '£40,001 to £50,000',
@@ -2679,6 +2967,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196972',
           code: 'More than £50,000',
           active: false,
           label: 'More than £50,000',
@@ -2687,6 +2976,7 @@ const OLD_FINDS2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '196973',
           code: 'Unknown',
           active: false,
           label: 'Unknown',

--- a/server/reportConfiguration/types/OLD_FINDS3.ts
+++ b/server/reportConfiguration/types/OLD_FINDS3.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:04.438Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:30.797Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '216684',
           code: 'AMNESTY',
           active: true,
           label: 'AMNESTY',
@@ -23,6 +24,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216685',
           code: 'ARCHWAY METAL DETECTOR (AMD)',
           active: true,
           label: 'ARCHWAY METAL DETECTOR (AMD)',
@@ -31,6 +33,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216686',
           code: 'BOSS CHAIR',
           active: true,
           label: 'BOSS CHAIR',
@@ -39,6 +42,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216687',
           code: 'CELL SEARCH',
           active: true,
           label: 'CELL SEARCH',
@@ -47,6 +51,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216688',
           code: 'CRIME SCENE',
           active: true,
           label: 'CRIME SCENE',
@@ -55,6 +60,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216689',
           code: 'DOG SEARCH',
           active: true,
           label: 'DOG SEARCH',
@@ -63,6 +69,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216690',
           code: 'DRONE RECOVERY',
           active: true,
           label: 'DRONE RECOVERY',
@@ -71,6 +78,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216691',
           code: 'DRUG TRACE DETECTION MACHINE',
           active: true,
           label: 'DRUG TRACE DETECTION MACHINE',
@@ -79,6 +87,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216692',
           code: 'GATE SEARCH - ENHANCED GATE SECURITY (EGS)',
           active: true,
           label: 'GATE SEARCH - ENHANCED GATE SECURITY (EGS)',
@@ -87,6 +96,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216693',
           code: 'GATE SEARCH - FRONT END SEARCH (FES), HIGH SECURITY ONLY (HSE)',
           active: true,
           label: 'GATE SEARCH - FRONT END SEARCH (FES), HIGH SECURITY ONLY (HSE)',
@@ -95,6 +105,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216694',
           code: 'GATE SEARCH - OTHER',
           active: true,
           label: 'GATE SEARCH - OTHER',
@@ -103,6 +114,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216695',
           code: 'HAND HELD METAL DETECTION (HHMD) WAND',
           active: true,
           label: 'HAND HELD METAL DETECTION (HHMD) WAND',
@@ -111,6 +123,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216696',
           code: 'INFORMATION RECEIVED',
           active: true,
           label: 'INFORMATION RECEIVED',
@@ -119,6 +132,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216697',
           code: 'INTELLIGENCE LED SEARCH',
           active: true,
           label: 'INTELLIGENCE LED SEARCH',
@@ -127,6 +141,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216698',
           code: 'ITEM HANDED OVER',
           active: true,
           label: 'ITEM HANDED OVER',
@@ -135,6 +150,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216699',
           code: 'ITEM OBSERVED & RECOVERED',
           active: true,
           label: 'ITEM OBSERVED & RECOVERED',
@@ -143,6 +159,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216700',
           code: 'MOBILE PHONE SIGNAL DETECTOR',
           active: true,
           label: 'MOBILE PHONE SIGNAL DETECTOR',
@@ -151,6 +168,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216701',
           code: 'PHONE DETECTION POLE',
           active: true,
           label: 'PHONE DETECTION POLE',
@@ -159,6 +177,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216702',
           code: 'PRE-OCCUPATION SEARCH',
           active: true,
           label: 'PRE-OCCUPATION SEARCH',
@@ -167,6 +186,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216703',
           code: 'UNUSUAL BEHAVIOUR',
           active: true,
           label: 'UNUSUAL BEHAVIOUR',
@@ -175,6 +195,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216704',
           code: 'X-RAY BAGGAGE SCANNER',
           active: true,
           label: 'X-RAY BAGGAGE SCANNER',
@@ -183,6 +204,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216705',
           code: 'X-RAY BODY SCANNER',
           active: true,
           label: 'X-RAY BODY SCANNER',
@@ -191,6 +213,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216706',
           code: 'OTHER SEARCH (PRISONER)',
           active: true,
           label: 'OTHER SEARCH (PRISONER)',
@@ -199,6 +222,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216707',
           code: 'OTHER SEARCH (PREMISES)',
           active: true,
           label: 'OTHER SEARCH (PREMISES)',
@@ -207,6 +231,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216708',
           code: 'OTHER SEARCH (STAFF)',
           active: true,
           label: 'OTHER SEARCH (STAFF)',
@@ -215,6 +240,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216709',
           code: 'OTHER SEARCH (VISITOR)',
           active: true,
           label: 'OTHER SEARCH (VISITOR)',
@@ -223,6 +249,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65180',
         },
         {
+          id: '216710',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -240,6 +267,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216711',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -248,6 +276,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216712',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -265,6 +294,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216713',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -273,6 +303,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216714',
           code: 'ASSOCIATION AREA (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'ASSOCIATION AREA (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -281,6 +312,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216715',
           code: 'CELL  (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'CELL  (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -289,6 +321,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216716',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -297,6 +330,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216717',
           code: 'COURT',
           active: true,
           label: 'COURT',
@@ -305,6 +339,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216718',
           code: 'DINING ROOM (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'DINING ROOM (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -313,6 +348,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216719',
           code: 'DORMITORY (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'DORMITORY (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -321,6 +357,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216720',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -329,6 +366,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216721',
           code: 'EXERCISE YARD (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'EXERCISE YARD (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -337,6 +375,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216722',
           code: 'GATE',
           active: true,
           label: 'GATE',
@@ -345,6 +384,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216723',
           code: 'GYM',
           active: true,
           label: 'GYM',
@@ -353,6 +393,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216724',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -361,6 +402,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216725',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: true,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -369,6 +411,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216726',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: true,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -377,6 +420,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216727',
           code: 'INDUCTION/FIRST NIGHT CENTRE',
           active: true,
           label: 'INDUCTION/FIRST NIGHT CENTRE',
@@ -385,6 +429,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216728',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -393,6 +438,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216729',
           code: 'MAIL ROOM',
           active: true,
           label: 'MAIL ROOM',
@@ -401,6 +447,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216730',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -409,6 +456,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216731',
           code: 'OUTSIDE WORKING PARTY',
           active: true,
           label: 'OUTSIDE WORKING PARTY',
@@ -417,6 +465,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216732',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -425,6 +474,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216733',
           code: 'RECESS/ ROOF VOID',
           active: true,
           label: 'RECESS/ ROOF VOID',
@@ -433,6 +483,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216734',
           code: 'SEGREGATION UNIT (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'SEGREGATION UNIT (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -441,6 +492,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216735',
           code: 'SHOWERS/CHANGING ROOM (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'SHOWERS/CHANGING ROOM (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -449,6 +501,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216736',
           code: 'VEHICLE USED FOR COURT/TRANSFER',
           active: true,
           label: 'VEHICLE USED FOR COURT/TRANSFER',
@@ -457,6 +510,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216737',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -465,6 +519,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216738',
           code: 'VULNERABLE PRISONERS UNIT (VPU) (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'VULNERABLE PRISONERS UNIT (VPU) (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -473,6 +528,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216739',
           code: 'WING (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'WING (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -481,6 +537,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216740',
           code: 'WORKSHOP (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'WORKSHOP (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -489,6 +546,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65182',
         },
         {
+          id: '216741',
           code: 'OTHER (PLEASE STATE LOCATION DETAILS IN COMMENT)',
           active: true,
           label: 'OTHER (PLEASE STATE LOCATION DETAILS IN COMMENT)',
@@ -506,6 +564,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216742',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -514,6 +573,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216743',
           code: 'CONTRACTOR',
           active: true,
           label: 'CONTRACTOR',
@@ -522,6 +582,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216744',
           code: 'DRONE/UAV',
           active: true,
           label: 'DRONE/UAV',
@@ -530,6 +591,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216745',
           code: 'POST - RULE 39 (CHECK RULE 39 MAIL, BARCODED)',
           active: true,
           label: 'POST - RULE 39 (CHECK RULE 39 MAIL, BARCODED)',
@@ -538,6 +600,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65183',
         },
         {
+          id: '216746',
           code: 'POST - RULE 39 (NOT CHECK RULE 39 MAIL, NO BARCODE)',
           active: true,
           label: 'POST - RULE 39 (NOT CHECK RULE 39 MAIL, NO BARCODE)',
@@ -546,6 +609,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216747',
           code: 'POST - OTHER',
           active: true,
           label: 'POST - OTHER',
@@ -554,6 +618,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216748',
           code: 'PRISONER',
           active: true,
           label: 'PRISONER',
@@ -562,6 +627,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216749',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -570,6 +636,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216750',
           code: 'THROWN IN',
           active: true,
           label: 'THROWN IN',
@@ -578,6 +645,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216751',
           code: 'VISITOR - DOMESTIC',
           active: true,
           label: 'VISITOR - DOMESTIC',
@@ -586,6 +654,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216752',
           code: 'VISITOR - SOCIAL',
           active: true,
           label: 'VISITOR - SOCIAL',
@@ -594,6 +663,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216753',
           code: 'VISITOR - OTHER (PLEASE ENTER COMMENT TO EXPLAIN)',
           active: true,
           label: 'VISITOR - OTHER (PLEASE ENTER COMMENT TO EXPLAIN)',
@@ -611,6 +681,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216754',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -619,6 +690,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65184',
         },
         {
+          id: '216755',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -636,6 +708,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216756',
           code: 'NOT APPLICABLE',
           active: true,
           label: 'NOT APPLICABLE',
@@ -644,6 +717,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65186',
         },
         {
+          id: '216757',
           code: 'CONTRACTOR',
           active: true,
           label: 'CONTRACTOR',
@@ -652,6 +726,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65185',
         },
         {
+          id: '216758',
           code: 'PRISONER',
           active: true,
           label: 'PRISONER',
@@ -660,6 +735,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65185',
         },
         {
+          id: '216759',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -668,6 +744,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65185',
         },
         {
+          id: '216760',
           code: 'VISITOR - DOMESTIC',
           active: true,
           label: 'VISITOR - DOMESTIC',
@@ -676,6 +753,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65185',
         },
         {
+          id: '216761',
           code: 'VISITOR - SOCIAL',
           active: true,
           label: 'VISITOR - SOCIAL',
@@ -684,6 +762,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65185',
         },
         {
+          id: '216762',
           code: 'VISITOR - OTHER (PLEASE ENTER COMMENT TO EXPLAIN)',
           active: true,
           label: 'VISITOR - OTHER (PLEASE ENTER COMMENT TO EXPLAIN)',
@@ -692,6 +771,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65185',
         },
         {
+          id: '216763',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -700,6 +780,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65185',
         },
         {
+          id: '216764',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -717,6 +798,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216765',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -725,6 +807,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65186',
         },
         {
+          id: '216766',
           code: 'YES (e.g. ITEM RETURN TO STAFF AT END OF SHIFT/VISIT)',
           active: true,
           label: 'YES (e.g. ITEM RETURN TO STAFF AT END OF SHIFT/VISIT)',
@@ -733,6 +816,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65186',
         },
         {
+          id: '216767',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -750,6 +834,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '216768',
           code: 'NOT CONCEALED',
           active: true,
           label: 'NOT CONCEALED',
@@ -758,6 +843,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216769',
           code: 'BED/BEDDING',
           active: true,
           label: 'BED/BEDDING',
@@ -766,6 +852,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216770',
           code: 'BOOK/PAPERS',
           active: true,
           label: 'BOOK/PAPERS',
@@ -774,6 +861,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216771',
           code: 'CELL/BUILDING FABRIC',
           active: true,
           label: 'CELL/BUILDING FABRIC',
@@ -782,6 +870,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216772',
           code: 'FOOD/CONTAINER',
           active: true,
           label: 'FOOD/CONTAINER',
@@ -790,6 +879,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216773',
           code: 'IN BAG (i.e. BACKPACK/BRIEFCASE/HANDBAG)',
           active: true,
           label: 'IN BAG (i.e. BACKPACK/BRIEFCASE/HANDBAG)',
@@ -798,6 +888,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216774',
           code: 'IN CLOTHING',
           active: true,
           label: 'IN CLOTHING',
@@ -806,6 +897,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216775',
           code: 'IN HAND',
           active: true,
           label: 'IN HAND',
@@ -814,6 +906,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216776',
           code: 'IN MOUTH',
           active: true,
           label: 'IN MOUTH',
@@ -822,6 +915,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216777',
           code: 'INTERNALLY CONCEALED',
           active: true,
           label: 'INTERNALLY CONCEALED',
@@ -830,6 +924,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216778',
           code: 'LETTER/PARCEL',
           active: true,
           label: 'LETTER/PARCEL',
@@ -838,6 +933,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216779',
           code: 'LIGHT FITTINGS',
           active: true,
           label: 'LIGHT FITTINGS',
@@ -846,6 +942,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216780',
           code: 'PIPEWORK',
           active: true,
           label: 'PIPEWORK',
@@ -854,6 +951,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216781',
           code: 'RULE 39/LEGAL PAPERS',
           active: true,
           label: 'RULE 39/LEGAL PAPERS',
@@ -862,6 +960,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216782',
           code: 'TV/RADIO/DVD/CONSOLES ETC',
           active: true,
           label: 'TV/RADIO/DVD/CONSOLES ETC',
@@ -870,6 +969,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65187',
         },
         {
+          id: '216783',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -887,6 +987,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216784',
           code: 'MULTIPLE TYPES (SEE FULL BELOW LIST BEFORE SELECTING)',
           active: true,
           label: 'MULTIPLE TYPES (SEE FULL BELOW LIST BEFORE SELECTING)',
@@ -895,6 +996,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65207',
         },
         {
+          id: '216785',
           code: 'ALCOHOL / HOOCH / DISTILLING EQUIPMENT',
           active: true,
           label: 'ALCOHOL / HOOCH / DISTILLING EQUIPMENT',
@@ -903,6 +1005,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65188',
         },
         {
+          id: '216786',
           code: 'DRUG / DRUG EQUIPMENT',
           active: true,
           label: 'DRUG / DRUG EQUIPMENT',
@@ -911,6 +1014,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65190',
         },
         {
+          id: '216787',
           code: 'MOBILE PHONE / MOBILE RELATED ITEM',
           active: true,
           label: 'MOBILE PHONE / MOBILE RELATED ITEM',
@@ -919,6 +1023,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65194',
         },
         {
+          id: '216788',
           code: 'DIGITAL FIND (EXLUDING MOBILE PHONES)',
           active: true,
           label: 'DIGITAL FIND (EXLUDING MOBILE PHONES)',
@@ -927,6 +1032,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65200',
         },
         {
+          id: '216789',
           code: 'TOBACCO / TOBACCO RELATED ITEMS',
           active: true,
           label: 'TOBACCO / TOBACCO RELATED ITEMS',
@@ -935,6 +1041,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65201',
         },
         {
+          id: '216790',
           code: 'WEAPON',
           active: true,
           label: 'WEAPON',
@@ -943,6 +1050,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65203',
         },
         {
+          id: '216791',
           code: 'OTHER REPORTALE ITEMS (BY NATIONAL OR LOCAL POLICY)',
           active: true,
           label: 'OTHER REPORTALE ITEMS (BY NATIONAL OR LOCAL POLICY)',
@@ -960,6 +1068,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216792',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -968,6 +1077,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65190',
         },
         {
+          id: '216793',
           code: 'LESS THAN 1 LITRE (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'LESS THAN 1 LITRE (PLEASE STATE NUMBER IN COMMENTS)',
@@ -976,6 +1086,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65190',
         },
         {
+          id: '216794',
           code: '1 LITRE TO LESS THAN 2 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '1 LITRE TO LESS THAN 2 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -984,6 +1095,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65190',
         },
         {
+          id: '216795',
           code: '2 LITRES TO LESS THAN 3 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '2 LITRES TO LESS THAN 3 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -992,6 +1104,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65190',
         },
         {
+          id: '216796',
           code: '3 LITRES TO LESS THAN 4 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '3 LITRES TO LESS THAN 4 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -1000,6 +1113,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65190',
         },
         {
+          id: '216797',
           code: '4 LITRES TO LESS THAN 5 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '4 LITRES TO LESS THAN 5 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -1008,6 +1122,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65190',
         },
         {
+          id: '216798',
           code: '5 LITRES TO LESS THAN 10 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '5 LITRES TO LESS THAN 10 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -1016,6 +1131,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65190',
         },
         {
+          id: '216799',
           code: '10 LITRES TO LESS THAN 20 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '10 LITRES TO LESS THAN 20 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -1024,6 +1140,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65190',
         },
         {
+          id: '216800',
           code: '20 LITRES OR MORE (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '20 LITRES OR MORE (PLEASE STATE NUMBER IN COMMENTS)',
@@ -1041,6 +1158,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216801',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1049,6 +1167,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216802',
           code: 'YES (Please specify)',
           active: true,
           label: 'YES (Please specify)',
@@ -1066,6 +1185,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '216803',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1074,6 +1194,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216804',
           code: 'NONE FOUND',
           active: true,
           label: 'NONE FOUND',
@@ -1082,6 +1203,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216805',
           code: 'AMPHETAMINES',
           active: true,
           label: 'AMPHETAMINES',
@@ -1090,6 +1212,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216806',
           code: 'BARBITURATES',
           active: true,
           label: 'BARBITURATES',
@@ -1098,6 +1221,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216807',
           code: 'BENZODIAZEPINES',
           active: true,
           label: 'BENZODIAZEPINES',
@@ -1106,6 +1230,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216808',
           code: 'BUPRENORPHINE/SUBUTEX',
           active: true,
           label: 'BUPRENORPHINE/SUBUTEX',
@@ -1114,6 +1239,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216809',
           code: 'CANNABIS',
           active: true,
           label: 'CANNABIS',
@@ -1122,6 +1248,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216810',
           code: 'CANNABIS PLANT',
           active: true,
           label: 'CANNABIS PLANT',
@@ -1130,6 +1257,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216811',
           code: 'COCAINE',
           active: true,
           label: 'COCAINE',
@@ -1138,6 +1266,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216812',
           code: 'CRACK',
           active: true,
           label: 'CRACK',
@@ -1146,6 +1275,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216813',
           code: 'GABAPENTIN',
           active: true,
           label: 'GABAPENTIN',
@@ -1154,6 +1284,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216814',
           code: 'HEROIN',
           active: true,
           label: 'HEROIN',
@@ -1162,6 +1293,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216815',
           code: 'KETAMINE',
           active: true,
           label: 'KETAMINE',
@@ -1170,6 +1302,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216816',
           code: 'LSD',
           active: true,
           label: 'LSD',
@@ -1178,6 +1311,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216817',
           code: 'METHADONE',
           active: true,
           label: 'METHADONE',
@@ -1186,6 +1320,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216818',
           code: 'NPS (NEW PSYCHOACTIVE SUBSTANCES)',
           active: true,
           label: 'NPS (NEW PSYCHOACTIVE SUBSTANCES)',
@@ -1194,6 +1329,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216819',
           code: 'PREGABALIN',
           active: true,
           label: 'PREGABALIN',
@@ -1202,6 +1338,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216820',
           code: 'STEROIDS',
           active: true,
           label: 'STEROIDS',
@@ -1210,6 +1347,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216821',
           code: 'TRAMADOL',
           active: true,
           label: 'TRAMADOL',
@@ -1218,6 +1356,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216822',
           code: 'TRANQUILISERS',
           active: true,
           label: 'TRANQUILISERS',
@@ -1226,6 +1365,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65191',
         },
         {
+          id: '216823',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -1243,6 +1383,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216824',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1251,6 +1392,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216825',
           code: 'LESS THAN OR EQUAL TO 1G',
           active: true,
           label: 'LESS THAN OR EQUAL TO 1G',
@@ -1259,6 +1401,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216826',
           code: '2G TO 5G',
           active: true,
           label: '2G TO 5G',
@@ -1267,6 +1410,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216827',
           code: '6G TO 10G',
           active: true,
           label: '6G TO 10G',
@@ -1275,6 +1419,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216828',
           code: '11G TO 20G',
           active: true,
           label: '11G TO 20G',
@@ -1283,6 +1428,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216829',
           code: '21G TO 30G',
           active: true,
           label: '21G TO 30G',
@@ -1291,6 +1437,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216830',
           code: '31G TO 40G',
           active: true,
           label: '31G TO 40G',
@@ -1299,6 +1446,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216831',
           code: '41G TO 50G',
           active: true,
           label: '41G TO 50G',
@@ -1307,6 +1455,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216832',
           code: '50G TO 100G',
           active: true,
           label: '50G TO 100G',
@@ -1315,6 +1464,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216833',
           code: '101G TO 200G',
           active: true,
           label: '101G TO 200G',
@@ -1323,6 +1473,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216834',
           code: '201G TO 300G',
           active: true,
           label: '201G TO 300G',
@@ -1331,6 +1482,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216835',
           code: '301G TO 400G',
           active: true,
           label: '301G TO 400G',
@@ -1339,6 +1491,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216836',
           code: '401G TO 500G',
           active: true,
           label: '401G TO 500G',
@@ -1347,6 +1500,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216837',
           code: '501G TO 1,000G',
           active: true,
           label: '501G TO 1,000G',
@@ -1355,6 +1509,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65192',
         },
         {
+          id: '216838',
           code: 'MORE THAN 1KG',
           active: true,
           label: 'MORE THAN 1KG',
@@ -1372,6 +1527,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216839',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1380,6 +1536,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65193',
         },
         {
+          id: '216840',
           code: 'YES - FORENSIC LABORATORY',
           active: true,
           label: 'YES - FORENSIC LABORATORY',
@@ -1388,6 +1545,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65193',
         },
         {
+          id: '216841',
           code: 'YES - LOCAL WITH BDH KIT OR SIMILAR',
           active: true,
           label: 'YES - LOCAL WITH BDH KIT OR SIMILAR',
@@ -1405,6 +1563,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '216842',
           code: 'NONE FOUND',
           active: true,
           label: 'NONE FOUND',
@@ -1413,6 +1572,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216843',
           code: 'AUTHENTIC NEEDLE',
           active: true,
           label: 'AUTHENTIC NEEDLE',
@@ -1421,6 +1581,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216844',
           code: 'AUTHENTIC SYRINGE',
           active: true,
           label: 'AUTHENTIC SYRINGE',
@@ -1429,6 +1590,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216845',
           code: 'IMPROVISED NEEDLE',
           active: true,
           label: 'IMPROVISED NEEDLE',
@@ -1437,6 +1599,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216846',
           code: 'IMPROVISED SYRINGE',
           active: true,
           label: 'IMPROVISED SYRINGE',
@@ -1445,6 +1608,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216847',
           code: 'PIPE(S)',
           active: true,
           label: 'PIPE(S)',
@@ -1453,6 +1617,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216848',
           code: 'ROACH',
           active: true,
           label: 'ROACH',
@@ -1461,6 +1626,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216849',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -1478,6 +1644,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216850',
           code: 'NO MOBILE PHONE FOUND',
           active: true,
           label: 'NO MOBILE PHONE FOUND',
@@ -1486,6 +1653,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216851',
           code: '1',
           active: true,
           label: '1',
@@ -1494,6 +1662,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216852',
           code: '2',
           active: true,
           label: '2',
@@ -1502,6 +1671,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216853',
           code: '3',
           active: true,
           label: '3',
@@ -1510,6 +1680,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216854',
           code: '4',
           active: true,
           label: '4',
@@ -1518,6 +1689,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216855',
           code: '5',
           active: true,
           label: '5',
@@ -1526,6 +1698,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216856',
           code: '6',
           active: true,
           label: '6',
@@ -1534,6 +1707,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216857',
           code: '7',
           active: true,
           label: '7',
@@ -1542,6 +1716,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216858',
           code: '8',
           active: true,
           label: '8',
@@ -1550,6 +1725,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216859',
           code: '9',
           active: true,
           label: '9',
@@ -1558,6 +1734,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216860',
           code: '10',
           active: true,
           label: '10',
@@ -1566,6 +1743,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216861',
           code: '11',
           active: true,
           label: '11',
@@ -1574,6 +1752,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216862',
           code: '12',
           active: true,
           label: '12',
@@ -1582,6 +1761,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216863',
           code: '13',
           active: true,
           label: '13',
@@ -1590,6 +1770,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216864',
           code: '14',
           active: true,
           label: '14',
@@ -1598,6 +1779,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216865',
           code: '15',
           active: true,
           label: '15',
@@ -1606,6 +1788,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216866',
           code: '16',
           active: true,
           label: '16',
@@ -1614,6 +1797,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216867',
           code: '17',
           active: true,
           label: '17',
@@ -1622,6 +1806,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216868',
           code: '18',
           active: true,
           label: '18',
@@ -1630,6 +1815,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216869',
           code: '19',
           active: true,
           label: '19',
@@ -1638,6 +1824,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216870',
           code: '20',
           active: true,
           label: '20',
@@ -1646,6 +1833,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216871',
           code: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
@@ -1654,6 +1842,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65195',
         },
         {
+          id: '216872',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1671,6 +1860,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216873',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1679,6 +1869,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216874',
           code: '1',
           active: true,
           label: '1',
@@ -1687,6 +1878,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216875',
           code: '2',
           active: true,
           label: '2',
@@ -1695,6 +1887,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216876',
           code: '3',
           active: true,
           label: '3',
@@ -1703,6 +1896,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216877',
           code: '4',
           active: true,
           label: '4',
@@ -1711,6 +1905,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216878',
           code: '5',
           active: true,
           label: '5',
@@ -1719,6 +1914,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216879',
           code: '6',
           active: true,
           label: '6',
@@ -1727,6 +1923,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216880',
           code: '7',
           active: true,
           label: '7',
@@ -1735,6 +1932,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216881',
           code: '8',
           active: true,
           label: '8',
@@ -1743,6 +1941,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216882',
           code: '9',
           active: true,
           label: '9',
@@ -1751,6 +1950,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216883',
           code: '10',
           active: true,
           label: '10',
@@ -1759,6 +1959,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216884',
           code: '11',
           active: true,
           label: '11',
@@ -1767,6 +1968,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216885',
           code: '12',
           active: true,
           label: '12',
@@ -1775,6 +1977,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216886',
           code: '13',
           active: true,
           label: '13',
@@ -1783,6 +1986,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216887',
           code: '14',
           active: true,
           label: '14',
@@ -1791,6 +1995,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216888',
           code: '15',
           active: true,
           label: '15',
@@ -1799,6 +2004,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216889',
           code: '16',
           active: true,
           label: '16',
@@ -1807,6 +2013,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216890',
           code: '17',
           active: true,
           label: '17',
@@ -1815,6 +2022,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216891',
           code: '18',
           active: true,
           label: '18',
@@ -1823,6 +2031,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216892',
           code: '19',
           active: true,
           label: '19',
@@ -1831,6 +2040,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216893',
           code: '20',
           active: true,
           label: '20',
@@ -1839,6 +2049,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216894',
           code: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
@@ -1847,6 +2058,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65196',
         },
         {
+          id: '216895',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1864,6 +2076,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216896',
           code: 'NO MEMORY CARD FOUND',
           active: true,
           label: 'NO MEMORY CARD FOUND',
@@ -1872,6 +2085,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216897',
           code: '1',
           active: true,
           label: '1',
@@ -1880,6 +2094,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216898',
           code: '2',
           active: true,
           label: '2',
@@ -1888,6 +2103,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216899',
           code: '3',
           active: true,
           label: '3',
@@ -1896,6 +2112,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216900',
           code: '4',
           active: true,
           label: '4',
@@ -1904,6 +2121,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216901',
           code: '5',
           active: true,
           label: '5',
@@ -1912,6 +2130,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216902',
           code: '6',
           active: true,
           label: '6',
@@ -1920,6 +2139,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216903',
           code: '7',
           active: true,
           label: '7',
@@ -1928,6 +2148,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216904',
           code: '8',
           active: true,
           label: '8',
@@ -1936,6 +2157,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216905',
           code: '9',
           active: true,
           label: '9',
@@ -1944,6 +2166,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216906',
           code: '10',
           active: true,
           label: '10',
@@ -1952,6 +2175,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216907',
           code: '11',
           active: true,
           label: '11',
@@ -1960,6 +2184,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216908',
           code: '12',
           active: true,
           label: '12',
@@ -1968,6 +2193,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216909',
           code: '13',
           active: true,
           label: '13',
@@ -1976,6 +2202,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216910',
           code: '14',
           active: true,
           label: '14',
@@ -1984,6 +2211,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216911',
           code: '15',
           active: true,
           label: '15',
@@ -1992,6 +2220,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216912',
           code: '16',
           active: true,
           label: '16',
@@ -2000,6 +2229,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216913',
           code: '17',
           active: true,
           label: '17',
@@ -2008,6 +2238,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216914',
           code: '18',
           active: true,
           label: '18',
@@ -2016,6 +2247,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216915',
           code: '19',
           active: true,
           label: '19',
@@ -2024,6 +2256,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216916',
           code: '20',
           active: true,
           label: '20',
@@ -2032,6 +2265,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216917',
           code: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
@@ -2040,6 +2274,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65197',
         },
         {
+          id: '216918',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2057,6 +2292,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216919',
           code: 'NO (ENTER REASON IN COMMENT)',
           active: true,
           label: 'NO (ENTER REASON IN COMMENT)',
@@ -2065,6 +2301,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65198',
         },
         {
+          id: '216920',
           code: 'YES (ENTER DATE AND COMMENT WITH BAG NUMBER)',
           active: true,
           label: 'YES (ENTER DATE AND COMMENT WITH BAG NUMBER)',
@@ -2082,6 +2319,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216921',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2090,6 +2328,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65199',
         },
         {
+          id: '216922',
           code: 'YES - HOMEMADE/ADAPTED',
           active: true,
           label: 'YES - HOMEMADE/ADAPTED',
@@ -2098,6 +2337,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65199',
         },
         {
+          id: '216923',
           code: 'YES - FACTORY MADE/MANUFACTURED',
           active: true,
           label: 'YES - FACTORY MADE/MANUFACTURED',
@@ -2115,6 +2355,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216924',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2123,6 +2364,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216925',
           code: 'YES (PLEASE SPECIFY IN COMMENTS)',
           active: true,
           label: 'YES (PLEASE SPECIFY IN COMMENTS)',
@@ -2140,6 +2382,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216926',
           code: 'DESKTOP',
           active: true,
           label: 'DESKTOP',
@@ -2148,6 +2391,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216927',
           code: 'DVD PLAYER',
           active: true,
           label: 'DVD PLAYER',
@@ -2156,6 +2400,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216928',
           code: 'EXTERNAL STORAGE, E.G. EXTERNAL HARD DRIVE',
           active: true,
           label: 'EXTERNAL STORAGE, E.G. EXTERNAL HARD DRIVE',
@@ -2164,6 +2409,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216929',
           code: 'GAMES CONSOLE',
           active: true,
           label: 'GAMES CONSOLE',
@@ -2172,6 +2418,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216930',
           code: 'LAPTOP',
           active: true,
           label: 'LAPTOP',
@@ -2180,6 +2427,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216931',
           code: 'MEDIA STREAMING DEVICE, E.G. KINDLE FIRE STICK',
           active: true,
           label: 'MEDIA STREAMING DEVICE, E.G. KINDLE FIRE STICK',
@@ -2188,6 +2436,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216932',
           code: 'MOBILE HOT SPOT (MIFI DIVICE)',
           active: true,
           label: 'MOBILE HOT SPOT (MIFI DIVICE)',
@@ -2196,6 +2445,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216933',
           code: 'SMART WATCH',
           active: true,
           label: 'SMART WATCH',
@@ -2204,6 +2454,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216934',
           code: 'STEREO / RADIO',
           active: true,
           label: 'STEREO / RADIO',
@@ -2212,6 +2463,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216935',
           code: 'TABLET, E.G. IPAD',
           active: true,
           label: 'TABLET, E.G. IPAD',
@@ -2220,6 +2472,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216936',
           code: 'USB MEMORY STICK',
           active: true,
           label: 'USB MEMORY STICK',
@@ -2228,6 +2481,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216937',
           code: 'WIRELESS HEADSET, E.G. APPLE AIRPODS',
           active: true,
           label: 'WIRELESS HEADSET, E.G. APPLE AIRPODS',
@@ -2236,6 +2490,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216938',
           code: 'OTHER (PLEASE STATE IN COMMENTS)',
           active: true,
           label: 'OTHER (PLEASE STATE IN COMMENTS)',
@@ -2253,6 +2508,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '216939',
           code: 'CIGARETTES/CIGARS',
           active: true,
           label: 'CIGARETTES/CIGARS',
@@ -2261,6 +2517,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65202',
         },
         {
+          id: '216940',
           code: 'LOOSE TOBACCO',
           active: true,
           label: 'LOOSE TOBACCO',
@@ -2269,6 +2526,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65202',
         },
         {
+          id: '216941',
           code: 'OTHER - INCLUDING PACKAGING AND ROACHES (PLEASE STATE IN COMMENTS)',
           active: true,
           label: 'OTHER - INCLUDING PACKAGING AND ROACHES (PLEASE STATE IN COMMENTS)',
@@ -2286,6 +2544,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216942',
           code: 'N/A',
           active: true,
           label: 'N/A',
@@ -2294,6 +2553,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216943',
           code: 'LESS THAN OR EQUAL TO 1G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'LESS THAN OR EQUAL TO 1G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2302,6 +2562,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216944',
           code: '2G TO 5G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '2G TO 5G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2310,6 +2571,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216945',
           code: '6G TO 10G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '6G TO 10G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2318,6 +2580,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216946',
           code: '11G TO 20G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '11G TO 20G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2326,6 +2589,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216947',
           code: 'GREATER THAN 20G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'GREATER THAN 20G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2343,6 +2607,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '216948',
           code: 'YES - BLUNT INSTRUMENT (COSH, ITEM IN SOCK ETC)',
           active: true,
           label: 'YES - BLUNT INSTRUMENT (COSH, ITEM IN SOCK ETC)',
@@ -2351,6 +2616,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216949',
           code: 'YES- FIREARM (FAKE GUNS, AMMUNITION, CHEMICAL INCAPACITANT ETC)',
           active: true,
           label: 'YES- FIREARM (FAKE GUNS, AMMUNITION, CHEMICAL INCAPACITANT ETC)',
@@ -2359,6 +2625,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216950',
           code: 'YES - KNIFE/BLADED ARTICLE',
           active: true,
           label: 'YES - KNIFE/BLADED ARTICLE',
@@ -2367,6 +2634,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216951',
           code: 'YES - OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'YES - OTHER (PLEASE SPECIFY)',
@@ -2384,6 +2652,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '216952',
           code: 'YES (NOOSE / LIGATURE)',
           active: true,
           label: 'YES (NOOSE / LIGATURE)',
@@ -2392,6 +2661,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216953',
           code: 'YES (PLEASE SPECIFY IN COMMENTS)',
           active: true,
           label: 'YES (PLEASE SPECIFY IN COMMENTS)',
@@ -2409,6 +2679,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216954',
           code: 'NIL',
           active: true,
           label: 'NIL',
@@ -2417,6 +2688,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65206',
         },
         {
+          id: '216955',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2425,6 +2697,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65206',
         },
         {
+          id: '216956',
           code: 'LESS THAN 1 LITRE (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'LESS THAN 1 LITRE (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2433,6 +2706,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65206',
         },
         {
+          id: '216957',
           code: '1 LITRE TO LESS THAN 2 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '1 LITRE TO LESS THAN 2 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2441,6 +2715,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65206',
         },
         {
+          id: '216958',
           code: '2 LITRES TO LESS THAN 3 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '2 LITRES TO LESS THAN 3 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2449,6 +2724,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65206',
         },
         {
+          id: '216959',
           code: '3 LITRES TO LESS THAN 4 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '3 LITRES TO LESS THAN 4 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2457,6 +2733,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65206',
         },
         {
+          id: '216960',
           code: '4 LITRES TO LESS THAN 5 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '4 LITRES TO LESS THAN 5 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2465,6 +2742,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65206',
         },
         {
+          id: '216961',
           code: '5 LITRES TO LESS THAN 10 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '5 LITRES TO LESS THAN 10 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2473,6 +2751,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65206',
         },
         {
+          id: '216962',
           code: '10 LITRES TO LESS THAN 20 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '10 LITRES TO LESS THAN 20 LITRES (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2481,6 +2760,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65206',
         },
         {
+          id: '216963',
           code: '20 LITRES OR MORE (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '20 LITRES OR MORE (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2498,6 +2778,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216964',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2506,6 +2787,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '216965',
           code: 'YES (Please specify)',
           active: true,
           label: 'YES (Please specify)',
@@ -2523,6 +2805,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216966',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2531,6 +2814,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65211',
         },
         {
+          id: '216967',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2548,6 +2832,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '216968',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2556,6 +2841,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216969',
           code: 'AMPHETAMINES',
           active: true,
           label: 'AMPHETAMINES',
@@ -2564,6 +2850,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216970',
           code: 'BARBITURATES',
           active: true,
           label: 'BARBITURATES',
@@ -2572,6 +2859,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216971',
           code: 'BENZODIAZEPINES',
           active: true,
           label: 'BENZODIAZEPINES',
@@ -2580,6 +2868,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216972',
           code: 'BUPRENORPHINE/SUBUTEX',
           active: true,
           label: 'BUPRENORPHINE/SUBUTEX',
@@ -2588,6 +2877,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216973',
           code: 'CANNABIS',
           active: true,
           label: 'CANNABIS',
@@ -2596,6 +2886,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216974',
           code: 'CANNABIS PLANT',
           active: true,
           label: 'CANNABIS PLANT',
@@ -2604,6 +2895,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216975',
           code: 'COCAINE',
           active: true,
           label: 'COCAINE',
@@ -2612,6 +2904,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216976',
           code: 'CRACK',
           active: true,
           label: 'CRACK',
@@ -2620,6 +2913,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216977',
           code: 'GABAPENTIN',
           active: true,
           label: 'GABAPENTIN',
@@ -2628,6 +2922,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216978',
           code: 'HEROIN',
           active: true,
           label: 'HEROIN',
@@ -2636,6 +2931,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216979',
           code: 'KETAMINE',
           active: true,
           label: 'KETAMINE',
@@ -2644,6 +2940,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216980',
           code: 'LSD',
           active: true,
           label: 'LSD',
@@ -2652,6 +2949,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216981',
           code: 'METHADONE',
           active: true,
           label: 'METHADONE',
@@ -2660,6 +2958,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216982',
           code: 'NPS (NEW PSYCHOACTIVE SUBSTANCES)',
           active: true,
           label: 'NPS (NEW PSYCHOACTIVE SUBSTANCES)',
@@ -2668,6 +2967,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216983',
           code: 'PREGABALIN',
           active: true,
           label: 'PREGABALIN',
@@ -2676,6 +2976,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216984',
           code: 'STEROIDS',
           active: true,
           label: 'STEROIDS',
@@ -2684,6 +2985,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216985',
           code: 'TRAMADOL',
           active: true,
           label: 'TRAMADOL',
@@ -2692,6 +2994,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216986',
           code: 'TRANQUILISERS',
           active: true,
           label: 'TRANQUILISERS',
@@ -2700,6 +3003,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65209',
         },
         {
+          id: '216987',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -2717,6 +3021,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '216988',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2725,6 +3030,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216989',
           code: 'LESS THAN OR EQUAL TO 1G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'LESS THAN OR EQUAL TO 1G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2733,6 +3039,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216990',
           code: '2G TO 5G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '2G TO 5G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2741,6 +3048,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216991',
           code: '6G TO 10G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '6G TO 10G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2749,6 +3057,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216992',
           code: '11G TO 20G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '11G TO 20G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2757,6 +3066,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216993',
           code: '21G TO 30G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '21G TO 30G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2765,6 +3075,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216994',
           code: '31G TO 40G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '31G TO 40G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2773,6 +3084,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216995',
           code: '41G TO 50G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '41G TO 50G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2781,6 +3093,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216996',
           code: '50G TO 100G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '50G TO 100G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2789,6 +3102,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216997',
           code: '101G TO 200G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '101G TO 200G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2797,6 +3111,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216998',
           code: '201G TO 300G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '201G TO 300G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2805,6 +3120,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '216999',
           code: '301G TO 400G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '301G TO 400G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2813,6 +3129,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '217000',
           code: '401G TO 500G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '401G TO 500G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2821,6 +3138,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '217001',
           code: '501G TO 1,000G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '501G TO 1,000G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2829,6 +3147,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65210',
         },
         {
+          id: '217002',
           code: 'MORE THAN 1KG (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'MORE THAN 1KG (PLEASE STATE NUMBER IN COMMENTS)',
@@ -2846,6 +3165,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217003',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2854,6 +3174,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65211',
         },
         {
+          id: '217004',
           code: 'YES - FORENSIC LABORATORY',
           active: true,
           label: 'YES - FORENSIC LABORATORY',
@@ -2862,6 +3183,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65211',
         },
         {
+          id: '217005',
           code: 'YES - LOCAL WITH BDH KIT OR SIMILAR',
           active: true,
           label: 'YES - LOCAL WITH BDH KIT OR SIMILAR',
@@ -2879,6 +3201,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217006',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2887,6 +3210,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65213',
         },
         {
+          id: '217007',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2904,6 +3228,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '217008',
           code: 'AUTHENTIC NEEDLE',
           active: true,
           label: 'AUTHENTIC NEEDLE',
@@ -2912,6 +3237,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65213',
         },
         {
+          id: '217009',
           code: 'AUTHENTIC SYRINGE',
           active: true,
           label: 'AUTHENTIC SYRINGE',
@@ -2920,6 +3246,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65213',
         },
         {
+          id: '217010',
           code: 'IMPROVISED NEEDLE',
           active: true,
           label: 'IMPROVISED NEEDLE',
@@ -2928,6 +3255,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65213',
         },
         {
+          id: '217011',
           code: 'IMPROVISED SYRINGE',
           active: true,
           label: 'IMPROVISED SYRINGE',
@@ -2936,6 +3264,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65213',
         },
         {
+          id: '217012',
           code: 'PIPE(S)',
           active: true,
           label: 'PIPE(S)',
@@ -2944,6 +3273,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65213',
         },
         {
+          id: '217013',
           code: 'ROACH',
           active: true,
           label: 'ROACH',
@@ -2952,6 +3282,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65213',
         },
         {
+          id: '217014',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -2969,6 +3300,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217015',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2977,6 +3309,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65220',
         },
         {
+          id: '217016',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2994,6 +3327,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217017',
           code: 'NO MOBILE PHONE FOUND',
           active: true,
           label: 'NO MOBILE PHONE FOUND',
@@ -3002,6 +3336,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217018',
           code: '1',
           active: true,
           label: '1',
@@ -3010,6 +3345,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217019',
           code: '2',
           active: true,
           label: '2',
@@ -3018,6 +3354,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217020',
           code: '3',
           active: true,
           label: '3',
@@ -3026,6 +3363,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217021',
           code: '4',
           active: true,
           label: '4',
@@ -3034,6 +3372,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217022',
           code: '5',
           active: true,
           label: '5',
@@ -3042,6 +3381,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217023',
           code: '6',
           active: true,
           label: '6',
@@ -3050,6 +3390,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217024',
           code: '7',
           active: true,
           label: '7',
@@ -3058,6 +3399,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217025',
           code: '8',
           active: true,
           label: '8',
@@ -3066,6 +3408,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217026',
           code: '9',
           active: true,
           label: '9',
@@ -3074,6 +3417,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217027',
           code: '10',
           active: true,
           label: '10',
@@ -3082,6 +3426,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217028',
           code: '11',
           active: true,
           label: '11',
@@ -3090,6 +3435,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217029',
           code: '12',
           active: true,
           label: '12',
@@ -3098,6 +3444,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217030',
           code: '13',
           active: true,
           label: '13',
@@ -3106,6 +3453,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217031',
           code: '14',
           active: true,
           label: '14',
@@ -3114,6 +3462,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217032',
           code: '15',
           active: true,
           label: '15',
@@ -3122,6 +3471,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217033',
           code: '16',
           active: true,
           label: '16',
@@ -3130,6 +3480,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217034',
           code: '17',
           active: true,
           label: '17',
@@ -3138,6 +3489,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217035',
           code: '18',
           active: true,
           label: '18',
@@ -3146,6 +3498,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217036',
           code: '19',
           active: true,
           label: '19',
@@ -3154,6 +3507,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217037',
           code: '20',
           active: true,
           label: '20',
@@ -3162,6 +3516,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217038',
           code: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
@@ -3170,6 +3525,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65215',
         },
         {
+          id: '217039',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -3187,6 +3543,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217040',
           code: 'NO SIM CARDS FOUND',
           active: true,
           label: 'NO SIM CARDS FOUND',
@@ -3195,6 +3552,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217041',
           code: '1',
           active: true,
           label: '1',
@@ -3203,6 +3561,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217042',
           code: '2',
           active: true,
           label: '2',
@@ -3211,6 +3570,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217043',
           code: '3',
           active: true,
           label: '3',
@@ -3219,6 +3579,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217044',
           code: '4',
           active: true,
           label: '4',
@@ -3227,6 +3588,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217045',
           code: '5',
           active: true,
           label: '5',
@@ -3235,6 +3597,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217046',
           code: '6',
           active: true,
           label: '6',
@@ -3243,6 +3606,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217047',
           code: '7',
           active: true,
           label: '7',
@@ -3251,6 +3615,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217048',
           code: '8',
           active: true,
           label: '8',
@@ -3259,6 +3624,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217049',
           code: '9',
           active: true,
           label: '9',
@@ -3267,6 +3633,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217050',
           code: '10',
           active: true,
           label: '10',
@@ -3275,6 +3642,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217051',
           code: '11',
           active: true,
           label: '11',
@@ -3283,6 +3651,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217052',
           code: '12',
           active: true,
           label: '12',
@@ -3291,6 +3660,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217053',
           code: '13',
           active: true,
           label: '13',
@@ -3299,6 +3669,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217054',
           code: '14',
           active: true,
           label: '14',
@@ -3307,6 +3678,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217055',
           code: '15',
           active: true,
           label: '15',
@@ -3315,6 +3687,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217056',
           code: '16',
           active: true,
           label: '16',
@@ -3323,6 +3696,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217057',
           code: '17',
           active: true,
           label: '17',
@@ -3331,6 +3705,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217058',
           code: '18',
           active: true,
           label: '18',
@@ -3339,6 +3714,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217059',
           code: '19',
           active: true,
           label: '19',
@@ -3347,6 +3723,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217060',
           code: '20',
           active: true,
           label: '20',
@@ -3355,6 +3732,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217061',
           code: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
@@ -3363,6 +3741,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65216',
         },
         {
+          id: '217062',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -3380,6 +3759,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217063',
           code: 'NO MEMORY CARD FOUND',
           active: true,
           label: 'NO MEMORY CARD FOUND',
@@ -3388,6 +3768,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217064',
           code: '1',
           active: true,
           label: '1',
@@ -3396,6 +3777,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217065',
           code: '2',
           active: true,
           label: '2',
@@ -3404,6 +3786,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217066',
           code: '3',
           active: true,
           label: '3',
@@ -3412,6 +3795,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217067',
           code: '4',
           active: true,
           label: '4',
@@ -3420,6 +3804,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217068',
           code: '5',
           active: true,
           label: '5',
@@ -3428,6 +3813,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217069',
           code: '6',
           active: true,
           label: '6',
@@ -3436,6 +3822,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217070',
           code: '7',
           active: true,
           label: '7',
@@ -3444,6 +3831,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217071',
           code: '8',
           active: true,
           label: '8',
@@ -3452,6 +3840,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217072',
           code: '9',
           active: true,
           label: '9',
@@ -3460,6 +3849,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217073',
           code: '10',
           active: true,
           label: '10',
@@ -3468,6 +3858,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217074',
           code: '11',
           active: true,
           label: '11',
@@ -3476,6 +3867,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217075',
           code: '12',
           active: true,
           label: '12',
@@ -3484,6 +3876,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217076',
           code: '13',
           active: true,
           label: '13',
@@ -3492,6 +3885,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217077',
           code: '14',
           active: true,
           label: '14',
@@ -3500,6 +3894,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217078',
           code: '15',
           active: true,
           label: '15',
@@ -3508,6 +3903,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217079',
           code: '16',
           active: true,
           label: '16',
@@ -3516,6 +3912,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217080',
           code: '17',
           active: true,
           label: '17',
@@ -3524,6 +3921,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217081',
           code: '18',
           active: true,
           label: '18',
@@ -3532,6 +3930,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217082',
           code: '19',
           active: true,
           label: '19',
@@ -3540,6 +3939,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217083',
           code: '20',
           active: true,
           label: '20',
@@ -3548,6 +3948,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217084',
           code: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
           active: true,
           label: 'MORE THAN 20 (STATE NUMBER IN COMMENT)',
@@ -3556,6 +3957,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65217',
         },
         {
+          id: '217085',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -3573,6 +3975,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217086',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3581,6 +3984,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65218',
         },
         {
+          id: '217087',
           code: 'YES - HOMEMADE/ADAPTED',
           active: true,
           label: 'YES - HOMEMADE/ADAPTED',
@@ -3589,6 +3993,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65218',
         },
         {
+          id: '217088',
           code: 'YES - FACTORY MADE/MANUFACTURED',
           active: true,
           label: 'YES - FACTORY MADE/MANUFACTURED',
@@ -3606,6 +4011,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217089',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3614,6 +4020,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65219',
         },
         {
+          id: '217090',
           code: 'YES: PLEASE SPECIFY',
           active: true,
           label: 'YES: PLEASE SPECIFY',
@@ -3631,6 +4038,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '217091',
           code: 'NO (ENTER REASON IN COMMENT)',
           active: true,
           label: 'NO (ENTER REASON IN COMMENT)',
@@ -3639,6 +4047,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65220',
         },
         {
+          id: '217092',
           code: 'YES (ENTER DATE AND COMMENT WITH BAG NUMBER)',
           active: true,
           label: 'YES (ENTER DATE AND COMMENT WITH BAG NUMBER)',
@@ -3656,6 +4065,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217093',
           code: 'NO OTHER DIGITAL FINDS',
           active: true,
           label: 'NO OTHER DIGITAL FINDS',
@@ -3664,6 +4074,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217094',
           code: 'DESKTOP',
           active: true,
           label: 'DESKTOP',
@@ -3672,6 +4083,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217095',
           code: 'DVD PLAYER',
           active: true,
           label: 'DVD PLAYER',
@@ -3680,6 +4092,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217096',
           code: 'EXTERNAL STORAGE, E.G. EXTERNAL HARD DRIVE',
           active: true,
           label: 'EXTERNAL STORAGE, E.G. EXTERNAL HARD DRIVE',
@@ -3688,6 +4101,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217097',
           code: 'GAMES CONSOLE',
           active: true,
           label: 'GAMES CONSOLE',
@@ -3696,6 +4110,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217098',
           code: 'LAPTOP',
           active: true,
           label: 'LAPTOP',
@@ -3704,6 +4119,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217099',
           code: 'MEDIA STREAMING DEVICE, E.G. KINDLE FIRE STICK',
           active: true,
           label: 'MEDIA STREAMING DEVICE, E.G. KINDLE FIRE STICK',
@@ -3712,6 +4128,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217100',
           code: 'MOBILE HOT SPOT (MIFI DIVICE)',
           active: true,
           label: 'MOBILE HOT SPOT (MIFI DIVICE)',
@@ -3720,6 +4137,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217101',
           code: 'SMART WATCH',
           active: true,
           label: 'SMART WATCH',
@@ -3728,6 +4146,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217102',
           code: 'STEREO / RADIO',
           active: true,
           label: 'STEREO / RADIO',
@@ -3736,6 +4155,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217103',
           code: 'TABLET, E.G. IPAD',
           active: true,
           label: 'TABLET, E.G. IPAD',
@@ -3744,6 +4164,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217104',
           code: 'USB MEMORY STICK',
           active: true,
           label: 'USB MEMORY STICK',
@@ -3752,6 +4173,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217105',
           code: 'WIRELESS HEADSET, E.G. APPLE AIRPODS',
           active: true,
           label: 'WIRELESS HEADSET, E.G. APPLE AIRPODS',
@@ -3760,6 +4182,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65221',
         },
         {
+          id: '217106',
           code: 'OTHER (PLEASE STATE)',
           active: true,
           label: 'OTHER (PLEASE STATE)',
@@ -3777,6 +4200,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217107',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3785,6 +4209,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65224',
         },
         {
+          id: '217108',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3802,6 +4227,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '217109',
           code: 'CIGARETTES/CIGARS',
           active: true,
           label: 'CIGARETTES/CIGARS',
@@ -3810,6 +4236,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65223',
         },
         {
+          id: '217110',
           code: 'LOOSE TOBACCO',
           active: true,
           label: 'LOOSE TOBACCO',
@@ -3818,6 +4245,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65223',
         },
         {
+          id: '217111',
           code: 'OTHER (including packaging and roaches)',
           active: true,
           label: 'OTHER (including packaging and roaches)',
@@ -3835,6 +4263,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217112',
           code: 'LESS THAN OR EQUAL TO 1G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'LESS THAN OR EQUAL TO 1G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -3843,6 +4272,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65224',
         },
         {
+          id: '217113',
           code: '2G TO 5G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '2G TO 5G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -3851,6 +4281,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65224',
         },
         {
+          id: '217114',
           code: '6G TO 10G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '6G TO 10G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -3859,6 +4290,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65224',
         },
         {
+          id: '217115',
           code: '11G TO 20G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: '11G TO 20G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -3867,6 +4299,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65224',
         },
         {
+          id: '217116',
           code: 'GREATER THAN 20G (PLEASE STATE NUMBER IN COMMENTS)',
           active: true,
           label: 'GREATER THAN 20G (PLEASE STATE NUMBER IN COMMENTS)',
@@ -3884,6 +4317,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '217117',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3892,6 +4326,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65225',
         },
         {
+          id: '217118',
           code: 'YES - BLUNT INSTRUMENT (COSH, ITEM IN SOCK ETC)',
           active: true,
           label: 'YES - BLUNT INSTRUMENT (COSH, ITEM IN SOCK ETC)',
@@ -3900,6 +4335,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65225',
         },
         {
+          id: '217119',
           code: 'YES- FIREARM (FAKE GUNS, AMMUNITION, CHEMICAL INCAPACITANT ETC)',
           active: true,
           label: 'YES- FIREARM (FAKE GUNS, AMMUNITION, CHEMICAL INCAPACITANT ETC)',
@@ -3908,6 +4344,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65225',
         },
         {
+          id: '217120',
           code: 'YES - KNIFE/BLADED ARTICLE',
           active: true,
           label: 'YES - KNIFE/BLADED ARTICLE',
@@ -3916,6 +4353,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65225',
         },
         {
+          id: '217121',
           code: 'YES - OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'YES - OTHER (PLEASE SPECIFY)',
@@ -3933,6 +4371,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '217122',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3941,6 +4380,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '217123',
           code: 'YES (NOOSE / LIGATURE)',
           active: true,
           label: 'YES (NOOSE / LIGATURE)',
@@ -3949,6 +4389,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: '65226',
         },
         {
+          id: '217124',
           code: 'YES (PLEASE SPECIFY IN COMMENTS)',
           active: true,
           label: 'YES (PLEASE SPECIFY IN COMMENTS)',
@@ -3966,6 +4407,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '217125',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -3974,6 +4416,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '217126',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -3982,6 +4425,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '217127',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -3999,6 +4443,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '217128',
           code: 'COMMUNITY VISIT',
           active: true,
           label: 'COMMUNITY VISIT',
@@ -4007,6 +4452,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '217129',
           code: 'COMPASSIONATE',
           active: true,
           label: 'COMPASSIONATE',
@@ -4015,6 +4461,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '217130',
           code: 'FACILITY',
           active: true,
           label: 'FACILITY',
@@ -4023,6 +4470,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '217131',
           code: 'RESETTLEMENT',
           active: true,
           label: 'RESETTLEMENT',
@@ -4031,6 +4479,7 @@ const OLD_FINDS3: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '217132',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',

--- a/server/reportConfiguration/types/OLD_FINDS4.ts
+++ b/server/reportConfiguration/types/OLD_FINDS4.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:08.119Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:34.426Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209109',
           code: 'NO FURTHER ACTION',
           active: true,
           label: 'NO FURTHER ACTION',
@@ -23,6 +24,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57285',
         },
         {
+          id: '209110',
           code: 'IEP REGRESSION',
           active: true,
           label: 'IEP REGRESSION',
@@ -31,6 +33,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57285',
         },
         {
+          id: '209111',
           code: 'PLACED ON REPORT/ADJUDICATION REFERRAL',
           active: true,
           label: 'PLACED ON REPORT/ADJUDICATION REFERRAL',
@@ -39,6 +42,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57285',
         },
         {
+          id: '209112',
           code: 'POLICE REFERRAL',
           active: true,
           label: 'POLICE REFERRAL',
@@ -47,6 +51,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57285',
         },
         {
+          id: '209113',
           code: 'CPS REFRRAL',
           active: false,
           label: 'CPS REFRRAL',
@@ -55,6 +60,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57285',
         },
         {
+          id: '209114',
           code: 'PROSECUTION REFERRAL',
           active: true,
           label: 'PROSECUTION REFERRAL',
@@ -72,6 +78,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209115',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -80,6 +87,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57286',
         },
         {
+          id: '209116',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -97,6 +105,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209117',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -105,6 +114,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57287',
         },
         {
+          id: '209118',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -122,6 +132,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209119',
           code: 'ADMINISTRATION',
           active: true,
           label: 'ADMINISTRATION',
@@ -130,6 +141,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209120',
           code: 'ASSOCIATION AREA',
           active: true,
           label: 'ASSOCIATION AREA',
@@ -138,6 +150,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209121',
           code: 'CELL',
           active: true,
           label: 'CELL',
@@ -146,6 +159,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209122',
           code: 'CHAPEL',
           active: true,
           label: 'CHAPEL',
@@ -154,6 +168,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209123',
           code: 'CROWN COURT',
           active: true,
           label: 'CROWN COURT',
@@ -162,6 +177,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209124',
           code: 'DINING ROOM',
           active: true,
           label: 'DINING ROOM',
@@ -170,6 +186,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209125',
           code: 'DORMITORY',
           active: true,
           label: 'DORMITORY',
@@ -178,6 +195,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209126',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -186,6 +204,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209127',
           code: 'ELSEWHERE',
           active: true,
           label: 'ELSEWHERE',
@@ -194,6 +213,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209128',
           code: 'EXERCISE YARD',
           active: true,
           label: 'EXERCISE YARD',
@@ -202,6 +222,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209129',
           code: 'FUNERAL',
           active: true,
           label: 'FUNERAL',
@@ -210,6 +231,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209130',
           code: 'GATE',
           active: true,
           label: 'GATE',
@@ -218,6 +240,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209131',
           code: 'GYM',
           active: true,
           label: 'GYM',
@@ -226,6 +249,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209132',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -234,6 +258,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209133',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: true,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -242,6 +267,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209134',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: true,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -250,6 +276,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209135',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -258,6 +285,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209136',
           code: 'MAGISTRATES COURT',
           active: true,
           label: 'MAGISTRATES COURT',
@@ -266,6 +294,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209137',
           code: 'OFFICE',
           active: true,
           label: 'OFFICE',
@@ -274,6 +303,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209138',
           code: 'OUTSIDE WORKING PARTY',
           active: true,
           label: 'OUTSIDE WORKING PARTY',
@@ -282,6 +312,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209139',
           code: 'RECEPTION',
           active: true,
           label: 'RECEPTION',
@@ -290,6 +321,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209140',
           code: 'RECESS',
           active: true,
           label: 'RECESS',
@@ -298,6 +330,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209141',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -306,6 +339,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209142',
           code: 'SHOWERS/CHANGING ROOM',
           active: true,
           label: 'SHOWERS/CHANGING ROOM',
@@ -314,6 +348,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209143',
           code: 'SPECIAL UNIT',
           active: true,
           label: 'SPECIAL UNIT',
@@ -322,6 +357,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209144',
           code: 'SPORTS FIELD',
           active: true,
           label: 'SPORTS FIELD',
@@ -330,6 +366,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209145',
           code: 'VEHICLE',
           active: true,
           label: 'VEHICLE',
@@ -338,6 +375,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209146',
           code: 'VISITS',
           active: true,
           label: 'VISITS',
@@ -346,6 +384,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209147',
           code: 'WEDDINGS',
           active: true,
           label: 'WEDDINGS',
@@ -354,6 +393,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209148',
           code: 'WING',
           active: true,
           label: 'WING',
@@ -362,6 +402,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209149',
           code: 'WITHIN PERIMETER',
           active: true,
           label: 'WITHIN PERIMETER',
@@ -370,6 +411,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209150',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -378,6 +420,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209151',
           code: 'WORKSHOP',
           active: true,
           label: 'WORKSHOP',
@@ -386,6 +429,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209152',
           code: 'INDUCTION/1ST NIGHT CENTRE',
           active: true,
           label: 'INDUCTION/1ST NIGHT CENTRE',
@@ -394,6 +438,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209153',
           code: 'MAIL ROOM',
           active: true,
           label: 'MAIL ROOM',
@@ -402,6 +447,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209154',
           code: 'EXTERNAL ROOF',
           active: true,
           label: 'EXTERNAL ROOF',
@@ -410,6 +456,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57288',
         },
         {
+          id: '209155',
           code: 'VULNERABLE PRISONERS UNIT (VPU)',
           active: true,
           label: 'VULNERABLE PRISONERS UNIT (VPU)',
@@ -427,6 +474,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209156',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -435,6 +483,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57289',
         },
         {
+          id: '209157',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -452,6 +501,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209158',
           code: 'AMPHETAMINES',
           active: true,
           label: 'AMPHETAMINES',
@@ -460,6 +510,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209159',
           code: 'BARBITURATES',
           active: true,
           label: 'BARBITURATES',
@@ -468,6 +519,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209160',
           code: 'BENZODIAZEPINES',
           active: true,
           label: 'BENZODIAZEPINES',
@@ -476,6 +528,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209161',
           code: 'BUPRENORPHINE/SUBUTEX',
           active: true,
           label: 'BUPRENORPHINE/SUBUTEX',
@@ -484,6 +537,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209162',
           code: 'CANNABIS',
           active: true,
           label: 'CANNABIS',
@@ -492,6 +546,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209163',
           code: 'CANNABIS PLANT',
           active: true,
           label: 'CANNABIS PLANT',
@@ -500,6 +555,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209164',
           code: 'COCAINE',
           active: true,
           label: 'COCAINE',
@@ -508,6 +564,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209165',
           code: 'CRACK',
           active: true,
           label: 'CRACK',
@@ -516,6 +573,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209166',
           code: 'HEROIN',
           active: true,
           label: 'HEROIN',
@@ -524,6 +582,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209167',
           code: 'LSD',
           active: true,
           label: 'LSD',
@@ -532,6 +591,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209168',
           code: 'METHADONE',
           active: true,
           label: 'METHADONE',
@@ -540,6 +600,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209169',
           code: 'PREGABALIN',
           active: true,
           label: 'PREGABALIN',
@@ -548,6 +609,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209170',
           code: 'TRANQUILISERS',
           active: true,
           label: 'TRANQUILISERS',
@@ -556,6 +618,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209171',
           code: 'TRAMADOL',
           active: true,
           label: 'TRAMADOL',
@@ -564,6 +627,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209172',
           code: 'GABAPENTIN',
           active: true,
           label: 'GABAPENTIN',
@@ -572,6 +636,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209173',
           code: 'NPS: SPICE',
           active: true,
           label: 'NPS: SPICE',
@@ -580,6 +645,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209174',
           code: 'NPS: BLACK MAMBA',
           active: true,
           label: 'NPS: BLACK MAMBA',
@@ -588,6 +654,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209175',
           code: 'NPS: OTHER',
           active: true,
           label: 'NPS: OTHER',
@@ -596,6 +663,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209176',
           code: 'STEROIDS',
           active: true,
           label: 'STEROIDS',
@@ -604,6 +672,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209177',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -612,6 +681,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57290',
         },
         {
+          id: '209178',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -629,6 +699,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209179',
           code: '<1g',
           active: true,
           label: '<1g',
@@ -637,6 +708,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209180',
           code: '2g to 5g',
           active: true,
           label: '2g to 5g',
@@ -645,6 +717,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209181',
           code: '6g to 10g',
           active: true,
           label: '6g to 10g',
@@ -653,6 +726,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209182',
           code: '11g to 20g',
           active: true,
           label: '11g to 20g',
@@ -661,6 +735,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209183',
           code: '21g to 30g',
           active: true,
           label: '21g to 30g',
@@ -669,6 +744,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209184',
           code: '31g to 40g',
           active: true,
           label: '31g to 40g',
@@ -677,6 +753,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209185',
           code: '41g to 50g',
           active: true,
           label: '41g to 50g',
@@ -685,6 +762,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209186',
           code: '51g to 100g',
           active: true,
           label: '51g to 100g',
@@ -693,6 +771,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209187',
           code: '101g to 200g',
           active: true,
           label: '101g to 200g',
@@ -701,6 +780,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209188',
           code: '201g to 300g',
           active: true,
           label: '201g to 300g',
@@ -709,6 +789,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209189',
           code: '301g to 400g',
           active: true,
           label: '301g to 400g',
@@ -717,6 +798,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209190',
           code: '401g to 500g',
           active: true,
           label: '401g to 500g',
@@ -725,6 +807,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209191',
           code: '501g to 1,000g',
           active: true,
           label: '501g to 1,000g',
@@ -733,6 +816,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209192',
           code: 'More than 1kg',
           active: true,
           label: 'More than 1kg',
@@ -741,6 +825,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57291',
         },
         {
+          id: '209193',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -758,6 +843,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209194',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -766,6 +852,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57292',
         },
         {
+          id: '209195',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -783,6 +870,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209196',
           code: 'FORENSIC LABORATORY',
           active: true,
           label: 'FORENSIC LABORATORY',
@@ -791,6 +879,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57293',
         },
         {
+          id: '209197',
           code: 'LOCAL WITH BDH KIT OR SIMILAR',
           active: true,
           label: 'LOCAL WITH BDH KIT OR SIMILAR',
@@ -808,6 +897,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209198',
           code: 'NAME',
           active: true,
           label: 'NAME',
@@ -825,6 +915,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209199',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -833,6 +924,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57295',
         },
         {
+          id: '209200',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -850,6 +942,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209201',
           code: 'AUTHENTIC NEEDLE',
           active: true,
           label: 'AUTHENTIC NEEDLE',
@@ -858,6 +951,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57296',
         },
         {
+          id: '209202',
           code: 'AUTHENTIC SYRINGE',
           active: true,
           label: 'AUTHENTIC SYRINGE',
@@ -866,6 +960,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57296',
         },
         {
+          id: '209203',
           code: 'IMPROVISED NEEDLE',
           active: true,
           label: 'IMPROVISED NEEDLE',
@@ -874,6 +969,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57296',
         },
         {
+          id: '209204',
           code: 'IMPROVISED SYRINGE',
           active: true,
           label: 'IMPROVISED SYRINGE',
@@ -882,6 +978,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57296',
         },
         {
+          id: '209205',
           code: 'PIPE(S)',
           active: true,
           label: 'PIPE(S)',
@@ -890,6 +987,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57296',
         },
         {
+          id: '209206',
           code: 'ROACH',
           active: true,
           label: 'ROACH',
@@ -898,6 +996,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57296',
         },
         {
+          id: '209207',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -915,6 +1014,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209208',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -923,6 +1023,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57297',
         },
         {
+          id: '209209',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -940,6 +1041,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209210',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -948,6 +1050,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57298',
         },
         {
+          id: '209211',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -965,6 +1068,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209212',
           code: '1',
           active: true,
           label: '1',
@@ -973,6 +1077,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209213',
           code: '2',
           active: true,
           label: '2',
@@ -981,6 +1086,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209214',
           code: '3',
           active: true,
           label: '3',
@@ -989,6 +1095,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209215',
           code: '4',
           active: true,
           label: '4',
@@ -997,6 +1104,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209216',
           code: '5',
           active: true,
           label: '5',
@@ -1005,6 +1113,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209217',
           code: '6',
           active: true,
           label: '6',
@@ -1013,6 +1122,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209218',
           code: '7',
           active: true,
           label: '7',
@@ -1021,6 +1131,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209219',
           code: '8',
           active: true,
           label: '8',
@@ -1029,6 +1140,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209220',
           code: '9',
           active: true,
           label: '9',
@@ -1037,6 +1149,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209221',
           code: '10',
           active: true,
           label: '10',
@@ -1045,6 +1158,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209222',
           code: '11',
           active: true,
           label: '11',
@@ -1053,6 +1167,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209223',
           code: '12',
           active: true,
           label: '12',
@@ -1061,6 +1176,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209224',
           code: '13',
           active: true,
           label: '13',
@@ -1069,6 +1185,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209225',
           code: '14',
           active: true,
           label: '14',
@@ -1077,6 +1194,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209226',
           code: '15',
           active: true,
           label: '15',
@@ -1085,6 +1203,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209227',
           code: '16',
           active: true,
           label: '16',
@@ -1093,6 +1212,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209228',
           code: '17',
           active: true,
           label: '17',
@@ -1101,6 +1221,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209229',
           code: '18',
           active: true,
           label: '18',
@@ -1109,6 +1230,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209230',
           code: '19',
           active: true,
           label: '19',
@@ -1117,6 +1239,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209231',
           code: '20',
           active: true,
           label: '20',
@@ -1125,6 +1248,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209232',
           code: 'MORE THAN 20',
           active: true,
           label: 'MORE THAN 20',
@@ -1133,6 +1257,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57299',
         },
         {
+          id: '209233',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1150,6 +1275,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209234',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1158,6 +1284,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57300',
         },
         {
+          id: '209235',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1175,6 +1302,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209236',
           code: '1',
           active: true,
           label: '1',
@@ -1183,6 +1311,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209237',
           code: '2',
           active: true,
           label: '2',
@@ -1191,6 +1320,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209238',
           code: '3',
           active: true,
           label: '3',
@@ -1199,6 +1329,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209239',
           code: '4',
           active: true,
           label: '4',
@@ -1207,6 +1338,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209240',
           code: '5',
           active: true,
           label: '5',
@@ -1215,6 +1347,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209241',
           code: '6',
           active: true,
           label: '6',
@@ -1223,6 +1356,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209242',
           code: '7',
           active: true,
           label: '7',
@@ -1231,6 +1365,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209243',
           code: '8',
           active: true,
           label: '8',
@@ -1239,6 +1374,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209244',
           code: '9',
           active: true,
           label: '9',
@@ -1247,6 +1383,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209245',
           code: '10',
           active: true,
           label: '10',
@@ -1255,6 +1392,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209246',
           code: '11',
           active: true,
           label: '11',
@@ -1263,6 +1401,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209247',
           code: '12',
           active: true,
           label: '12',
@@ -1271,6 +1410,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209248',
           code: '13',
           active: true,
           label: '13',
@@ -1279,6 +1419,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209249',
           code: '14',
           active: true,
           label: '14',
@@ -1287,6 +1428,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209250',
           code: '15',
           active: true,
           label: '15',
@@ -1295,6 +1437,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209251',
           code: '16',
           active: true,
           label: '16',
@@ -1303,6 +1446,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209252',
           code: '17',
           active: true,
           label: '17',
@@ -1311,6 +1455,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209253',
           code: '18',
           active: true,
           label: '18',
@@ -1319,6 +1464,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209254',
           code: '19',
           active: true,
           label: '19',
@@ -1327,6 +1473,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209255',
           code: '20',
           active: true,
           label: '20',
@@ -1335,6 +1482,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209256',
           code: 'MORE THAN 20',
           active: true,
           label: 'MORE THAN 20',
@@ -1343,6 +1491,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57301',
         },
         {
+          id: '209257',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1360,6 +1509,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209258',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1368,6 +1518,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57302',
         },
         {
+          id: '209259',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1385,6 +1536,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209260',
           code: '1',
           active: true,
           label: '1',
@@ -1393,6 +1545,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209261',
           code: '2',
           active: true,
           label: '2',
@@ -1401,6 +1554,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209262',
           code: '3',
           active: true,
           label: '3',
@@ -1409,6 +1563,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209263',
           code: '4',
           active: true,
           label: '4',
@@ -1417,6 +1572,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209264',
           code: '5',
           active: true,
           label: '5',
@@ -1425,6 +1581,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209265',
           code: '6',
           active: true,
           label: '6',
@@ -1433,6 +1590,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209266',
           code: '7',
           active: true,
           label: '7',
@@ -1441,6 +1599,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209267',
           code: '8',
           active: true,
           label: '8',
@@ -1449,6 +1608,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209268',
           code: '9',
           active: true,
           label: '9',
@@ -1457,6 +1617,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209269',
           code: '10',
           active: true,
           label: '10',
@@ -1465,6 +1626,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209270',
           code: '11',
           active: true,
           label: '11',
@@ -1473,6 +1635,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209271',
           code: '12',
           active: true,
           label: '12',
@@ -1481,6 +1644,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209272',
           code: '13',
           active: true,
           label: '13',
@@ -1489,6 +1653,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209273',
           code: '14',
           active: true,
           label: '14',
@@ -1497,6 +1662,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209274',
           code: '15',
           active: true,
           label: '15',
@@ -1505,6 +1671,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209275',
           code: '16',
           active: true,
           label: '16',
@@ -1513,6 +1680,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209276',
           code: '17',
           active: true,
           label: '17',
@@ -1521,6 +1689,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209277',
           code: '18',
           active: true,
           label: '18',
@@ -1529,6 +1698,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209278',
           code: '19',
           active: true,
           label: '19',
@@ -1537,6 +1707,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209279',
           code: '20',
           active: true,
           label: '20',
@@ -1545,6 +1716,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209280',
           code: 'MORE THAN 20',
           active: true,
           label: 'MORE THAN 20',
@@ -1553,6 +1725,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57303',
         },
         {
+          id: '209281',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1570,6 +1743,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209282',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1578,6 +1752,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57304',
         },
         {
+          id: '209283',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1595,6 +1770,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209284',
           code: 'YES (PLEASE SPECIFY)',
           active: true,
           label: 'YES (PLEASE SPECIFY)',
@@ -1603,6 +1779,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57305',
         },
         {
+          id: '209285',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1620,6 +1797,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209286',
           code: 'YES (PLEASE ENTER DATE)',
           active: true,
           label: 'YES (PLEASE ENTER DATE)',
@@ -1628,6 +1806,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57306',
         },
         {
+          id: '209287',
           code: 'EVIDENCE BAG (PLEASE ENTER BAG NUMBER)',
           active: true,
           label: 'EVIDENCE BAG (PLEASE ENTER BAG NUMBER)',
@@ -1636,6 +1815,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57306',
         },
         {
+          id: '209288',
           code: 'NO (PLEASE STATE WHY)',
           active: true,
           label: 'NO (PLEASE STATE WHY)',
@@ -1653,6 +1833,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209289',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1661,6 +1842,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57307',
         },
         {
+          id: '209290',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1678,6 +1860,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209291',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1686,6 +1869,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57308',
         },
         {
+          id: '209292',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1703,6 +1887,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209293',
           code: 'BLUNT INSTRUMENT (COSH, ITEM IN SOCK ETC.)',
           active: true,
           label: 'BLUNT INSTRUMENT (COSH, ITEM IN SOCK ETC.)',
@@ -1711,6 +1896,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57309',
         },
         {
+          id: '209294',
           code: 'KNIFE/BLADED ARTICLE',
           active: true,
           label: 'KNIFE/BLADED ARTICLE',
@@ -1719,6 +1905,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57309',
         },
         {
+          id: '209295',
           code: 'FIREARM (FAKE GUNS, AMMUNITION, CHEMIICAL INCAPACITANT ETC.)',
           active: true,
           label: 'FIREARM (FAKE GUNS, AMMUNITION, CHEMIICAL INCAPACITANT ETC.)',
@@ -1727,6 +1914,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57309',
         },
         {
+          id: '209296',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -1744,6 +1932,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209297',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1752,6 +1941,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57310',
         },
         {
+          id: '209298',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1769,6 +1959,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209299',
           code: '< 1 litre',
           active: true,
           label: '< 1 litre',
@@ -1777,6 +1968,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57311',
         },
         {
+          id: '209300',
           code: '1 to 2 litres',
           active: true,
           label: '1 to 2 litres',
@@ -1785,6 +1977,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57311',
         },
         {
+          id: '209301',
           code: '2 to 3 litres',
           active: true,
           label: '2 to 3 litres',
@@ -1793,6 +1986,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57311',
         },
         {
+          id: '209302',
           code: '3 to 4 litres',
           active: true,
           label: '3 to 4 litres',
@@ -1801,6 +1995,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57311',
         },
         {
+          id: '209303',
           code: ' 4 to 5 litres',
           active: true,
           label: ' 4 to 5 litres',
@@ -1809,6 +2004,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57311',
         },
         {
+          id: '209304',
           code: '6 to 10 litres',
           active: true,
           label: '6 to 10 litres',
@@ -1817,6 +2013,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57311',
         },
         {
+          id: '209305',
           code: '11 to 20 litres',
           active: true,
           label: '11 to 20 litres',
@@ -1825,6 +2022,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57311',
         },
         {
+          id: '209306',
           code: 'More than 20 litres',
           active: true,
           label: 'More than 20 litres',
@@ -1833,6 +2031,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57311',
         },
         {
+          id: '209307',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -1850,6 +2049,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209308',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1858,6 +2058,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57312',
         },
         {
+          id: '209309',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1875,6 +2076,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209310',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1883,6 +2085,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57313',
         },
         {
+          id: '209311',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1900,6 +2103,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209312',
           code: 'LOOSE TOBACCO',
           active: true,
           label: 'LOOSE TOBACCO',
@@ -1908,6 +2112,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57314',
         },
         {
+          id: '209313',
           code: 'CIGARETTES/CIGARS',
           active: true,
           label: 'CIGARETTES/CIGARS',
@@ -1916,6 +2121,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57314',
         },
         {
+          id: '209314',
           code: 'OTHER (INC PACKAGING AND ROACHES)',
           active: true,
           label: 'OTHER (INC PACKAGING AND ROACHES)',
@@ -1933,6 +2139,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209315',
           code: '<1g',
           active: true,
           label: '<1g',
@@ -1941,6 +2148,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57315',
         },
         {
+          id: '209316',
           code: '2g to 5g',
           active: true,
           label: '2g to 5g',
@@ -1949,6 +2157,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57315',
         },
         {
+          id: '209317',
           code: '6g to 10g',
           active: true,
           label: '6g to 10g',
@@ -1957,6 +2166,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57315',
         },
         {
+          id: '209318',
           code: '10g+',
           active: true,
           label: '10g+',
@@ -1974,6 +2184,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209319',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1982,6 +2193,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57316',
         },
         {
+          id: '209320',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -1999,6 +2211,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209321',
           code: 'PLEASE SPECIFY',
           active: true,
           label: 'PLEASE SPECIFY',
@@ -2016,6 +2229,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209322',
           code: 'BOSS CHAIR',
           active: true,
           label: 'BOSS CHAIR',
@@ -2024,6 +2238,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209323',
           code: 'CELL SEARCH',
           active: true,
           label: 'CELL SEARCH',
@@ -2032,6 +2247,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209324',
           code: 'CRIME SCENE',
           active: true,
           label: 'CRIME SCENE',
@@ -2040,6 +2256,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209325',
           code: 'DOG SEARCH',
           active: true,
           label: 'DOG SEARCH',
@@ -2048,6 +2265,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209326',
           code: 'DRONE RECOVERY',
           active: true,
           label: 'DRONE RECOVERY',
@@ -2056,6 +2274,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209327',
           code: 'HIGH SENSITIVITY WAND',
           active: true,
           label: 'HIGH SENSITIVITY WAND',
@@ -2064,6 +2283,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209328',
           code: 'INFORMATION RECEIVED',
           active: true,
           label: 'INFORMATION RECEIVED',
@@ -2072,6 +2292,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209329',
           code: 'INTELLIGENCE LED SEARCH',
           active: true,
           label: 'INTELLIGENCE LED SEARCH',
@@ -2080,6 +2301,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209330',
           code: 'ITEM OBSERVED',
           active: true,
           label: 'ITEM OBSERVED',
@@ -2088,6 +2310,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209331',
           code: 'MOBILE PHONE SIGNAL DETECTOR',
           active: true,
           label: 'MOBILE PHONE SIGNAL DETECTOR',
@@ -2096,6 +2319,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209332',
           code: 'MOBILE PHONE ROD',
           active: true,
           label: 'MOBILE PHONE ROD',
@@ -2104,6 +2328,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209333',
           code: 'OTHER SEARCH (INMATE)',
           active: true,
           label: 'OTHER SEARCH (INMATE)',
@@ -2112,6 +2337,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209334',
           code: 'OTHER SEARCH (PREMISES)',
           active: true,
           label: 'OTHER SEARCH (PREMISES)',
@@ -2120,6 +2346,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209335',
           code: 'OTHER SEARCH (VISITOR)',
           active: true,
           label: 'OTHER SEARCH (VISITOR)',
@@ -2128,6 +2355,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209336',
           code: 'PRE-OCCUPATION SEARCH',
           active: true,
           label: 'PRE-OCCUPATION SEARCH',
@@ -2136,6 +2364,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209337',
           code: 'UNUSUAL BEHAVIOUR',
           active: true,
           label: 'UNUSUAL BEHAVIOUR',
@@ -2144,6 +2373,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57318',
         },
         {
+          id: '209338',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -2161,6 +2391,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '209339',
           code: 'PRISONER',
           active: true,
           label: 'PRISONER',
@@ -2169,6 +2400,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209340',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -2177,6 +2409,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209341',
           code: 'VISITOR (FRIEND)',
           active: true,
           label: 'VISITOR (FRIEND)',
@@ -2185,6 +2418,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209342',
           code: 'VISITOR (OFFICIAL)',
           active: true,
           label: 'VISITOR (OFFICIAL)',
@@ -2193,6 +2427,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209343',
           code: 'VISITOR (RELATIVE)',
           active: true,
           label: 'VISITOR (RELATIVE)',
@@ -2201,6 +2436,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209344',
           code: 'CONTRACTOR',
           active: true,
           label: 'CONTRACTOR',
@@ -2209,6 +2445,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209345',
           code: 'POST (RULE 39)',
           active: true,
           label: 'POST (RULE 39)',
@@ -2217,6 +2454,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209346',
           code: 'POST (OTHER)',
           active: true,
           label: 'POST (OTHER)',
@@ -2225,6 +2463,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209347',
           code: 'THROWN IN',
           active: true,
           label: 'THROWN IN',
@@ -2233,6 +2472,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209348',
           code: 'DRONE/UAV',
           active: true,
           label: 'DRONE/UAV',
@@ -2241,6 +2481,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209349',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -2249,6 +2490,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57319',
         },
         {
+          id: '209350',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2266,6 +2508,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209351',
           code: 'PRISONER',
           active: true,
           label: 'PRISONER',
@@ -2274,6 +2517,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57320',
         },
         {
+          id: '209352',
           code: 'STAFF',
           active: true,
           label: 'STAFF',
@@ -2282,6 +2526,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57320',
         },
         {
+          id: '209353',
           code: 'VISITOR (FRIEND)',
           active: true,
           label: 'VISITOR (FRIEND)',
@@ -2290,6 +2535,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57320',
         },
         {
+          id: '209354',
           code: 'VISITOR (OFFICIAL)',
           active: true,
           label: 'VISITOR (OFFICIAL)',
@@ -2298,6 +2544,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57320',
         },
         {
+          id: '209355',
           code: 'VISITOR (RELATIVE)',
           active: true,
           label: 'VISITOR (RELATIVE)',
@@ -2306,6 +2553,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57320',
         },
         {
+          id: '209356',
           code: 'CONTRACTOR',
           active: true,
           label: 'CONTRACTOR',
@@ -2314,6 +2562,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57320',
         },
         {
+          id: '209357',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -2322,6 +2571,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57320',
         },
         {
+          id: '209358',
           code: 'NOT APPLICABLE',
           active: true,
           label: 'NOT APPLICABLE',
@@ -2339,6 +2589,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209359',
           code: 'NOT CONCEALED',
           active: true,
           label: 'NOT CONCEALED',
@@ -2347,6 +2598,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209360',
           code: 'BED/BEDDING',
           active: true,
           label: 'BED/BEDDING',
@@ -2355,6 +2607,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209361',
           code: 'BOOK/PAPERS',
           active: true,
           label: 'BOOK/PAPERS',
@@ -2363,6 +2616,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209362',
           code: 'CELL/BUILDING FABRIC',
           active: true,
           label: 'CELL/BUILDING FABRIC',
@@ -2371,6 +2625,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209363',
           code: 'FOOD/CONTAINER',
           active: true,
           label: 'FOOD/CONTAINER',
@@ -2379,6 +2634,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209364',
           code: 'IN CLOTHING',
           active: true,
           label: 'IN CLOTHING',
@@ -2387,6 +2643,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209365',
           code: 'IN HAND',
           active: true,
           label: 'IN HAND',
@@ -2395,6 +2652,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209366',
           code: 'IN MOUTH',
           active: true,
           label: 'IN MOUTH',
@@ -2403,6 +2661,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209367',
           code: 'INTERNALLY/PLUGGED',
           active: true,
           label: 'INTERNALLY/PLUGGED',
@@ -2411,6 +2670,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209368',
           code: 'LETTER/PARCEL',
           active: true,
           label: 'LETTER/PARCEL',
@@ -2419,6 +2679,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209369',
           code: 'LIGHT FITTINGS',
           active: true,
           label: 'LIGHT FITTINGS',
@@ -2427,6 +2688,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209370',
           code: 'PIPEWORK',
           active: true,
           label: 'PIPEWORK',
@@ -2435,6 +2697,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209371',
           code: 'RULE 39/LEGAL PAPERS',
           active: true,
           label: 'RULE 39/LEGAL PAPERS',
@@ -2443,6 +2706,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209372',
           code: 'TV/RADIO/DVD/CONSOLES ETC.',
           active: true,
           label: 'TV/RADIO/DVD/CONSOLES ETC.',
@@ -2451,6 +2715,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57321',
         },
         {
+          id: '209373',
           code: 'OTHER (PLEASE SPECIFY)',
           active: true,
           label: 'OTHER (PLEASE SPECIFY)',
@@ -2468,6 +2733,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209374',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2476,6 +2742,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57322',
         },
         {
+          id: '209375',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2493,6 +2760,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209376',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2501,6 +2769,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57323',
         },
         {
+          id: '209377',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2518,6 +2787,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209378',
           code: 'AFTER ENTERING PRISON',
           active: true,
           label: 'AFTER ENTERING PRISON',
@@ -2526,6 +2796,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57324',
         },
         {
+          id: '209379',
           code: 'BEFORE ENTERING PRISON',
           active: true,
           label: 'BEFORE ENTERING PRISON',
@@ -2543,6 +2814,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209380',
           code: 'PLEASE SPECIFY',
           active: true,
           label: 'PLEASE SPECIFY',
@@ -2560,6 +2832,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209381',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -2568,6 +2841,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57326',
         },
         {
+          id: '209382',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -2576,6 +2850,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57327',
         },
         {
+          id: '209383',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2593,6 +2868,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209384',
           code: 'COMMUNITY VISIT',
           active: true,
           label: 'COMMUNITY VISIT',
@@ -2601,6 +2877,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57327',
         },
         {
+          id: '209385',
           code: 'COMPASSIONATE',
           active: true,
           label: 'COMPASSIONATE',
@@ -2609,6 +2886,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57327',
         },
         {
+          id: '209386',
           code: 'FACILITY',
           active: true,
           label: 'FACILITY',
@@ -2617,6 +2895,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57327',
         },
         {
+          id: '209387',
           code: 'RESETTLEMENT',
           active: true,
           label: 'RESETTLEMENT',
@@ -2625,6 +2904,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: '57327',
         },
         {
+          id: '209388',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',
@@ -2642,6 +2922,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '209389',
           code: '£0',
           active: true,
           label: '£0',
@@ -2650,6 +2931,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209390',
           code: '£1 to £100',
           active: true,
           label: '£1 to £100',
@@ -2658,6 +2940,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209391',
           code: '£101 to £200',
           active: true,
           label: '£101 to £200',
@@ -2666,6 +2949,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209392',
           code: '£201 to £300',
           active: true,
           label: '£201 to £300',
@@ -2674,6 +2958,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209393',
           code: '£301 to £400',
           active: true,
           label: '£301 to £400',
@@ -2682,6 +2967,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209394',
           code: '£401 to £500',
           active: true,
           label: '£401 to £500',
@@ -2690,6 +2976,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209395',
           code: '£501 to £1,000',
           active: true,
           label: '£501 to £1,000',
@@ -2698,6 +2985,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209396',
           code: '£1,001 to £5,000',
           active: true,
           label: '£1,001 to £5,000',
@@ -2706,6 +2994,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209397',
           code: '£5,001 to £10,000',
           active: true,
           label: '£5,001 to £10,000',
@@ -2714,6 +3003,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209398',
           code: '£10,001 to £20,000',
           active: true,
           label: '£10,001 to £20,000',
@@ -2722,6 +3012,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209399',
           code: '£20,001 to £30,000',
           active: true,
           label: '£20,001 to £30,000',
@@ -2730,6 +3021,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209400',
           code: '£30,001 to £40,000',
           active: true,
           label: '£30,001 to £40,000',
@@ -2738,6 +3030,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209401',
           code: '£40,001 to £50,000',
           active: true,
           label: '£40,001 to £50,000',
@@ -2746,6 +3039,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209402',
           code: 'More than £50,000',
           active: true,
           label: 'More than £50,000',
@@ -2754,6 +3048,7 @@ const OLD_FINDS4: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '209403',
           code: 'UNKNOWN',
           active: true,
           label: 'UNKNOWN',

--- a/server/reportConfiguration/types/OLD_FIREARM_ETC.ts
+++ b/server/reportConfiguration/types/OLD_FIREARM_ETC.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:12.981Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:39.288Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178891',
           code: 'TARGET SEARCH',
           active: false,
           label: 'TARGET SEARCH',
@@ -23,6 +24,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44637',
         },
         {
+          id: '178893',
           code: 'ROUTINE SEARCH',
           active: false,
           label: 'ROUTINE SEARCH',
@@ -31,6 +33,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44980',
         },
         {
+          id: '178892',
           code: 'CHANCE',
           active: false,
           label: 'CHANCE',
@@ -48,6 +51,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179027',
           code: 'SPECIFY',
           active: false,
           label: 'SPECIFY',
@@ -65,6 +69,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179069',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -73,6 +78,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44548',
         },
         {
+          id: '179070',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -90,6 +96,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179112',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -98,6 +105,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44846',
         },
         {
+          id: '179111',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -115,6 +123,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179119',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -123,6 +132,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44451',
         },
         {
+          id: '179120',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -140,6 +150,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179190',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -148,6 +159,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45049',
         },
         {
+          id: '179189',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -165,6 +177,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179191',
           code: 'LOCAL',
           active: false,
           label: 'LOCAL',
@@ -173,6 +186,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179192',
           code: 'SERVICE SUPPLIER',
           active: false,
           label: 'SERVICE SUPPLIER',
@@ -190,6 +204,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179569',
           code: 'DESCRIPTION',
           active: false,
           label: 'DESCRIPTION',
@@ -207,6 +222,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179616',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -215,6 +231,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44755',
         },
         {
+          id: '179615',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -232,6 +249,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179817',
           code: 'PISTOL/REVOLVER',
           active: false,
           label: 'PISTOL/REVOLVER',
@@ -240,6 +258,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44698',
         },
         {
+          id: '179818',
           code: 'RIFLE',
           active: false,
           label: 'RIFLE',
@@ -248,6 +267,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44698',
         },
         {
+          id: '179819',
           code: 'SHOTGUN',
           active: false,
           label: 'SHOTGUN',
@@ -256,6 +276,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44698',
         },
         {
+          id: '179815',
           code: 'HILTI GUN',
           active: false,
           label: 'HILTI GUN',
@@ -264,6 +285,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44698',
         },
         {
+          id: '179816',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -281,6 +303,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179839',
           code: 'ENTER TIME',
           active: false,
           label: 'ENTER TIME',
@@ -298,6 +321,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179918',
           code: 'NUMBER',
           active: false,
           label: 'NUMBER',
@@ -315,6 +339,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179975',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -323,6 +348,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44524',
         },
         {
+          id: '179976',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -340,6 +366,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179988',
           code: 'LOCAL',
           active: false,
           label: 'LOCAL',
@@ -348,6 +375,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44755',
         },
         {
+          id: '179987',
           code: 'SERVICE SUPPLIER',
           active: false,
           label: 'SERVICE SUPPLIER',
@@ -365,6 +393,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180000',
           code: 'PRISONER',
           active: false,
           label: 'PRISONER',
@@ -373,6 +402,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44980',
         },
         {
+          id: '180001',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -381,6 +411,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44980',
         },
         {
+          id: '179999',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -389,6 +420,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44980',
         },
         {
+          id: '180002',
           code: 'VISITOR',
           active: false,
           label: 'VISITOR',
@@ -397,6 +429,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44980',
         },
         {
+          id: '179998',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -414,6 +447,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180090',
           code: 'CONCEALED',
           active: false,
           label: 'CONCEALED',
@@ -422,6 +456,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45102',
         },
         {
+          id: '180091',
           code: 'DISCARDED',
           active: false,
           label: 'DISCARDED',
@@ -439,6 +474,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180112',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -447,6 +483,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44676',
         },
         {
+          id: '180111',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -464,6 +501,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180237',
           code: 'SPECIFY',
           active: false,
           label: 'SPECIFY',
@@ -481,6 +519,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180261',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -489,6 +528,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45000',
         },
         {
+          id: '180260',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -506,6 +546,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180289',
           code: 'PRISONER',
           active: false,
           label: 'PRISONER',
@@ -514,6 +555,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44874',
         },
         {
+          id: '180291',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -522,6 +564,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44874',
         },
         {
+          id: '180290',
           code: 'SOCIAL VISITOR',
           active: false,
           label: 'SOCIAL VISITOR',
@@ -530,6 +573,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44874',
         },
         {
+          id: '180287',
           code: 'OFFICIAL VISITOR',
           active: false,
           label: 'OFFICIAL VISITOR',
@@ -538,6 +582,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44874',
         },
         {
+          id: '180288',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -555,6 +600,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180301',
           code: 'ADMINISTRATION',
           active: false,
           label: 'ADMINISTRATION',
@@ -563,6 +609,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180303',
           code: 'CELL',
           active: false,
           label: 'CELL',
@@ -571,6 +618,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180302',
           code: 'ASSOCIATION AREA',
           active: false,
           label: 'ASSOCIATION AREA',
@@ -579,6 +627,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180304',
           code: 'CHAPEL',
           active: false,
           label: 'CHAPEL',
@@ -587,6 +636,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180306',
           code: 'DINING ROOM',
           active: false,
           label: 'DINING ROOM',
@@ -595,6 +645,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180307',
           code: 'DORMITORY',
           active: false,
           label: 'DORMITORY',
@@ -603,6 +654,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180308',
           code: 'EDUCATION',
           active: false,
           label: 'EDUCATION',
@@ -611,6 +663,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180310',
           code: 'EXERCISE YARD',
           active: false,
           label: 'EXERCISE YARD',
@@ -619,6 +672,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180312',
           code: 'GATE',
           active: false,
           label: 'GATE',
@@ -627,6 +681,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180313',
           code: 'GYM',
           active: false,
           label: 'GYM',
@@ -635,6 +690,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180314',
           code: 'HEALTH CARE CENTRE',
           active: false,
           label: 'HEALTH CARE CENTRE',
@@ -643,6 +699,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180317',
           code: 'KITCHEN',
           active: false,
           label: 'KITCHEN',
@@ -651,6 +708,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180319',
           code: 'OFFICE',
           active: false,
           label: 'OFFICE',
@@ -659,6 +717,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180321',
           code: 'RECEPTION',
           active: false,
           label: 'RECEPTION',
@@ -667,6 +726,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180322',
           code: 'RECESS',
           active: false,
           label: 'RECESS',
@@ -675,6 +735,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180323',
           code: 'SEGREGATION UNIT',
           active: false,
           label: 'SEGREGATION UNIT',
@@ -683,6 +744,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180325',
           code: 'SPECIAL UNIT',
           active: false,
           label: 'SPECIAL UNIT',
@@ -691,6 +753,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180324',
           code: 'SHOWERS/CHANGING ROOM',
           active: false,
           label: 'SHOWERS/CHANGING ROOM',
@@ -699,6 +762,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180328',
           code: 'VISITS',
           active: false,
           label: 'VISITS',
@@ -707,6 +771,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180330',
           code: 'WING',
           active: false,
           label: 'WING',
@@ -715,6 +780,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180332',
           code: 'WORKS DEPARTMENT',
           active: false,
           label: 'WORKS DEPARTMENT',
@@ -723,6 +789,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180333',
           code: 'WORKSHOP',
           active: false,
           label: 'WORKSHOP',
@@ -731,6 +798,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180331',
           code: 'WITHIN PERIMETER',
           active: false,
           label: 'WITHIN PERIMETER',
@@ -739,6 +807,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180309',
           code: 'ELSEWHERE',
           active: false,
           label: 'ELSEWHERE',
@@ -747,6 +816,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180311',
           code: 'FUNERAL',
           active: false,
           label: 'FUNERAL',
@@ -755,6 +825,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180315',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: false,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -763,6 +834,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180316',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: false,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -771,6 +843,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180320',
           code: 'OUTSIDE WORKING PARTY',
           active: false,
           label: 'OUTSIDE WORKING PARTY',
@@ -779,6 +852,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180326',
           code: 'SPORTSFIELD',
           active: false,
           label: 'SPORTSFIELD',
@@ -787,6 +861,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180327',
           code: 'VEHICLE',
           active: false,
           label: 'VEHICLE',
@@ -795,6 +870,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180329',
           code: 'WEDDING',
           active: false,
           label: 'WEDDING',
@@ -803,6 +879,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180318',
           code: 'MAGISTRATES COURT',
           active: false,
           label: 'MAGISTRATES COURT',
@@ -811,6 +888,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44470',
         },
         {
+          id: '180305',
           code: 'CROWN COURT',
           active: false,
           label: 'CROWN COURT',
@@ -828,6 +906,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180426',
           code: 'C.N (CHLORACETOPHEONE)',
           active: false,
           label: 'C.N (CHLORACETOPHEONE)',
@@ -836,6 +915,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44622',
         },
         {
+          id: '180427',
           code: 'C.S (ORTHO..NITRILE)',
           active: false,
           label: 'C.S (ORTHO..NITRILE)',
@@ -844,6 +924,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44622',
         },
         {
+          id: '180429',
           code: 'O.C (MACE/PEPPER)',
           active: false,
           label: 'O.C (MACE/PEPPER)',
@@ -852,6 +933,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44622',
         },
         {
+          id: '180430',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -860,6 +942,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44622',
         },
         {
+          id: '180428',
           code: 'NOT KNOWN',
           active: false,
           label: 'NOT KNOWN',
@@ -877,6 +960,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180661',
           code: 'SPECIFY',
           active: false,
           label: 'SPECIFY',
@@ -894,6 +978,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180664',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -902,6 +987,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44692',
         },
         {
+          id: '180665',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -919,6 +1005,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180713',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -927,6 +1014,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44455',
         },
         {
+          id: '180714',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -944,6 +1032,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180839',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -952,6 +1041,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45026',
         },
         {
+          id: '180838',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -969,6 +1059,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180885',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -977,6 +1068,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44446',
         },
         {
+          id: '180884',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -994,6 +1086,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180919',
           code: 'SPECIFY',
           active: false,
           label: 'SPECIFY',
@@ -1011,6 +1104,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180959',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1019,6 +1113,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44870',
         },
         {
+          id: '180960',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1036,6 +1131,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181116',
           code: 'TELEPHONY',
           active: false,
           label: 'TELEPHONY',
@@ -1044,6 +1140,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44398',
         },
         {
+          id: '181115',
           code: 'IT',
           active: false,
           label: 'IT',
@@ -1061,6 +1158,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181170',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1069,6 +1167,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44513',
         },
         {
+          id: '181171',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1086,6 +1185,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181176',
           code: 'ENTER COMMENT AND DATE',
           active: false,
           label: 'ENTER COMMENT AND DATE',
@@ -1103,6 +1203,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181302',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1111,6 +1212,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44323',
         },
         {
+          id: '181303',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1128,6 +1230,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181317',
           code: 'BARREL',
           active: false,
           label: 'BARREL',
@@ -1136,6 +1239,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44703',
         },
         {
+          id: '181318',
           code: 'BUTT',
           active: false,
           label: 'BUTT',
@@ -1144,6 +1248,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44703',
         },
         {
+          id: '181319',
           code: 'MAGAZINE',
           active: false,
           label: 'MAGAZINE',
@@ -1152,6 +1257,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44703',
         },
         {
+          id: '181320',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1169,6 +1275,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181329',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1177,6 +1284,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44330',
         },
         {
+          id: '181330',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1194,6 +1302,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181374',
           code: 'SPECIFY',
           active: false,
           label: 'SPECIFY',
@@ -1211,6 +1320,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181474',
           code: 'LIVE',
           active: false,
           label: 'LIVE',
@@ -1219,6 +1329,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44390',
         },
         {
+          id: '181471',
           code: 'BLANK',
           active: false,
           label: 'BLANK',
@@ -1227,6 +1338,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44390',
         },
         {
+          id: '181473',
           code: 'DISABLED',
           active: false,
           label: 'DISABLED',
@@ -1235,6 +1347,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44390',
         },
         {
+          id: '181472',
           code: 'CARTRIDGE CASE',
           active: false,
           label: 'CARTRIDGE CASE',
@@ -1243,6 +1356,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44390',
         },
         {
+          id: '181475',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1260,6 +1374,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181495',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1268,6 +1383,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44208',
         },
         {
+          id: '181494',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1285,6 +1401,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181609',
           code: 'GOVERNOR',
           active: false,
           label: 'GOVERNOR',
@@ -1293,6 +1410,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44820',
         },
         {
+          id: '181607',
           code: 'DEPUTY GOVERNOR',
           active: false,
           label: 'DEPUTY GOVERNOR',
@@ -1301,6 +1419,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44820',
         },
         {
+          id: '181608',
           code: 'DUTY GOVERNOR',
           active: false,
           label: 'DUTY GOVERNOR',
@@ -1309,6 +1428,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44820',
         },
         {
+          id: '181610',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1326,6 +1446,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181654',
           code: 'METAL DETECTING PORTAL',
           active: false,
           label: 'METAL DETECTING PORTAL',
@@ -1334,6 +1455,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44624',
         },
         {
+          id: '181653',
           code: 'HAND HELD METAL DETECTOR',
           active: false,
           label: 'HAND HELD METAL DETECTOR',
@@ -1342,6 +1464,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44624',
         },
         {
+          id: '181656',
           code: 'X-RAY MACHINE',
           active: false,
           label: 'X-RAY MACHINE',
@@ -1350,6 +1473,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44624',
         },
         {
+          id: '181655',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1367,6 +1491,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181717',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1375,6 +1500,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44922',
         },
         {
+          id: '181718',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1392,6 +1518,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181833',
           code: 'FULL',
           active: false,
           label: 'FULL',
@@ -1400,6 +1527,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44907',
         },
         {
+          id: '181834',
           code: 'PARTIAL',
           active: false,
           label: 'PARTIAL',
@@ -1417,6 +1545,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181905',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1425,6 +1554,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44928',
         },
         {
+          id: '181904',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1442,6 +1572,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181925',
           code: 'NUMBER',
           active: false,
           label: 'NUMBER',
@@ -1459,6 +1590,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181959',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1467,6 +1599,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45005',
         },
         {
+          id: '181958',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1484,6 +1617,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181961',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1492,6 +1626,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44703',
         },
         {
+          id: '181960',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1509,6 +1644,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181971',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1517,6 +1653,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44473',
         },
         {
+          id: '181970',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1534,6 +1671,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182040',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1542,6 +1680,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45029',
         },
         {
+          id: '182041',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1559,6 +1698,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182046',
           code: 'PISTOL',
           active: false,
           label: 'PISTOL',
@@ -1567,6 +1707,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45119',
         },
         {
+          id: '182047',
           code: 'REVOLVER',
           active: false,
           label: 'REVOLVER',
@@ -1575,6 +1716,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45119',
         },
         {
+          id: '182048',
           code: 'RIFLE',
           active: false,
           label: 'RIFLE',
@@ -1583,6 +1725,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45119',
         },
         {
+          id: '182049',
           code: 'SHOTGUN',
           active: false,
           label: 'SHOTGUN',
@@ -1591,6 +1734,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45119',
         },
         {
+          id: '182045',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1608,6 +1752,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182172',
           code: 'PRISON',
           active: false,
           label: 'PRISON',
@@ -1616,6 +1761,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44193',
         },
         {
+          id: '182171',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -1624,6 +1770,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44193',
         },
         {
+          id: '182170',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1641,6 +1788,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182210',
           code: 'PRISONER',
           active: false,
           label: 'PRISONER',
@@ -1649,6 +1797,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182212',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -1657,6 +1806,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182211',
           code: 'SOCIAL VISITOR',
           active: false,
           label: 'SOCIAL VISITOR',
@@ -1665,6 +1815,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182208',
           code: 'OFFICIAL VISITOR',
           active: false,
           label: 'OFFICIAL VISITOR',
@@ -1673,6 +1824,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182209',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1690,6 +1842,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182346',
           code: 'ON A PERSON',
           active: false,
           label: 'ON A PERSON',
@@ -1698,6 +1851,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '45056',
         },
         {
+          id: '182347',
           code: 'BURIED',
           active: false,
           label: 'BURIED',
@@ -1706,6 +1860,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182352',
           code: 'IN I/P PROPERTY',
           active: false,
           label: 'IN I/P PROPERTY',
@@ -1714,6 +1869,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182353',
           code: 'IN STORED PROPERTY',
           active: false,
           label: 'IN STORED PROPERTY',
@@ -1722,6 +1878,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182351',
           code: 'IN CELL FURNITURE',
           active: false,
           label: 'IN CELL FURNITURE',
@@ -1730,6 +1887,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182350',
           code: 'IN BUILDING FABRIC',
           active: false,
           label: 'IN BUILDING FABRIC',
@@ -1738,6 +1896,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182354',
           code: 'STORES ITEMS',
           active: false,
           label: 'STORES ITEMS',
@@ -1746,6 +1905,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182348',
           code: 'DELIVERED FOODS/PARCELS',
           active: false,
           label: 'DELIVERED FOODS/PARCELS',
@@ -1754,6 +1914,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182355',
           code: 'VEHICLE',
           active: false,
           label: 'VEHICLE',
@@ -1762,6 +1923,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44123',
         },
         {
+          id: '182349',
           code: 'ELSEWHERE',
           active: false,
           label: 'ELSEWHERE',
@@ -1779,6 +1941,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182424',
           code: 'REAL (FUNCTIONAL)',
           active: false,
           label: 'REAL (FUNCTIONAL)',
@@ -1787,6 +1950,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44504',
         },
         {
+          id: '182425',
           code: 'REAL (NON-FUNCTIONAL)',
           active: false,
           label: 'REAL (NON-FUNCTIONAL)',
@@ -1795,6 +1959,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44504',
         },
         {
+          id: '182426',
           code: 'REPLICA',
           active: false,
           label: 'REPLICA',
@@ -1803,6 +1968,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44504',
         },
         {
+          id: '182423',
           code: 'HOME MADE',
           active: false,
           label: 'HOME MADE',
@@ -1811,6 +1977,7 @@ const OLD_FIREARM_ETC: IncidentTypeConfiguration = {
           nextQuestionId: '44504',
         },
         {
+          id: '182427',
           code: 'TOY',
           active: false,
           label: 'TOY',

--- a/server/reportConfiguration/types/OLD_HOSTAGE.ts
+++ b/server/reportConfiguration/types/OLD_HOSTAGE.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:15.069Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:41.703Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178952',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -23,6 +24,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44365',
         },
         {
+          id: '178951',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -40,6 +42,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179194',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -48,6 +51,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44452',
         },
         {
+          id: '179193',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -65,6 +69,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179199',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: false,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -82,6 +87,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179209',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -90,6 +96,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44235',
         },
         {
+          id: '179210',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -107,6 +114,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179270',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -115,6 +123,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45093',
         },
         {
+          id: '179269',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -132,6 +141,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179275',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -140,6 +150,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44347',
         },
         {
+          id: '179274',
           code: 'PRISONERS',
           active: false,
           label: 'PRISONERS',
@@ -148,6 +159,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44347',
         },
         {
+          id: '179271',
           code: 'CIVILIAN GRADES',
           active: false,
           label: 'CIVILIAN GRADES',
@@ -156,6 +168,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44347',
         },
         {
+          id: '179273',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -164,6 +177,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44347',
         },
         {
+          id: '179272',
           code: 'EXTERNAL CIVILIANS',
           active: false,
           label: 'EXTERNAL CIVILIANS',
@@ -181,6 +195,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179287',
           code: 'GOVERNOR',
           active: false,
           label: 'GOVERNOR',
@@ -189,6 +204,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45076',
         },
         {
+          id: '179285',
           code: 'DEPUTY GOVERNOR',
           active: false,
           label: 'DEPUTY GOVERNOR',
@@ -197,6 +213,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45076',
         },
         {
+          id: '179286',
           code: 'DUTY GOVERNOR',
           active: false,
           label: 'DUTY GOVERNOR',
@@ -205,6 +222,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45076',
         },
         {
+          id: '179288',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -222,6 +240,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179338',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -230,6 +249,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44891',
         },
         {
+          id: '179337',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -247,6 +267,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179357',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -255,6 +276,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44963',
         },
         {
+          id: '179356',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -272,6 +294,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179388',
           code: 'TELEPHONY',
           active: false,
           label: 'TELEPHONY',
@@ -280,6 +303,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44788',
         },
         {
+          id: '179387',
           code: 'IT',
           active: false,
           label: 'IT',
@@ -297,6 +321,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179424',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -305,6 +330,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44805',
         },
         {
+          id: '179425',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -322,6 +348,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179532',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -330,6 +357,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44600',
         },
         {
+          id: '179533',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -347,6 +375,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179553',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -355,6 +384,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44463',
         },
         {
+          id: '179554',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -372,6 +402,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179568',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -380,6 +411,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44137',
         },
         {
+          id: '179567',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -397,6 +429,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179627',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -405,6 +438,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45101',
         },
         {
+          id: '179628',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -422,6 +456,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179669',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -430,6 +465,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44937',
         },
         {
+          id: '179668',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -447,6 +483,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179701',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -455,6 +492,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44275',
         },
         {
+          id: '179700',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -472,6 +510,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179720',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -480,6 +519,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44959',
         },
         {
+          id: '179719',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -497,6 +537,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179850',
           code: 'NUMBER',
           active: false,
           label: 'NUMBER',
@@ -514,6 +555,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179881',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -522,6 +564,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44939',
         },
         {
+          id: '179880',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -539,6 +582,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179920',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -547,6 +591,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44777',
         },
         {
+          id: '179919',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -564,6 +609,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179989',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -572,6 +618,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44474',
         },
         {
+          id: '179990',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -589,6 +636,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180034',
           code: 'ADMINISTRATION',
           active: false,
           label: 'ADMINISTRATION',
@@ -597,6 +645,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180035',
           code: 'ASSOCIATION AREA',
           active: false,
           label: 'ASSOCIATION AREA',
@@ -605,6 +654,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180036',
           code: 'CELL',
           active: false,
           label: 'CELL',
@@ -613,6 +663,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180037',
           code: 'CHAPEL',
           active: false,
           label: 'CHAPEL',
@@ -621,6 +672,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180039',
           code: 'DINING ROOM',
           active: false,
           label: 'DINING ROOM',
@@ -629,6 +681,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180040',
           code: 'DORMITORY',
           active: false,
           label: 'DORMITORY',
@@ -637,6 +690,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180041',
           code: 'EDUCATION',
           active: false,
           label: 'EDUCATION',
@@ -645,6 +699,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180043',
           code: 'EXERCISE YARD',
           active: false,
           label: 'EXERCISE YARD',
@@ -653,6 +708,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180045',
           code: 'GATE',
           active: false,
           label: 'GATE',
@@ -661,6 +717,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180046',
           code: 'GYM',
           active: false,
           label: 'GYM',
@@ -669,6 +726,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180047',
           code: 'HEALTH CARE CENTRE',
           active: false,
           label: 'HEALTH CARE CENTRE',
@@ -677,6 +735,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180050',
           code: 'KITCHEN',
           active: false,
           label: 'KITCHEN',
@@ -685,6 +744,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180052',
           code: 'OFFICE',
           active: false,
           label: 'OFFICE',
@@ -693,6 +753,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180054',
           code: 'RECEPTION',
           active: false,
           label: 'RECEPTION',
@@ -701,6 +762,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180055',
           code: 'RECESS',
           active: false,
           label: 'RECESS',
@@ -709,6 +771,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180056',
           code: 'SEGREGATION UNIT',
           active: false,
           label: 'SEGREGATION UNIT',
@@ -717,6 +780,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180058',
           code: 'SPECIAL UNIT',
           active: false,
           label: 'SPECIAL UNIT',
@@ -725,6 +789,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180057',
           code: 'SHOWERS/CHANGING ROOM',
           active: false,
           label: 'SHOWERS/CHANGING ROOM',
@@ -733,6 +798,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180061',
           code: 'VISITS',
           active: false,
           label: 'VISITS',
@@ -741,6 +807,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180063',
           code: 'WING',
           active: false,
           label: 'WING',
@@ -749,6 +816,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180065',
           code: 'WORKS DEPARTMENT',
           active: false,
           label: 'WORKS DEPARTMENT',
@@ -757,6 +825,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180066',
           code: 'WORKSHOP',
           active: false,
           label: 'WORKSHOP',
@@ -765,6 +834,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180064',
           code: 'WITHIN PERIMETER',
           active: false,
           label: 'WITHIN PERIMETER',
@@ -773,6 +843,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180042',
           code: 'ELSEWHERE',
           active: false,
           label: 'ELSEWHERE',
@@ -781,6 +852,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180044',
           code: 'FUNERAL',
           active: false,
           label: 'FUNERAL',
@@ -789,6 +861,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180048',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: false,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -797,6 +870,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180049',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: false,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -805,6 +879,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180053',
           code: 'OUTSIDE WORKING PARTY',
           active: false,
           label: 'OUTSIDE WORKING PARTY',
@@ -813,6 +888,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180059',
           code: 'SPORTS FIELD',
           active: false,
           label: 'SPORTS FIELD',
@@ -821,6 +897,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180060',
           code: 'VEHICLE',
           active: false,
           label: 'VEHICLE',
@@ -829,6 +906,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180062',
           code: 'WEDDINGS',
           active: false,
           label: 'WEDDINGS',
@@ -837,6 +915,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180051',
           code: 'MAGISTRATES COURT',
           active: false,
           label: 'MAGISTRATES COURT',
@@ -845,6 +924,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44690',
         },
         {
+          id: '180038',
           code: 'CROWN COURT',
           active: true,
           label: 'CROWN COURT',
@@ -862,6 +942,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180117',
           code: 'FIREARM',
           active: false,
           label: 'FIREARM',
@@ -870,6 +951,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180114',
           code: 'CHEMICAL INCAPACITANT',
           active: false,
           label: 'CHEMICAL INCAPACITANT',
@@ -878,6 +960,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180119',
           code: 'KNIFE/BLADE',
           active: false,
           label: 'KNIFE/BLADE',
@@ -886,6 +969,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180122',
           code: 'OTHER SHARP INSTRUMENT',
           active: false,
           label: 'OTHER SHARP INSTRUMENT',
@@ -894,6 +978,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180113',
           code: 'BLUNT INSTRUMENT',
           active: false,
           label: 'BLUNT INSTRUMENT',
@@ -902,6 +987,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180120',
           code: 'LIGATURE',
           active: false,
           label: 'LIGATURE',
@@ -910,6 +996,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180115',
           code: 'DANGEROUS LIQUID',
           active: false,
           label: 'DANGEROUS LIQUID',
@@ -918,6 +1005,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180116',
           code: 'EXCRETA/URINE',
           active: false,
           label: 'EXCRETA/URINE',
@@ -926,6 +1014,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180123',
           code: 'SPITTING',
           active: false,
           label: 'SPITTING',
@@ -934,6 +1023,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180118',
           code: 'FOOD',
           active: false,
           label: 'FOOD',
@@ -942,6 +1032,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180125',
           code: 'THROWN FURNITURE',
           active: false,
           label: 'THROWN FURNITURE',
@@ -950,6 +1041,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180124',
           code: 'THROWN EQUIPMENT',
           active: false,
           label: 'THROWN EQUIPMENT',
@@ -958,6 +1050,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45162',
         },
         {
+          id: '180121',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -975,6 +1068,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180167',
           code: 'LOCAL',
           active: false,
           label: 'LOCAL',
@@ -983,6 +1077,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '180168',
           code: 'SERVICE SUPPLIER',
           active: false,
           label: 'SERVICE SUPPLIER',
@@ -1000,6 +1095,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180207',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1008,6 +1104,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44614',
         },
         {
+          id: '180208',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1025,6 +1122,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180454',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1033,6 +1131,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45078',
         },
         {
+          id: '180453',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1050,6 +1149,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180472',
           code: 'NUMBER',
           active: false,
           label: 'NUMBER',
@@ -1067,6 +1167,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180486',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1075,6 +1176,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44335',
         },
         {
+          id: '180485',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1092,6 +1194,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180536',
           code: 'INTERVENTION',
           active: false,
           label: 'INTERVENTION',
@@ -1100,6 +1203,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44814',
         },
         {
+          id: '180537',
           code: 'NEGOTIATION',
           active: false,
           label: 'NEGOTIATION',
@@ -1108,6 +1212,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44891',
         },
         {
+          id: '180538',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1125,6 +1230,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180602',
           code: 'MINOR',
           active: false,
           label: 'MINOR',
@@ -1133,6 +1239,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44213',
         },
         {
+          id: '180603',
           code: 'SERIOUS',
           active: false,
           label: 'SERIOUS',
@@ -1141,6 +1248,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44213',
         },
         {
+          id: '180601',
           code: 'EXTENSIVE',
           active: false,
           label: 'EXTENSIVE',
@@ -1158,6 +1266,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180622',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: false,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -1166,6 +1275,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45059',
         },
         {
+          id: '180623',
           code: 'MINOR BRUISES',
           active: false,
           label: 'MINOR BRUISES',
@@ -1174,6 +1284,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45059',
         },
         {
+          id: '180626',
           code: 'SWELLINGS',
           active: false,
           label: 'SWELLINGS',
@@ -1182,6 +1293,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45059',
         },
         {
+          id: '180625',
           code: 'SUPERFICIAL CUTS',
           active: false,
           label: 'SUPERFICIAL CUTS',
@@ -1190,6 +1302,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45059',
         },
         {
+          id: '180624',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1207,6 +1320,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180631',
           code: 'DESCRIPTION',
           active: false,
           label: 'DESCRIPTION',
@@ -1224,6 +1338,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180637',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1232,6 +1347,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44608',
         },
         {
+          id: '180638',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1249,6 +1365,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180640',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1257,6 +1374,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44431',
         },
         {
+          id: '180639',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1274,6 +1392,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180879',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1282,6 +1401,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45135',
         },
         {
+          id: '180878',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1299,6 +1419,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180893',
           code: 'FRACTURE',
           active: false,
           label: 'FRACTURE',
@@ -1307,6 +1428,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180895',
           code: 'SCALD OR BURN',
           active: false,
           label: 'SCALD OR BURN',
@@ -1315,6 +1437,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180896',
           code: 'STABBING',
           active: false,
           label: 'STABBING',
@@ -1323,6 +1446,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180890',
           code: 'CRUSHING',
           active: false,
           label: 'CRUSHING',
@@ -1331,6 +1455,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180892',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: false,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -1339,6 +1464,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180887',
           code: 'BLACK EYE',
           active: false,
           label: 'BLACK EYE',
@@ -1347,6 +1473,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180888',
           code: 'BROKEN NOSE',
           active: false,
           label: 'BROKEN NOSE',
@@ -1355,6 +1482,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180889',
           code: 'BROKEN TEETH',
           active: false,
           label: 'BROKEN TEETH',
@@ -1363,6 +1491,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180891',
           code: 'CUTS REQUIRING SUTURES',
           active: false,
           label: 'CUTS REQUIRING SUTURES',
@@ -1371,6 +1500,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180886',
           code: 'BITES',
           active: false,
           label: 'BITES',
@@ -1379,6 +1509,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180894',
           code: 'GUN SHOT WOUND',
           active: false,
           label: 'GUN SHOT WOUND',
@@ -1387,6 +1518,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44613',
         },
         {
+          id: '180897',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: false,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -1404,6 +1536,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180983',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1412,6 +1545,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44555',
         },
         {
+          id: '180982',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1429,6 +1563,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181173',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1437,6 +1572,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44585',
         },
         {
+          id: '181172',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1454,6 +1590,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181205',
           code: 'ENTER TIME',
           active: false,
           label: 'ENTER TIME',
@@ -1471,6 +1608,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181269',
           code: 'LOCAL',
           active: false,
           label: 'LOCAL',
@@ -1479,6 +1617,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44275',
         },
         {
+          id: '181268',
           code: 'SERVICE SUPPLIER',
           active: false,
           label: 'SERVICE SUPPLIER',
@@ -1496,6 +1635,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181293',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1504,6 +1644,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44257',
         },
         {
+          id: '181292',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1521,6 +1662,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181298',
           code: 'ENTER COMMENT AND DATE',
           active: false,
           label: 'ENTER COMMENT AND DATE',
@@ -1538,6 +1680,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181309',
           code: 'PRISONER',
           active: false,
           label: 'PRISONER',
@@ -1546,6 +1689,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44497',
         },
         {
+          id: '181310',
           code: 'VISITOR',
           active: false,
           label: 'VISITOR',
@@ -1554,6 +1698,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44497',
         },
         {
+          id: '181308',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1571,6 +1716,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181327',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1579,6 +1725,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44356',
         },
         {
+          id: '181328',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1596,6 +1743,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181557',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1604,6 +1752,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44322',
         },
         {
+          id: '181556',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1621,6 +1770,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181748',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1629,6 +1779,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44564',
         },
         {
+          id: '181747',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1646,6 +1797,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181752',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1654,6 +1806,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44210',
         },
         {
+          id: '181751',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1671,6 +1824,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181821',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1679,6 +1833,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45079',
         },
         {
+          id: '181820',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1696,6 +1851,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181832',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1704,6 +1860,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44411',
         },
         {
+          id: '181831',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1721,6 +1878,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181969',
           code: 'NUMBER',
           active: false,
           label: 'NUMBER',
@@ -1738,6 +1896,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181991',
           code: 'FULL',
           active: false,
           label: 'FULL',
@@ -1746,6 +1905,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44239',
         },
         {
+          id: '181992',
           code: 'PARTIAL',
           active: false,
           label: 'PARTIAL',
@@ -1763,6 +1923,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182220',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -1771,6 +1932,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44218',
         },
         {
+          id: '182219',
           code: 'PRISONERS',
           active: false,
           label: 'PRISONERS',
@@ -1779,6 +1941,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44218',
         },
         {
+          id: '182216',
           code: 'CIVILIAN GRADES',
           active: false,
           label: 'CIVILIAN GRADES',
@@ -1787,6 +1950,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44218',
         },
         {
+          id: '182218',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -1795,6 +1959,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44218',
         },
         {
+          id: '182217',
           code: 'EXTERNAL CIVILIANS',
           active: false,
           label: 'EXTERNAL CIVILIANS',
@@ -1812,6 +1977,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182272',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1820,6 +1986,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44611',
         },
         {
+          id: '182273',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1837,6 +2004,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182277',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1845,6 +2013,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45148',
         },
         {
+          id: '182276',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1862,6 +2031,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182279',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1870,6 +2040,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '45087',
         },
         {
+          id: '182278',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1887,6 +2058,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182298',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1895,6 +2067,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44711',
         },
         {
+          id: '182297',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1912,6 +2085,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182322',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1920,6 +2094,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44569',
         },
         {
+          id: '182321',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1937,6 +2112,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182344',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1945,6 +2121,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44693',
         },
         {
+          id: '182345',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1962,6 +2139,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182509',
           code: 'INVESTIGATION BY POLICE',
           active: false,
           label: 'INVESTIGATION BY POLICE',
@@ -1970,6 +2148,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44234',
         },
         {
+          id: '182510',
           code: 'INVESTIGATION INTERNALLY',
           active: false,
           label: 'INVESTIGATION INTERNALLY',
@@ -1978,6 +2157,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44234',
         },
         {
+          id: '182508',
           code: "GOVERNOR'S ADJUDICATION",
           active: false,
           label: "GOVERNOR'S ADJUDICATION",
@@ -1986,6 +2166,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44234',
         },
         {
+          id: '182511',
           code: 'NO INVESTIGATION',
           active: false,
           label: 'NO INVESTIGATION',
@@ -2003,6 +2184,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182538',
           code: 'PRISONER',
           active: false,
           label: 'PRISONER',
@@ -2011,6 +2193,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44823',
         },
         {
+          id: '182539',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -2019,6 +2202,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44823',
         },
         {
+          id: '182536',
           code: 'OFFICER',
           active: false,
           label: 'OFFICER',
@@ -2027,6 +2211,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44823',
         },
         {
+          id: '182535',
           code: 'CIVILIAN STAFF',
           active: false,
           label: 'CIVILIAN STAFF',
@@ -2035,6 +2220,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44823',
         },
         {
+          id: '182537',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -2052,6 +2238,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182554',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -2060,6 +2247,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
           nextQuestionId: '44265',
         },
         {
+          id: '182553',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -2077,6 +2265,7 @@ const OLD_HOSTAGE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182603',
           code: 'HOURS',
           active: false,
           label: 'HOURS',

--- a/server/reportConfiguration/types/OLD_KEY_LOCK_INCIDENT.ts
+++ b/server/reportConfiguration/types/OLD_KEY_LOCK_INCIDENT.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:17.489Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:44.246Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179053',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -23,6 +24,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44331',
         },
         {
+          id: '179052',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -40,6 +42,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179240',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -48,6 +51,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44972',
         },
         {
+          id: '179239',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -65,6 +69,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179618',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -73,6 +78,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44386',
         },
         {
+          id: '179617',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -90,6 +96,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179699',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -98,6 +105,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44894',
         },
         {
+          id: '179698',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -115,6 +123,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179807',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -123,6 +132,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44414',
         },
         {
+          id: '179806',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -140,6 +150,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179860',
           code: 'HACKSAW BLADE',
           active: false,
           label: 'HACKSAW BLADE',
@@ -148,6 +159,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44925',
         },
         {
+          id: '179863',
           code: 'OTHER BLADE',
           active: false,
           label: 'OTHER BLADE',
@@ -156,6 +168,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44925',
         },
         {
+          id: '179865',
           code: 'WIRE CUTTERS',
           active: false,
           label: 'WIRE CUTTERS',
@@ -164,6 +177,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44925',
         },
         {
+          id: '179857',
           code: 'BOLT CROPPERS',
           active: false,
           label: 'BOLT CROPPERS',
@@ -172,6 +186,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44925',
         },
         {
+          id: '179859',
           code: 'DIGGING TOOL',
           active: false,
           label: 'DIGGING TOOL',
@@ -180,6 +195,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44925',
         },
         {
+          id: '179858',
           code: 'CROW BAR',
           active: false,
           label: 'CROW BAR',
@@ -188,6 +204,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44925',
         },
         {
+          id: '179861',
           code: 'IMPROVISED TOOL',
           active: false,
           label: 'IMPROVISED TOOL',
@@ -196,6 +213,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44925',
         },
         {
+          id: '179864',
           code: 'OTHER TOOL',
           active: false,
           label: 'OTHER TOOL',
@@ -204,6 +222,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44925',
         },
         {
+          id: '179862',
           code: 'NOT KNOWN',
           active: false,
           label: 'NOT KNOWN',
@@ -221,6 +240,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179886',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -229,6 +249,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44678',
         },
         {
+          id: '179885',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -246,6 +267,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179981',
           code: 'COMPLETE RELOCK',
           active: false,
           label: 'COMPLETE RELOCK',
@@ -254,6 +276,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44921',
         },
         {
+          id: '179983',
           code: 'PARTIAL RELOCK',
           active: false,
           label: 'PARTIAL RELOCK',
@@ -262,6 +285,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44921',
         },
         {
+          id: '179982',
           code: 'COMPLETE REPLACEMENT',
           active: false,
           label: 'COMPLETE REPLACEMENT',
@@ -270,6 +294,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44921',
         },
         {
+          id: '179984',
           code: 'PARTIAL REPLACEMENT',
           active: false,
           label: 'PARTIAL REPLACEMENT',
@@ -287,6 +312,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180597',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -295,6 +321,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45072',
         },
         {
+          id: '180598',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -312,6 +339,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180656',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -320,6 +348,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44894',
         },
         {
+          id: '180655',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -337,6 +366,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180843',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -345,6 +375,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44228',
         },
         {
+          id: '180842',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -362,6 +393,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181168',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -370,6 +402,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44449',
         },
         {
+          id: '181169',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -387,6 +420,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181450',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -395,6 +429,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44407',
         },
         {
+          id: '181451',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -412,6 +447,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181562',
           code: 'FULL CLOSE DOWN SEARCH',
           active: false,
           label: 'FULL CLOSE DOWN SEARCH',
@@ -420,6 +456,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44866',
         },
         {
+          id: '181564',
           code: 'PARTIAL SEARCH',
           active: false,
           label: 'PARTIAL SEARCH',
@@ -428,6 +465,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44866',
         },
         {
+          id: '181563',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -445,6 +483,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181652',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: false,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -462,6 +501,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181680',
           code: 'WORKS DEPARTMENT',
           active: false,
           label: 'WORKS DEPARTMENT',
@@ -470,6 +510,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181669',
           code: 'CONTRACTORS',
           active: false,
           label: 'CONTRACTORS',
@@ -478,6 +519,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181670',
           code: 'EDUCATION',
           active: false,
           label: 'EDUCATION',
@@ -486,6 +528,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181673',
           code: 'HEALTH CARE CENTRE',
           active: false,
           label: 'HEALTH CARE CENTRE',
@@ -494,6 +537,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181671',
           code: 'FARMS AND GARDENS',
           active: false,
           label: 'FARMS AND GARDENS',
@@ -502,6 +546,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181672',
           code: 'GYMNASIUM/SPORTS FIELD',
           active: false,
           label: 'GYMNASIUM/SPORTS FIELD',
@@ -510,6 +555,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181681',
           code: 'WORKSHOPS',
           active: false,
           label: 'WORKSHOPS',
@@ -518,6 +564,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181675',
           code: 'KITCHEN',
           active: false,
           label: 'KITCHEN',
@@ -526,6 +573,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181674',
           code: 'HOBBIES',
           active: false,
           label: 'HOBBIES',
@@ -534,6 +582,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181668',
           code: 'CELL FURNISHINGS',
           active: false,
           label: 'CELL FURNISHINGS',
@@ -542,6 +591,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181679',
           code: 'WING/HOUSEBLOCK FURNISHINGS',
           active: false,
           label: 'WING/HOUSEBLOCK FURNISHINGS',
@@ -550,6 +600,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181678',
           code: 'SMUGGLED',
           active: false,
           label: 'SMUGGLED',
@@ -558,6 +609,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181676',
           code: 'NOT KNOWN',
           active: false,
           label: 'NOT KNOWN',
@@ -566,6 +618,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44775',
         },
         {
+          id: '181677',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -583,6 +636,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181869',
           code: 'CLASS 1 PASS KEY',
           active: false,
           label: 'CLASS 1 PASS KEY',
@@ -591,6 +645,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181871',
           code: 'CLASS 2 PASS KEY',
           active: false,
           label: 'CLASS 2 PASS KEY',
@@ -599,6 +654,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181866',
           code: 'CELL KEY',
           active: false,
           label: 'CELL KEY',
@@ -607,6 +663,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181872',
           code: 'CLASS 3 A1 SUITE KEY',
           active: false,
           label: 'CLASS 3 A1 SUITE KEY',
@@ -615,6 +672,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181874',
           code: 'CLASS 3 ACCOUNTABLE KEY',
           active: false,
           label: 'CLASS 3 ACCOUNTABLE KEY',
@@ -623,6 +681,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181880',
           code: 'HANDCUFF KEY',
           active: false,
           label: 'HANDCUFF KEY',
@@ -631,6 +690,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181877',
           code: 'CLOSETING/ESCORT CHAIN KEY',
           active: false,
           label: 'CLOSETING/ESCORT CHAIN KEY',
@@ -639,6 +699,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181868',
           code: 'CLASS 1 LOCK',
           active: false,
           label: 'CLASS 1 LOCK',
@@ -647,6 +708,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181870',
           code: 'CLASS 2 LOCK',
           active: false,
           label: 'CLASS 2 LOCK',
@@ -655,6 +717,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181867',
           code: 'CELL LOCK',
           active: false,
           label: 'CELL LOCK',
@@ -663,6 +726,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181873',
           code: 'CLASS 3 A1 SUITE LOCK',
           active: false,
           label: 'CLASS 3 A1 SUITE LOCK',
@@ -671,6 +735,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181875',
           code: 'CLASS 3 ACCOUNTABLE LOCK',
           active: false,
           label: 'CLASS 3 ACCOUNTABLE LOCK',
@@ -679,6 +744,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181879',
           code: 'HANDCUFF',
           active: false,
           label: 'HANDCUFF',
@@ -687,6 +753,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181876',
           code: 'CLOSETING/ESCORT CHAIN',
           active: false,
           label: 'CLOSETING/ESCORT CHAIN',
@@ -695,6 +762,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181878',
           code: 'ELECTRONIC LOCK SYSTEM',
           active: false,
           label: 'ELECTRONIC LOCK SYSTEM',
@@ -703,6 +771,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '45015',
         },
         {
+          id: '181881',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -720,6 +789,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181999',
           code: 'LOSS OF KEY(S)',
           active: false,
           label: 'LOSS OF KEY(S)',
@@ -728,6 +798,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44619',
         },
         {
+          id: '181998',
           code: 'LOSS OF HANDCUFFS',
           active: false,
           label: 'LOSS OF HANDCUFFS',
@@ -736,6 +807,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44619',
         },
         {
+          id: '181997',
           code: 'LOSS OF CLOSETING/ESCORT CHAIN',
           active: false,
           label: 'LOSS OF CLOSETING/ESCORT CHAIN',
@@ -744,6 +816,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44619',
         },
         {
+          id: '181996',
           code: 'COMPLETE LOCK REMOVED',
           active: false,
           label: 'COMPLETE LOCK REMOVED',
@@ -752,6 +825,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44619',
         },
         {
+          id: '182000',
           code: 'PART LOCK REMOVED',
           active: false,
           label: 'PART LOCK REMOVED',
@@ -760,6 +834,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44619',
         },
         {
+          id: '182001',
           code: 'REPLICA KEY USED',
           active: false,
           label: 'REPLICA KEY USED',
@@ -768,6 +843,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44355',
         },
         {
+          id: '182003',
           code: 'LOCKS PICKED',
           active: false,
           label: 'LOCKS PICKED',
@@ -776,6 +852,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44866',
         },
         {
+          id: '182002',
           code: 'ELECTRONICS OVERCOME',
           active: false,
           label: 'ELECTRONICS OVERCOME',
@@ -784,6 +861,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44866',
         },
         {
+          id: '182004',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -801,6 +879,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182261',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -809,6 +888,7 @@ const OLD_KEY_LOCK_INCIDENT: IncidentTypeConfiguration = {
           nextQuestionId: '44166',
         },
         {
+          id: '182260',
           code: 'NO',
           active: false,
           label: 'NO',

--- a/server/reportConfiguration/types/OLD_MOBILES.ts
+++ b/server/reportConfiguration/types/OLD_MOBILES.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:20.444Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:47.422Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182826',
           code: 'Mobile:',
           active: false,
           label: 'Mobile:',
@@ -23,6 +24,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182827',
           code: 'SIM:',
           active: false,
           label: 'SIM:',
@@ -31,6 +33,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182828',
           code: 'Charger:',
           active: false,
           label: 'Charger:',
@@ -39,6 +42,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182829',
           code: 'Other please specify:',
           active: false,
           label: 'Other please specify:',
@@ -47,6 +51,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182941',
           code: 'Mobile:',
           active: false,
           label: 'Mobile:',
@@ -55,6 +60,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45210',
         },
         {
+          id: '182942',
           code: 'SIM:',
           active: false,
           label: 'SIM:',
@@ -63,6 +69,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45210',
         },
         {
+          id: '182943',
           code: 'Charger:',
           active: false,
           label: 'Charger:',
@@ -71,6 +78,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45210',
         },
         {
+          id: '182944',
           code: 'Other please specify:',
           active: false,
           label: 'Other please specify:',
@@ -88,6 +96,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182830',
           code: 'Enter Date:',
           active: false,
           label: 'Enter Date:',
@@ -96,6 +105,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183080',
           code: 'Enter Date:',
           active: false,
           label: 'Enter Date:',
@@ -113,6 +123,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182831',
           code: 'Enter Time:',
           active: true,
           label: 'Enter Time:',
@@ -121,6 +132,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183081',
           code: 'Enter Time:',
           active: true,
           label: 'Enter Time:',
@@ -138,6 +150,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182832',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -146,6 +159,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182833',
           code: 'No',
           active: false,
           label: 'No',
@@ -154,6 +168,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183082',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -162,6 +177,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45213',
         },
         {
+          id: '183083',
           code: 'No',
           active: false,
           label: 'No',
@@ -179,6 +195,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182834',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -187,6 +204,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182835',
           code: 'Prisoner/Young Offender',
           active: false,
           label: 'Prisoner/Young Offender',
@@ -195,6 +213,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182836',
           code: 'Visitor: Specify:',
           active: false,
           label: 'Visitor: Specify:',
@@ -203,6 +222,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182837',
           code: 'Social',
           active: false,
           label: 'Social',
@@ -211,6 +231,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182838',
           code: 'Official',
           active: false,
           label: 'Official',
@@ -219,6 +240,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182839',
           code: 'Contractor',
           active: false,
           label: 'Contractor',
@@ -227,6 +249,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182840',
           code: 'Thrown In',
           active: false,
           label: 'Thrown In',
@@ -235,6 +258,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182841',
           code: 'Post - Social/Rule 39',
           active: false,
           label: 'Post - Social/Rule 39',
@@ -243,6 +267,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182842',
           code: 'Not attributable',
           active: false,
           label: 'Not attributable',
@@ -251,6 +276,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182843',
           code: 'Other: Please specify',
           active: false,
           label: 'Other: Please specify',
@@ -259,6 +285,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183084',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -267,6 +294,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45214',
         },
         {
+          id: '183085',
           code: 'Prisoner / Young Offender',
           active: false,
           label: 'Prisoner / Young Offender',
@@ -275,6 +303,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45214',
         },
         {
+          id: '183086',
           code: 'Visitor: Social',
           active: false,
           label: 'Visitor: Social',
@@ -283,6 +312,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45214',
         },
         {
+          id: '183087',
           code: 'Visitor: Official',
           active: false,
           label: 'Visitor: Official',
@@ -291,6 +321,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45214',
         },
         {
+          id: '183088',
           code: 'Contractor',
           active: false,
           label: 'Contractor',
@@ -299,6 +330,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45214',
         },
         {
+          id: '183089',
           code: 'Thrown In',
           active: false,
           label: 'Thrown In',
@@ -307,6 +339,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45214',
         },
         {
+          id: '183090',
           code: 'Post – Social / Rule 39',
           active: false,
           label: 'Post – Social / Rule 39',
@@ -315,6 +348,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45214',
         },
         {
+          id: '183091',
           code: 'Not attributable',
           active: false,
           label: 'Not attributable',
@@ -323,6 +357,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45214',
         },
         {
+          id: '183092',
           code: 'Other : Please Specify',
           active: false,
           label: 'Other : Please Specify',
@@ -340,6 +375,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182844',
           code: 'Boss Chair',
           active: false,
           label: 'Boss Chair',
@@ -348,6 +384,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182845',
           code: 'High Sensitivity Wand',
           active: false,
           label: 'High Sensitivity Wand',
@@ -356,6 +393,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182846',
           code: 'Mobile Phone Detection Dog',
           active: false,
           label: 'Mobile Phone Detection Dog',
@@ -364,6 +402,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182847',
           code: 'Physical search',
           active: false,
           label: 'Physical search',
@@ -372,6 +411,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182848',
           code: 'Cell search',
           active: false,
           label: 'Cell search',
@@ -380,6 +420,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182849',
           code: 'Unusual/Suspicious behaviour',
           active: false,
           label: 'Unusual/Suspicious behaviour',
@@ -388,6 +429,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182850',
           code: 'Mobile phone signal detector',
           active: false,
           label: 'Mobile phone signal detector',
@@ -396,6 +438,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182851',
           code: 'Intelligence led search',
           active: false,
           label: 'Intelligence led search',
@@ -404,6 +447,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182852',
           code: 'Information received',
           active: false,
           label: 'Information received',
@@ -412,6 +456,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182853',
           code: 'Other: Please specify',
           active: false,
           label: 'Other: Please specify',
@@ -420,6 +465,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183093',
           code: 'Boss Chair',
           active: false,
           label: 'Boss Chair',
@@ -428,6 +474,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45215',
         },
         {
+          id: '183094',
           code: 'High Sensitivity Wand',
           active: false,
           label: 'High Sensitivity Wand',
@@ -436,6 +483,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45215',
         },
         {
+          id: '183095',
           code: 'Mobile phone detection Dog',
           active: false,
           label: 'Mobile phone detection Dog',
@@ -444,6 +492,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45215',
         },
         {
+          id: '183096',
           code: 'Physical Search',
           active: false,
           label: 'Physical Search',
@@ -452,6 +501,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45215',
         },
         {
+          id: '183097',
           code: 'Cell Search',
           active: false,
           label: 'Cell Search',
@@ -460,6 +510,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45215',
         },
         {
+          id: '183098',
           code: 'Unusual/Suspicious Behaviour',
           active: false,
           label: 'Unusual/Suspicious Behaviour',
@@ -468,6 +519,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45215',
         },
         {
+          id: '183099',
           code: 'Mobile phone signal detector',
           active: false,
           label: 'Mobile phone signal detector',
@@ -476,6 +528,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45215',
         },
         {
+          id: '183100',
           code: 'Intelligence led search',
           active: false,
           label: 'Intelligence led search',
@@ -484,6 +537,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45215',
         },
         {
+          id: '183101',
           code: 'Information Received',
           active: false,
           label: 'Information Received',
@@ -492,6 +546,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45215',
         },
         {
+          id: '183102',
           code: 'Other: Please Specify',
           active: false,
           label: 'Other: Please Specify',
@@ -509,6 +564,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182854',
           code: 'Prisoner/Young Offender',
           active: false,
           label: 'Prisoner/Young Offender',
@@ -517,6 +573,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182855',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -525,6 +582,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182856',
           code: 'Contractor',
           active: false,
           label: 'Contractor',
@@ -533,6 +591,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182857',
           code: 'Visitor: Please specify',
           active: false,
           label: 'Visitor: Please specify',
@@ -541,6 +600,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182858',
           code: 'Official',
           active: false,
           label: 'Official',
@@ -549,6 +609,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182859',
           code: 'Other: Please specify',
           active: false,
           label: 'Other: Please specify',
@@ -557,6 +618,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183103',
           code: 'Prisoner/Young Offender',
           active: false,
           label: 'Prisoner/Young Offender',
@@ -565,6 +627,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45216',
         },
         {
+          id: '183104',
           code: 'Staff',
           active: false,
           label: 'Staff',
@@ -573,6 +636,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45216',
         },
         {
+          id: '183105',
           code: 'Contractor',
           active: false,
           label: 'Contractor',
@@ -581,6 +645,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45216',
         },
         {
+          id: '183106',
           code: 'Visitor: Social',
           active: false,
           label: 'Visitor: Social',
@@ -589,6 +654,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45216',
         },
         {
+          id: '183107',
           code: 'Visitor: Official',
           active: false,
           label: 'Visitor: Official',
@@ -597,6 +663,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45216',
         },
         {
+          id: '183108',
           code: 'Other: Please Specify',
           active: false,
           label: 'Other: Please Specify',
@@ -614,6 +681,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182860',
           code: 'Administration Area',
           active: false,
           label: 'Administration Area',
@@ -622,6 +690,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182861',
           code: 'Association Area',
           active: false,
           label: 'Association Area',
@@ -630,6 +699,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182862',
           code: 'Prisoner Accommodation',
           active: false,
           label: 'Prisoner Accommodation',
@@ -638,6 +708,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182863',
           code: 'Chapel',
           active: false,
           label: 'Chapel',
@@ -646,6 +717,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182864',
           code: 'Dormitory',
           active: false,
           label: 'Dormitory',
@@ -654,6 +726,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182865',
           code: 'Education',
           active: false,
           label: 'Education',
@@ -662,6 +735,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182866',
           code: 'Exercise Yard',
           active: false,
           label: 'Exercise Yard',
@@ -670,6 +744,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182867',
           code: 'External Area (within prison grounds)',
           active: false,
           label: 'External Area (within prison grounds)',
@@ -678,6 +753,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182868',
           code: 'Gate',
           active: false,
           label: 'Gate',
@@ -686,6 +762,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182869',
           code: 'Gym',
           active: false,
           label: 'Gym',
@@ -694,6 +771,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182870',
           code: 'Health Care Centre',
           active: false,
           label: 'Health Care Centre',
@@ -702,6 +780,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182871',
           code: 'Kitchen',
           active: false,
           label: 'Kitchen',
@@ -710,6 +789,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182872',
           code: 'Post/Parcel',
           active: false,
           label: 'Post/Parcel',
@@ -718,6 +798,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182873',
           code: 'Reception',
           active: false,
           label: 'Reception',
@@ -726,6 +807,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182874',
           code: 'Recess',
           active: false,
           label: 'Recess',
@@ -734,6 +816,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182875',
           code: 'Segregation Unit',
           active: false,
           label: 'Segregation Unit',
@@ -742,6 +825,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182876',
           code: 'Special Unit',
           active: false,
           label: 'Special Unit',
@@ -750,6 +834,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182877',
           code: 'Showers/Changing Room',
           active: false,
           label: 'Showers/Changing Room',
@@ -758,6 +843,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182878',
           code: 'Visits',
           active: false,
           label: 'Visits',
@@ -766,6 +852,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182879',
           code: 'Wing',
           active: false,
           label: 'Wing',
@@ -774,6 +861,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182880',
           code: 'Works Department',
           active: false,
           label: 'Works Department',
@@ -782,6 +870,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182881',
           code: 'Workshop',
           active: false,
           label: 'Workshop',
@@ -790,6 +879,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182882',
           code: 'Sports field',
           active: false,
           label: 'Sports field',
@@ -798,6 +888,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182883',
           code: 'Staff Area',
           active: false,
           label: 'Staff Area',
@@ -806,6 +897,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182884',
           code: 'Other: Please Specify',
           active: false,
           label: 'Other: Please Specify',
@@ -814,6 +906,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183109',
           code: 'Administration Area',
           active: false,
           label: 'Administration Area',
@@ -822,6 +915,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183110',
           code: 'Association Area',
           active: false,
           label: 'Association Area',
@@ -830,6 +924,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183111',
           code: 'Prisoner Accommodation',
           active: false,
           label: 'Prisoner Accommodation',
@@ -838,6 +933,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183112',
           code: 'Chapel',
           active: false,
           label: 'Chapel',
@@ -846,6 +942,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183113',
           code: 'Dormitory',
           active: false,
           label: 'Dormitory',
@@ -854,6 +951,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183114',
           code: 'Education',
           active: false,
           label: 'Education',
@@ -862,6 +960,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183115',
           code: 'Exercise Yard',
           active: false,
           label: 'Exercise Yard',
@@ -870,6 +969,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183116',
           code: 'External Area (within prison grounds)',
           active: false,
           label: 'External Area (within prison grounds)',
@@ -878,6 +978,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183117',
           code: 'Gate',
           active: false,
           label: 'Gate',
@@ -886,6 +987,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183118',
           code: 'Gym',
           active: false,
           label: 'Gym',
@@ -894,6 +996,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183119',
           code: 'Health Care Centre',
           active: false,
           label: 'Health Care Centre',
@@ -902,6 +1005,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183120',
           code: 'Kitchen',
           active: false,
           label: 'Kitchen',
@@ -910,6 +1014,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183121',
           code: 'Post/Parcel',
           active: false,
           label: 'Post/Parcel',
@@ -918,6 +1023,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183122',
           code: 'Reception',
           active: false,
           label: 'Reception',
@@ -926,6 +1032,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183123',
           code: 'Recess',
           active: false,
           label: 'Recess',
@@ -934,6 +1041,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183124',
           code: 'Segregation Unit',
           active: false,
           label: 'Segregation Unit',
@@ -942,6 +1050,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183125',
           code: 'Special Unit',
           active: false,
           label: 'Special Unit',
@@ -950,6 +1059,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183126',
           code: 'Showers/Changing Room',
           active: false,
           label: 'Showers/Changing Room',
@@ -958,6 +1068,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183127',
           code: 'Visits',
           active: false,
           label: 'Visits',
@@ -966,6 +1077,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183128',
           code: 'Wing',
           active: false,
           label: 'Wing',
@@ -974,6 +1086,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183129',
           code: 'Works Department',
           active: false,
           label: 'Works Department',
@@ -982,6 +1095,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183130',
           code: 'Workshop',
           active: false,
           label: 'Workshop',
@@ -990,6 +1104,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183131',
           code: 'Sports field',
           active: false,
           label: 'Sports field',
@@ -998,6 +1113,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183132',
           code: 'Staff Area',
           active: false,
           label: 'Staff Area',
@@ -1006,6 +1122,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45217',
         },
         {
+          id: '183133',
           code: 'Other: Please Specify',
           active: false,
           label: 'Other: Please Specify',
@@ -1023,6 +1140,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182885',
           code: 'Yes: Please specify',
           active: false,
           label: 'Yes: Please specify',
@@ -1031,6 +1149,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182886',
           code: 'No',
           active: false,
           label: 'No',
@@ -1039,6 +1158,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183134',
           code: 'Yes: Please specify',
           active: false,
           label: 'Yes: Please specify',
@@ -1047,6 +1167,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45218',
         },
         {
+          id: '183135',
           code: 'No',
           active: false,
           label: 'No',
@@ -1064,6 +1185,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182887',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -1072,6 +1194,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182888',
           code: 'Evidence Bag Number:',
           active: false,
           label: 'Evidence Bag Number:',
@@ -1080,6 +1203,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182889',
           code: 'No: Please state why',
           active: false,
           label: 'No: Please state why',
@@ -1088,6 +1212,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183136',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -1096,6 +1221,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45219',
         },
         {
+          id: '183137',
           code: 'Evidence Bag Number:',
           active: false,
           label: 'Evidence Bag Number:',
@@ -1104,6 +1230,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45219',
         },
         {
+          id: '183138',
           code: 'No: Please state why',
           active: false,
           label: 'No: Please state why',
@@ -1121,6 +1248,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182890',
           code: 'Name:',
           active: false,
           label: 'Name:',
@@ -1129,6 +1257,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182891',
           code: 'Grade:',
           active: false,
           label: 'Grade:',
@@ -1137,6 +1266,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183139',
           code: 'Name:',
           active: false,
           label: 'Name:',
@@ -1145,6 +1275,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45220',
         },
         {
+          id: '183140',
           code: 'Grade:',
           active: false,
           label: 'Grade:',
@@ -1162,6 +1293,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182892',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -1170,6 +1302,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182893',
           code: 'Police Incident Number:',
           active: false,
           label: 'Police Incident Number:',
@@ -1178,6 +1311,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182894',
           code: 'No',
           active: false,
           label: 'No',
@@ -1186,6 +1320,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183141',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -1194,6 +1329,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45221',
         },
         {
+          id: '183142',
           code: 'Police Incident Number:',
           active: false,
           label: 'Police Incident Number:',
@@ -1202,6 +1338,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45221',
         },
         {
+          id: '183143',
           code: 'No',
           active: false,
           label: 'No',
@@ -1219,6 +1356,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182895',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -1227,6 +1365,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182896',
           code: 'Police Ref Number:',
           active: false,
           label: 'Police Ref Number:',
@@ -1235,6 +1374,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182897',
           code: 'No',
           active: false,
           label: 'No',
@@ -1243,6 +1383,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183144',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -1251,6 +1392,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45222',
         },
         {
+          id: '183145',
           code: 'Police Ref Number:',
           active: false,
           label: 'Police Ref Number:',
@@ -1259,6 +1401,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45222',
         },
         {
+          id: '183146',
           code: 'No',
           active: false,
           label: 'No',
@@ -1276,6 +1419,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182898',
           code: '1',
           active: false,
           label: '1',
@@ -1284,6 +1428,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182899',
           code: '2',
           active: false,
           label: '2',
@@ -1292,6 +1437,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182900',
           code: 'Urgent',
           active: false,
           label: 'Urgent',
@@ -1300,6 +1446,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183147',
           code: '1',
           active: false,
           label: '1',
@@ -1308,6 +1455,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45223',
         },
         {
+          id: '183148',
           code: '2',
           active: false,
           label: '2',
@@ -1316,6 +1464,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45223',
         },
         {
+          id: '183149',
           code: 'Urgent',
           active: false,
           label: 'Urgent',
@@ -1324,6 +1473,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45223',
         },
         {
+          id: '186684',
           code: 'N/A Not Applicable',
           active: false,
           label: 'N/A Not Applicable',
@@ -1342,6 +1492,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182901',
           code: 'Please state where on person mobile phone was found:',
           active: false,
           label: 'Please state where on person mobile phone was found:',
@@ -1350,6 +1501,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183150',
           code: 'Please state where on person mobile phone was found:',
           active: false,
           label: 'Please state where on person mobile phone was found:',
@@ -1367,6 +1519,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182902',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1375,6 +1528,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182903',
           code: 'No',
           active: false,
           label: 'No',
@@ -1383,6 +1537,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183151',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1391,6 +1546,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45225',
         },
         {
+          id: '183152',
           code: 'No',
           active: false,
           label: 'No',
@@ -1408,6 +1564,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182904',
           code: 'Yes: Please state why',
           active: false,
           label: 'Yes: Please state why',
@@ -1416,6 +1573,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182905',
           code: 'No',
           active: false,
           label: 'No',
@@ -1424,6 +1582,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183153',
           code: 'Yes: Please state why',
           active: false,
           label: 'Yes: Please state why',
@@ -1432,6 +1591,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45226',
         },
         {
+          id: '183154',
           code: 'No',
           active: false,
           label: 'No',
@@ -1449,6 +1609,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182906',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1457,6 +1618,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182907',
           code: 'No: Please state why',
           active: false,
           label: 'No: Please state why',
@@ -1465,6 +1627,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183155',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1473,6 +1636,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45227',
         },
         {
+          id: '183156',
           code: 'No: Please state why',
           active: false,
           label: 'No: Please state why',
@@ -1490,6 +1654,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182908',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1498,6 +1663,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182909',
           code: 'No',
           active: false,
           label: 'No',
@@ -1506,6 +1672,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183157',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1514,6 +1681,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45228',
         },
         {
+          id: '183158',
           code: 'No',
           active: false,
           label: 'No',
@@ -1531,6 +1699,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182910',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1539,6 +1708,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182911',
           code: 'No',
           active: false,
           label: 'No',
@@ -1547,6 +1717,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183159',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1555,6 +1726,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45229',
         },
         {
+          id: '183160',
           code: 'No',
           active: false,
           label: 'No',
@@ -1572,6 +1744,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182912',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1580,6 +1753,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182913',
           code: 'No',
           active: false,
           label: 'No',
@@ -1588,6 +1762,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183161',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1596,6 +1771,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45230',
         },
         {
+          id: '183162',
           code: 'No',
           active: false,
           label: 'No',
@@ -1613,6 +1789,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182914',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1621,6 +1798,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182915',
           code: 'No',
           active: false,
           label: 'No',
@@ -1629,6 +1807,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183163',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -1637,6 +1816,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45231',
         },
         {
+          id: '183164',
           code: 'No',
           active: false,
           label: 'No',
@@ -1654,6 +1834,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182916',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -1662,6 +1843,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182917',
           code: 'No',
           active: false,
           label: 'No',
@@ -1670,6 +1852,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183165',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -1678,6 +1861,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45232',
         },
         {
+          id: '183166',
           code: 'No',
           active: false,
           label: 'No',
@@ -1695,6 +1879,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182918',
           code: 'HSE',
           active: false,
           label: 'HSE',
@@ -1703,6 +1888,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182919',
           code: 'Local Male',
           active: false,
           label: 'Local Male',
@@ -1711,6 +1897,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182920',
           code: 'Cat B Male',
           active: false,
           label: 'Cat B Male',
@@ -1719,6 +1906,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182921',
           code: 'Cat C Male',
           active: false,
           label: 'Cat C Male',
@@ -1727,6 +1915,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182922',
           code: 'Open Male',
           active: false,
           label: 'Open Male',
@@ -1735,6 +1924,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182923',
           code: 'Cluster',
           active: false,
           label: 'Cluster',
@@ -1743,6 +1933,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182924',
           code: 'YOI Male',
           active: false,
           label: 'YOI Male',
@@ -1751,6 +1942,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182925',
           code: 'Young People',
           active: false,
           label: 'Young People',
@@ -1759,6 +1951,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182926',
           code: 'Female Estate',
           active: false,
           label: 'Female Estate',
@@ -1767,6 +1960,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183167',
           code: 'HSE',
           active: false,
           label: 'HSE',
@@ -1775,6 +1969,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45233',
         },
         {
+          id: '183168',
           code: 'Local Male',
           active: false,
           label: 'Local Male',
@@ -1783,6 +1978,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45233',
         },
         {
+          id: '183169',
           code: 'Cat B Male',
           active: false,
           label: 'Cat B Male',
@@ -1791,6 +1987,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45233',
         },
         {
+          id: '183170',
           code: 'Cat C Male',
           active: false,
           label: 'Cat C Male',
@@ -1799,6 +1996,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45233',
         },
         {
+          id: '183171',
           code: 'Open Male',
           active: false,
           label: 'Open Male',
@@ -1807,6 +2005,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45233',
         },
         {
+          id: '183172',
           code: 'Cluster',
           active: false,
           label: 'Cluster',
@@ -1815,6 +2014,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45233',
         },
         {
+          id: '183173',
           code: 'YOI Male',
           active: false,
           label: 'YOI Male',
@@ -1823,6 +2023,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45233',
         },
         {
+          id: '183174',
           code: 'Young People',
           active: false,
           label: 'Young People',
@@ -1831,6 +2032,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45233',
         },
         {
+          id: '183175',
           code: 'Female Estate',
           active: false,
           label: 'Female Estate',
@@ -1848,6 +2050,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182927',
           code: 'Enter Establishment name in comments:',
           active: false,
           label: 'Enter Establishment name in comments:',
@@ -1856,6 +2059,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183176',
           code: 'Enter Establishment name in comments:',
           active: false,
           label: 'Enter Establishment name in comments:',
@@ -1873,6 +2077,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182928',
           code: 'High Security',
           active: false,
           label: 'High Security',
@@ -1881,6 +2086,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182929',
           code: 'East Midlands',
           active: false,
           label: 'East Midlands',
@@ -1889,6 +2095,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182930',
           code: 'West Midlands',
           active: false,
           label: 'West Midlands',
@@ -1897,6 +2104,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182931',
           code: 'Greater London',
           active: false,
           label: 'Greater London',
@@ -1905,6 +2113,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182932',
           code: 'South West',
           active: false,
           label: 'South West',
@@ -1913,6 +2122,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182933',
           code: 'Kent & Sussex',
           active: false,
           label: 'Kent & Sussex',
@@ -1921,6 +2131,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182934',
           code: 'North East',
           active: false,
           label: 'North East',
@@ -1929,6 +2140,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182935',
           code: 'South Central',
           active: false,
           label: 'South Central',
@@ -1937,6 +2149,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182936',
           code: 'East of England',
           active: false,
           label: 'East of England',
@@ -1945,6 +2158,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182937',
           code: 'North West',
           active: false,
           label: 'North West',
@@ -1953,6 +2167,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182938',
           code: 'Wales',
           active: false,
           label: 'Wales',
@@ -1961,6 +2176,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182939',
           code: 'Yorkshire & Humberside',
           active: false,
           label: 'Yorkshire & Humberside',
@@ -1969,6 +2185,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182940',
           code: 'Contracted',
           active: false,
           label: 'Contracted',
@@ -1986,6 +2203,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '192684',
           code: 'Mobile:',
           active: false,
           label: 'Mobile:',
@@ -1994,6 +2212,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45210',
         },
         {
+          id: '192685',
           code: 'SIM:',
           active: false,
           label: 'SIM:',
@@ -2002,6 +2221,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45210',
         },
         {
+          id: '192686',
           code: 'Charger:',
           active: false,
           label: 'Charger:',
@@ -2010,6 +2230,7 @@ const OLD_MOBILES: IncidentTypeConfiguration = {
           nextQuestionId: '45210',
         },
         {
+          id: '192687',
           code: 'Other please specify:',
           active: false,
           label: 'Other please specify:',

--- a/server/reportConfiguration/types/OLD_ROOF_CLIMB.ts
+++ b/server/reportConfiguration/types/OLD_ROOF_CLIMB.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:16.739Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:43.450Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178986',
           code: 'FULL',
           active: false,
           label: 'FULL',
@@ -23,6 +24,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44806',
         },
         {
+          id: '178987',
           code: 'PARTIAL',
           active: false,
           label: 'PARTIAL',
@@ -40,6 +42,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178998',
           code: 'ENTER AMOUNT IN POUND STERLING',
           active: false,
           label: 'ENTER AMOUNT IN POUND STERLING',
@@ -57,6 +60,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178999',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -65,6 +69,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44518',
         },
         {
+          id: '179000',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -82,6 +87,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179082',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -90,6 +96,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44842',
         },
         {
+          id: '179081',
           code: 'PRISONERS',
           active: false,
           label: 'PRISONERS',
@@ -98,6 +105,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44842',
         },
         {
+          id: '179078',
           code: 'CIVILIAN GRADES',
           active: false,
           label: 'CIVILIAN GRADES',
@@ -106,6 +114,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44842',
         },
         {
+          id: '179080',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -114,6 +123,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44842',
         },
         {
+          id: '179079',
           code: 'EXTERNAL CIVILIANS',
           active: false,
           label: 'EXTERNAL CIVILIANS',
@@ -131,6 +141,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179084',
           code: 'ENTER COMMENT AND DATE',
           active: false,
           label: 'ENTER COMMENT AND DATE',
@@ -148,6 +159,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179096',
           code: 'NUMBER OF HOURS',
           active: false,
           label: 'NUMBER OF HOURS',
@@ -165,6 +177,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179157',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -173,6 +186,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44337',
         },
         {
+          id: '179158',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -190,6 +204,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179384',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -198,6 +213,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44487',
         },
         {
+          id: '179383',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -215,6 +231,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179416',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -223,6 +240,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44767',
         },
         {
+          id: '179417',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -240,6 +258,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179610',
           code: 'LOCAL',
           active: false,
           label: 'LOCAL',
@@ -248,6 +267,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179611',
           code: 'SERVICE SUPPLIER',
           active: false,
           label: 'SERVICE SUPPLIER',
@@ -265,6 +285,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179625',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -273,6 +294,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45098',
         },
         {
+          id: '179626',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -290,6 +312,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179631',
           code: 'FACILITIES',
           active: false,
           label: 'FACILITIES',
@@ -298,6 +321,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45128',
         },
         {
+          id: '179632',
           code: 'FOOD',
           active: false,
           label: 'FOOD',
@@ -306,6 +330,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45128',
         },
         {
+          id: '179634',
           code: 'PAY',
           active: false,
           label: 'PAY',
@@ -314,6 +339,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45128',
         },
         {
+          id: '179636',
           code: 'VISITS',
           active: false,
           label: 'VISITS',
@@ -322,6 +348,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45128',
         },
         {
+          id: '179635',
           code: 'TIME OUT OF CELL',
           active: false,
           label: 'TIME OUT OF CELL',
@@ -330,6 +357,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45128',
         },
         {
+          id: '179633',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -347,6 +375,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179707',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -355,6 +384,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44375',
         },
         {
+          id: '179706',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -372,6 +402,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179765',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -380,6 +411,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44536',
         },
         {
+          id: '179764',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -397,6 +429,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179767',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -405,6 +438,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44151',
         },
         {
+          id: '179766',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -422,6 +456,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179828',
           code: 'GRAZES, SCRATCHES OR ABRASIONS',
           active: false,
           label: 'GRAZES, SCRATCHES OR ABRASIONS',
@@ -430,6 +465,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44462',
         },
         {
+          id: '179829',
           code: 'MINOR BRUISES',
           active: false,
           label: 'MINOR BRUISES',
@@ -438,6 +474,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44462',
         },
         {
+          id: '179832',
           code: 'SWELLINGS',
           active: false,
           label: 'SWELLINGS',
@@ -446,6 +483,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44462',
         },
         {
+          id: '179831',
           code: 'SUPERFICIAL CUTS',
           active: false,
           label: 'SUPERFICIAL CUTS',
@@ -454,6 +492,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44462',
         },
         {
+          id: '179830',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -471,6 +510,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179891',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -479,6 +519,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44927',
         },
         {
+          id: '179892',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -496,6 +537,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179901',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -504,6 +546,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44853',
         },
         {
+          id: '179902',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -521,6 +564,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180033',
           code: 'STAFF',
           active: false,
           label: 'STAFF',
@@ -529,6 +573,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44533',
         },
         {
+          id: '180032',
           code: 'PRISONERS',
           active: false,
           label: 'PRISONERS',
@@ -537,6 +582,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44533',
         },
         {
+          id: '180029',
           code: 'CIVILIAN GRADES',
           active: false,
           label: 'CIVILIAN GRADES',
@@ -545,6 +591,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44533',
         },
         {
+          id: '180031',
           code: 'POLICE',
           active: false,
           label: 'POLICE',
@@ -553,6 +600,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44533',
         },
         {
+          id: '180030',
           code: 'EXTERNAL CIVILIANS',
           active: false,
           label: 'EXTERNAL CIVILIANS',
@@ -570,6 +618,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180081',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -578,6 +627,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44359',
         },
         {
+          id: '180080',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -595,6 +645,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180089',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -603,6 +654,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44625',
         },
         {
+          id: '180088',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -620,6 +672,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180127',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -628,6 +681,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44183',
         },
         {
+          id: '180126',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -645,6 +699,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180163',
           code: 'EXTERNAL ACCESS',
           active: false,
           label: 'EXTERNAL ACCESS',
@@ -653,6 +708,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44986',
         },
         {
+          id: '180164',
           code: 'INTERNAL ACCESS',
           active: false,
           label: 'INTERNAL ACCESS',
@@ -661,6 +717,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44986',
         },
         {
+          id: '180166',
           code: 'WORKS EQUIPMENT',
           active: false,
           label: 'WORKS EQUIPMENT',
@@ -669,6 +726,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44986',
         },
         {
+          id: '180162',
           code: 'CONTRACTORS EQUIPMENT',
           active: false,
           label: 'CONTRACTORS EQUIPMENT',
@@ -677,6 +735,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44986',
         },
         {
+          id: '180165',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -694,6 +753,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180273',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -702,6 +762,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45155',
         },
         {
+          id: '180274',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -719,6 +780,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180387',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -727,6 +789,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44175',
         },
         {
+          id: '180388',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -744,6 +807,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180394',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -752,6 +816,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44797',
         },
         {
+          id: '180393',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -769,6 +834,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180439',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -777,6 +843,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44465',
         },
         {
+          id: '180438',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -794,6 +861,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180521',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -802,6 +870,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44469',
         },
         {
+          id: '180520',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -819,6 +888,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180594',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -827,6 +897,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44422',
         },
         {
+          id: '180593',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -844,6 +915,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180630',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -852,6 +924,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44475',
         },
         {
+          id: '180629',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -869,6 +942,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180667',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -877,6 +951,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44374',
         },
         {
+          id: '180666',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -894,6 +969,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180694',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -902,6 +978,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44756',
         },
         {
+          id: '180693',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -919,6 +996,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180726',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -927,6 +1005,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44334',
         },
         {
+          id: '180725',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -944,6 +1023,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180797',
           code: 'ENTER NUMBER',
           active: false,
           label: 'ENTER NUMBER',
@@ -961,6 +1041,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180865',
           code: 'FIREARM',
           active: false,
           label: 'FIREARM',
@@ -969,6 +1050,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180862',
           code: 'CHEMICAL INCAPACITANT',
           active: false,
           label: 'CHEMICAL INCAPACITANT',
@@ -977,6 +1059,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180867',
           code: 'KNIFE/BLADE',
           active: false,
           label: 'KNIFE/BLADE',
@@ -985,6 +1068,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180870',
           code: 'OTHER SHARP INSTRUMENT',
           active: false,
           label: 'OTHER SHARP INSTRUMENT',
@@ -993,6 +1077,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180861',
           code: 'BLUNT INSTRUMENT',
           active: false,
           label: 'BLUNT INSTRUMENT',
@@ -1001,6 +1086,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180868',
           code: 'LIGATURE',
           active: false,
           label: 'LIGATURE',
@@ -1009,6 +1095,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180863',
           code: 'DANGEROUS LIQUID',
           active: false,
           label: 'DANGEROUS LIQUID',
@@ -1017,6 +1104,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180864',
           code: 'EXCRETA/URINE',
           active: false,
           label: 'EXCRETA/URINE',
@@ -1025,6 +1113,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180871',
           code: 'SPITTING',
           active: false,
           label: 'SPITTING',
@@ -1033,6 +1122,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180866',
           code: 'FOOD',
           active: false,
           label: 'FOOD',
@@ -1041,6 +1131,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180873',
           code: 'THROWN FURNITURE',
           active: false,
           label: 'THROWN FURNITURE',
@@ -1049,6 +1140,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180872',
           code: 'THROWN EQUIPMENT',
           active: false,
           label: 'THROWN EQUIPMENT',
@@ -1057,6 +1149,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44725',
         },
         {
+          id: '180869',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1074,6 +1167,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180981',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1082,6 +1176,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44610',
         },
         {
+          id: '180980',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1099,6 +1194,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180987',
           code: 'NUMBER',
           active: false,
           label: 'NUMBER',
@@ -1116,6 +1212,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181034',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1124,6 +1221,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44196',
         },
         {
+          id: '181033',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1141,6 +1239,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181118',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1149,6 +1248,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44710',
         },
         {
+          id: '181117',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1166,6 +1266,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181148',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1174,6 +1275,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45163',
         },
         {
+          id: '181147',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1191,6 +1293,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181178',
           code: 'NEGOTIATION',
           active: false,
           label: 'NEGOTIATION',
@@ -1199,6 +1302,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44660',
         },
         {
+          id: '181177',
           code: 'INTERVENTION',
           active: false,
           label: 'INTERVENTION',
@@ -1207,6 +1311,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44660',
         },
         {
+          id: '181179',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1224,6 +1329,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181252',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1232,6 +1338,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44873',
         },
         {
+          id: '181251',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1249,6 +1356,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181267',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1257,6 +1365,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44553',
         },
         {
+          id: '181266',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1274,6 +1383,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181272',
           code: 'GOVERNOR',
           active: false,
           label: 'GOVERNOR',
@@ -1282,6 +1392,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44825',
         },
         {
+          id: '181270',
           code: 'DEPUTY GOVERNOR',
           active: false,
           label: 'DEPUTY GOVERNOR',
@@ -1290,6 +1401,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44825',
         },
         {
+          id: '181271',
           code: 'DUTY GOVERNOR',
           active: false,
           label: 'DUTY GOVERNOR',
@@ -1298,6 +1410,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44825',
         },
         {
+          id: '181273',
           code: 'OTHER',
           active: false,
           label: 'OTHER',
@@ -1315,6 +1428,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181295',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1323,6 +1437,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44951',
         },
         {
+          id: '181294',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1340,6 +1455,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181313',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1348,6 +1464,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44847',
         },
         {
+          id: '181314',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1365,6 +1482,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181359',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1373,6 +1491,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44273',
         },
         {
+          id: '181358',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1390,6 +1509,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181375',
           code: 'DESCRIPTION',
           active: false,
           label: 'DESCRIPTION',
@@ -1407,6 +1527,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181399',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1415,6 +1536,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44804',
         },
         {
+          id: '181398',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1432,6 +1554,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181492',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1440,6 +1563,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44687',
         },
         {
+          id: '181493',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1457,6 +1581,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181551',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1465,6 +1590,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44630',
         },
         {
+          id: '181550',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1482,6 +1608,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181559',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1490,6 +1617,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44815',
         },
         {
+          id: '181558',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1507,6 +1635,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181684',
           code: 'ADMINISTRATION',
           active: false,
           label: 'ADMINISTRATION',
@@ -1515,6 +1644,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181685',
           code: 'ASSOCIATION AREA',
           active: false,
           label: 'ASSOCIATION AREA',
@@ -1523,6 +1653,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181686',
           code: 'CELL',
           active: false,
           label: 'CELL',
@@ -1531,6 +1662,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181687',
           code: 'CHAPEL',
           active: false,
           label: 'CHAPEL',
@@ -1539,6 +1671,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181689',
           code: 'DINING ROOM',
           active: false,
           label: 'DINING ROOM',
@@ -1547,6 +1680,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181690',
           code: 'DORMITORY',
           active: false,
           label: 'DORMITORY',
@@ -1555,6 +1689,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181691',
           code: 'EDUCATION',
           active: false,
           label: 'EDUCATION',
@@ -1563,6 +1698,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181693',
           code: 'EXERCISE YARD',
           active: false,
           label: 'EXERCISE YARD',
@@ -1571,6 +1707,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181695',
           code: 'GATE',
           active: false,
           label: 'GATE',
@@ -1579,6 +1716,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181696',
           code: 'GYM',
           active: false,
           label: 'GYM',
@@ -1587,6 +1725,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181697',
           code: 'HEALTH CARE CENTRE',
           active: false,
           label: 'HEALTH CARE CENTRE',
@@ -1595,6 +1734,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181700',
           code: 'KITCHEN',
           active: false,
           label: 'KITCHEN',
@@ -1603,6 +1743,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181702',
           code: 'OFFICE',
           active: false,
           label: 'OFFICE',
@@ -1611,6 +1752,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181704',
           code: 'RECEPTION',
           active: false,
           label: 'RECEPTION',
@@ -1619,6 +1761,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181705',
           code: 'RECESS',
           active: false,
           label: 'RECESS',
@@ -1627,6 +1770,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181706',
           code: 'SEGREGATION UNIT',
           active: false,
           label: 'SEGREGATION UNIT',
@@ -1635,6 +1779,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181708',
           code: 'SPECIAL UNIT',
           active: false,
           label: 'SPECIAL UNIT',
@@ -1643,6 +1788,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181707',
           code: 'SHOWERS/CHANGING ROOM',
           active: false,
           label: 'SHOWERS/CHANGING ROOM',
@@ -1651,6 +1797,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181711',
           code: 'VISITS',
           active: false,
           label: 'VISITS',
@@ -1659,6 +1806,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181713',
           code: 'WING',
           active: false,
           label: 'WING',
@@ -1667,6 +1815,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181715',
           code: 'WORKS DEPARTMENT',
           active: false,
           label: 'WORKS DEPARTMENT',
@@ -1675,6 +1824,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181716',
           code: 'WORKSHOP',
           active: false,
           label: 'WORKSHOP',
@@ -1683,6 +1833,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181714',
           code: 'WITHIN PERIMETER',
           active: false,
           label: 'WITHIN PERIMETER',
@@ -1691,6 +1842,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181692',
           code: 'ELSEWHERE',
           active: false,
           label: 'ELSEWHERE',
@@ -1699,6 +1851,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181694',
           code: 'FUNERAL',
           active: false,
           label: 'FUNERAL',
@@ -1707,6 +1860,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181698',
           code: 'HOSPITAL OUTSIDE (PATIENT)',
           active: false,
           label: 'HOSPITAL OUTSIDE (PATIENT)',
@@ -1715,6 +1869,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181699',
           code: 'HOSPITAL OUTSIDE (VISITING)',
           active: false,
           label: 'HOSPITAL OUTSIDE (VISITING)',
@@ -1723,6 +1878,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181703',
           code: 'OUTSIDE WORKING PARTY',
           active: false,
           label: 'OUTSIDE WORKING PARTY',
@@ -1731,6 +1887,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181709',
           code: 'SPORTS FIELD',
           active: false,
           label: 'SPORTS FIELD',
@@ -1739,6 +1896,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181710',
           code: 'VEHICLE',
           active: false,
           label: 'VEHICLE',
@@ -1747,6 +1905,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181712',
           code: 'WEDDINGS',
           active: false,
           label: 'WEDDINGS',
@@ -1755,6 +1914,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181701',
           code: 'MAGISTRATES COURT',
           active: false,
           label: 'MAGISTRATES COURT',
@@ -1763,6 +1923,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44596',
         },
         {
+          id: '181688',
           code: 'CROWN COURT',
           active: false,
           label: 'CROWN COURT',
@@ -1780,6 +1941,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181799',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1788,6 +1950,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44580',
         },
         {
+          id: '181798',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1805,6 +1968,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181921',
           code: 'LOCAL',
           active: false,
           label: 'LOCAL',
@@ -1813,6 +1977,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45163',
         },
         {
+          id: '181920',
           code: 'SERVICE SUPPLIER',
           active: false,
           label: 'SERVICE SUPPLIER',
@@ -1830,6 +1995,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181923',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1838,6 +2004,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44892',
         },
         {
+          id: '181922',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1855,6 +2022,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182044',
           code: 'ENTER TIME',
           active: false,
           label: 'ENTER TIME',
@@ -1872,6 +2040,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182338',
           code: 'MINOR',
           active: false,
           label: 'MINOR',
@@ -1880,6 +2049,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44150',
         },
         {
+          id: '182339',
           code: 'SERIOUS',
           active: false,
           label: 'SERIOUS',
@@ -1888,6 +2058,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44150',
         },
         {
+          id: '182337',
           code: 'EXTENSIVE',
           active: false,
           label: 'EXTENSIVE',
@@ -1905,6 +2076,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182461',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -1913,6 +2085,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44985',
         },
         {
+          id: '182462',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -1930,6 +2103,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182463',
           code: 'ACTIVE',
           active: false,
           label: 'ACTIVE',
@@ -1938,6 +2112,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44780',
         },
         {
+          id: '182464',
           code: 'PASSIVE',
           active: false,
           label: 'PASSIVE',
@@ -1955,6 +2130,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182583',
           code: 'FRACTURE',
           active: false,
           label: 'FRACTURE',
@@ -1963,6 +2139,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182585',
           code: 'SCALD OR BURN',
           active: false,
           label: 'SCALD OR BURN',
@@ -1971,6 +2148,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182586',
           code: 'STABBING',
           active: false,
           label: 'STABBING',
@@ -1979,6 +2157,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182580',
           code: 'CRUSHING',
           active: false,
           label: 'CRUSHING',
@@ -1987,6 +2166,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182582',
           code: 'EXTENSIVE/MULTIPLE BRUISING',
           active: false,
           label: 'EXTENSIVE/MULTIPLE BRUISING',
@@ -1995,6 +2175,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182577',
           code: 'BLACK EYE',
           active: false,
           label: 'BLACK EYE',
@@ -2003,6 +2184,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182578',
           code: 'BROKEN NOSE',
           active: false,
           label: 'BROKEN NOSE',
@@ -2011,6 +2193,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182579',
           code: 'BROKEN TEETH',
           active: false,
           label: 'BROKEN TEETH',
@@ -2019,6 +2202,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182581',
           code: 'CUTS REQUIRING SUTURES',
           active: false,
           label: 'CUTS REQUIRING SUTURES',
@@ -2027,6 +2211,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182576',
           code: 'BITES',
           active: false,
           label: 'BITES',
@@ -2035,6 +2220,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182584',
           code: 'GUN SHOT WOUND',
           active: false,
           label: 'GUN SHOT WOUND',
@@ -2043,6 +2229,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45175',
         },
         {
+          id: '182587',
           code: 'TEMPORARY/PERMANENT BLINDNESS',
           active: false,
           label: 'TEMPORARY/PERMANENT BLINDNESS',
@@ -2060,6 +2247,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182605',
           code: 'TELEPHONY',
           active: false,
           label: 'TELEPHONY',
@@ -2068,6 +2256,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '45028',
         },
         {
+          id: '182604',
           code: 'IT',
           active: false,
           label: 'IT',
@@ -2085,6 +2274,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182643',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -2093,6 +2283,7 @@ const OLD_ROOF_CLIMB: IncidentTypeConfiguration = {
           nextQuestionId: '44394',
         },
         {
+          id: '182644',
           code: 'NO',
           active: false,
           label: 'NO',

--- a/server/reportConfiguration/types/OLD_TEMPORARY_RELEASE_FAILURE.ts
+++ b/server/reportConfiguration/types/OLD_TEMPORARY_RELEASE_FAILURE.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:09.101Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:35.273Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179344',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44772',
         },
         {
+          id: '179345',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179358',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -48,6 +51,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44694',
         },
         {
+          id: '179359',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -65,6 +69,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179663',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -73,6 +78,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44893',
         },
         {
+          id: '179662',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -90,6 +96,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179679',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -98,6 +105,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44934',
         },
         {
+          id: '179680',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -115,6 +123,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179705',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -123,6 +132,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179704',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -140,6 +150,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180013',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -148,6 +159,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44736',
         },
         {
+          id: '180012',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -165,6 +177,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180607',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -173,6 +186,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '180606',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -190,6 +204,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180902',
           code: 'MURDER/ATTEMPTED MURDER',
           active: true,
           label: 'MURDER/ATTEMPTED MURDER',
@@ -198,6 +213,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180901',
           code: 'MANSLAUGHTER',
           active: true,
           label: 'MANSLAUGHTER',
@@ -206,6 +222,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180898',
           code: 'ASSAULT',
           active: true,
           label: 'ASSAULT',
@@ -214,6 +231,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180906',
           code: 'RAPE/ATTEMPTED RAPE',
           active: true,
           label: 'RAPE/ATTEMPTED RAPE',
@@ -222,6 +240,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180904',
           code: 'OTHER SEXUAL OFFENCE',
           active: true,
           label: 'OTHER SEXUAL OFFENCE',
@@ -230,6 +249,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180908',
           code: 'THEFT',
           active: true,
           label: 'THEFT',
@@ -238,6 +258,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180907',
           code: 'ROBBERY',
           active: true,
           label: 'ROBBERY',
@@ -246,6 +267,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180900',
           code: 'FIREARM OFFENCE',
           active: true,
           label: 'FIREARM OFFENCE',
@@ -254,6 +276,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180899',
           code: 'DRUG OFFENCE',
           active: true,
           label: 'DRUG OFFENCE',
@@ -262,6 +285,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180909',
           code: 'VEHICLE CRIME',
           active: true,
           label: 'VEHICLE CRIME',
@@ -270,6 +294,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180905',
           code: 'PUBLIC ORDER OFFENCE',
           active: true,
           label: 'PUBLIC ORDER OFFENCE',
@@ -278,6 +303,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '180903',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -295,6 +321,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181072',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -303,6 +330,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44942',
         },
         {
+          id: '181071',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -320,6 +348,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181162',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -328,6 +357,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44266',
         },
         {
+          id: '181163',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -345,6 +375,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181315',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -353,6 +384,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44997',
         },
         {
+          id: '181316',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -370,6 +402,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181534',
           code: 'YES',
           active: false,
           label: 'YES',
@@ -378,6 +411,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44345',
         },
         {
+          id: '181535',
           code: 'NO',
           active: false,
           label: 'NO',
@@ -395,6 +429,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181561',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -403,6 +438,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44926',
         },
         {
+          id: '181560',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -420,6 +456,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181683',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -428,6 +465,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44459',
         },
         {
+          id: '181682',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -445,6 +483,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181735',
           code: 'MURDER/ATTEMPTED MURDER',
           active: true,
           label: 'MURDER/ATTEMPTED MURDER',
@@ -453,6 +492,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181734',
           code: 'MANSLAUGHTER',
           active: true,
           label: 'MANSLAUGHTER',
@@ -461,6 +501,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181731',
           code: 'ASSAULT',
           active: true,
           label: 'ASSAULT',
@@ -469,6 +510,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181739',
           code: 'RAPE/ATTEMPTED RAPE',
           active: true,
           label: 'RAPE/ATTEMPTED RAPE',
@@ -477,6 +519,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181737',
           code: 'OTHER SEXUAL OFFENCE',
           active: true,
           label: 'OTHER SEXUAL OFFENCE',
@@ -485,6 +528,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181741',
           code: 'THEFT',
           active: true,
           label: 'THEFT',
@@ -493,6 +537,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181740',
           code: 'ROBBERY',
           active: true,
           label: 'ROBBERY',
@@ -501,6 +546,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181733',
           code: 'FIREARM OFFENCE',
           active: true,
           label: 'FIREARM OFFENCE',
@@ -509,6 +555,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181732',
           code: 'DRUG OFFENCE',
           active: true,
           label: 'DRUG OFFENCE',
@@ -517,6 +564,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181742',
           code: 'VEHICLE CRIME',
           active: true,
           label: 'VEHICLE CRIME',
@@ -525,6 +573,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181738',
           code: 'PUBLIC ORDER OFFENCE',
           active: true,
           label: 'PUBLIC ORDER OFFENCE',
@@ -533,6 +582,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44602',
         },
         {
+          id: '181736',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -550,6 +600,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181764',
           code: 'COMPASSIONATE',
           active: true,
           label: 'COMPASSIONATE',
@@ -558,6 +609,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '45081',
         },
         {
+          id: '181765',
           code: 'FACILITY',
           active: true,
           label: 'FACILITY',
@@ -566,6 +618,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '45081',
         },
         {
+          id: '181766',
           code: 'RESETTLEMENT',
           active: true,
           label: 'RESETTLEMENT',
@@ -574,6 +627,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '45081',
         },
         {
+          id: '181763',
           code: 'COMMUNITY VISIT',
           active: true,
           label: 'COMMUNITY VISIT',
@@ -591,6 +645,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181950',
           code: 'POLICE ARREST',
           active: true,
           label: 'POLICE ARREST',
@@ -599,6 +654,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44259',
         },
         {
+          id: '181951',
           code: 'PRISON STAFF ARREST',
           active: true,
           label: 'PRISON STAFF ARREST',
@@ -607,6 +663,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44259',
         },
         {
+          id: '181952',
           code: 'SURRENDER',
           active: true,
           label: 'SURRENDER',
@@ -615,6 +672,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44259',
         },
         {
+          id: '181949',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -632,6 +690,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182285',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -640,6 +699,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '44826',
         },
         {
+          id: '182284',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -657,6 +717,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182600',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -665,6 +726,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182599',
           code: 'NO',
           active: true,
           label: 'NO',

--- a/server/reportConfiguration/types/OLD_TEMPORARY_RELEASE_FAILURE1.ts
+++ b/server/reportConfiguration/types/OLD_TEMPORARY_RELEASE_FAILURE1.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:09.907Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:36.088Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195150',
           code: 'Resettlement Day',
           active: false,
           label: 'Resettlement Day',
@@ -23,6 +24,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49309',
         },
         {
+          id: '195151',
           code: 'Resettlement Overnight',
           active: false,
           label: 'Resettlement Overnight',
@@ -31,6 +33,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49309',
         },
         {
+          id: '195152',
           code: 'Childcare Resettlement',
           active: false,
           label: 'Childcare Resettlement',
@@ -39,6 +42,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49309',
         },
         {
+          id: '195153',
           code: 'Special Purpose',
           active: false,
           label: 'Special Purpose',
@@ -56,6 +60,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195154',
           code: 'Court / Legal / Police',
           active: false,
           label: 'Court / Legal / Police',
@@ -64,6 +69,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49310',
         },
         {
+          id: '195155',
           code: 'CRL',
           active: false,
           label: 'CRL',
@@ -72,6 +78,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49310',
         },
         {
+          id: '195156',
           code: 'Funeral / Visiting A Dying Relative',
           active: false,
           label: 'Funeral / Visiting A Dying Relative',
@@ -80,6 +87,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49310',
         },
         {
+          id: '195157',
           code: 'Maintaining Family Ties',
           active: false,
           label: 'Maintaining Family Ties',
@@ -88,6 +96,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49310',
         },
         {
+          id: '195158',
           code: 'Other Compassionate Reason',
           active: false,
           label: 'Other Compassionate Reason',
@@ -96,6 +105,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49310',
         },
         {
+          id: '195159',
           code: 'Other RDR Linked to Sentence Plan',
           active: false,
           label: 'Other RDR Linked to Sentence Plan',
@@ -104,6 +114,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49310',
         },
         {
+          id: '195160',
           code: 'Outside Prison Activity (OPA)',
           active: false,
           label: 'Outside Prison Activity (OPA)',
@@ -112,6 +123,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49310',
         },
         {
+          id: '195161',
           code: 'Resettlement Overnight Release (ROR)',
           active: false,
           label: 'Resettlement Overnight Release (ROR)',
@@ -120,6 +132,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49310',
         },
         {
+          id: '195162',
           code: 'Training Or Education',
           active: false,
           label: 'Training Or Education',
@@ -137,6 +150,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195163',
           code: 'Yes (Enter Date)',
           active: false,
           label: 'Yes (Enter Date)',
@@ -145,6 +159,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49311',
         },
         {
+          id: '195164',
           code: 'No',
           active: false,
           label: 'No',
@@ -162,6 +177,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195165',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -170,6 +186,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49312',
         },
         {
+          id: '195166',
           code: 'No',
           active: false,
           label: 'No',
@@ -187,6 +204,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195167',
           code: 'Yes - Local Only',
           active: false,
           label: 'Yes - Local Only',
@@ -195,6 +213,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49313',
         },
         {
+          id: '195168',
           code: 'Yes - DDC Commissioned',
           active: false,
           label: 'Yes - DDC Commissioned',
@@ -203,6 +222,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49313',
         },
         {
+          id: '195169',
           code: 'Yes - SFO Investigation',
           active: false,
           label: 'Yes - SFO Investigation',
@@ -211,6 +231,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49313',
         },
         {
+          id: '195170',
           code: 'No (Enter Reasons)',
           active: false,
           label: 'No (Enter Reasons)',
@@ -228,6 +249,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195171',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -236,6 +258,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49314',
         },
         {
+          id: '195172',
           code: 'No',
           active: false,
           label: 'No',
@@ -253,6 +276,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195173',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -261,6 +285,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49315',
         },
         {
+          id: '195174',
           code: 'No',
           active: false,
           label: 'No',
@@ -278,6 +303,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195175',
           code: 'Yes (Enter Date)',
           active: false,
           label: 'Yes (Enter Date)',
@@ -286,6 +312,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49316',
         },
         {
+          id: '195176',
           code: 'No (Enter Reason)',
           active: false,
           label: 'No (Enter Reason)',
@@ -303,6 +330,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195177',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -311,6 +339,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49317',
         },
         {
+          id: '195178',
           code: 'No',
           active: false,
           label: 'No',
@@ -328,6 +357,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195179',
           code: 'Yes (Enter Date)',
           active: false,
           label: 'Yes (Enter Date)',
@@ -336,6 +366,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49318',
         },
         {
+          id: '195180',
           code: 'No (Enter Reason)',
           active: false,
           label: 'No (Enter Reason)',
@@ -353,6 +384,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195181',
           code: 'Yes (Enter Date)',
           active: false,
           label: 'Yes (Enter Date)',
@@ -361,6 +393,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49319',
         },
         {
+          id: '195182',
           code: 'No (Enter Reasons)',
           active: false,
           label: 'No (Enter Reasons)',
@@ -378,6 +411,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195183',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -386,6 +420,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49320',
         },
         {
+          id: '195184',
           code: 'No',
           active: false,
           label: 'No',
@@ -404,6 +439,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195185',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -412,6 +448,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49321',
         },
         {
+          id: '195186',
           code: 'No (Enter Reasons)',
           active: false,
           label: 'No (Enter Reasons)',
@@ -429,6 +466,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195187',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -437,6 +475,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49322',
         },
         {
+          id: '195188',
           code: 'No',
           active: false,
           label: 'No',
@@ -454,6 +493,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195189',
           code: 'Yes (Enter Date)',
           active: false,
           label: 'Yes (Enter Date)',
@@ -462,6 +502,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49323',
         },
         {
+          id: '195190',
           code: 'No',
           active: false,
           label: 'No',
@@ -479,6 +520,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195191',
           code: 'Surrender To HMPS',
           active: false,
           label: 'Surrender To HMPS',
@@ -487,6 +529,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49324',
         },
         {
+          id: '195192',
           code: 'Surrender To Police',
           active: false,
           label: 'Surrender To Police',
@@ -495,6 +538,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49324',
         },
         {
+          id: '195193',
           code: 'Arrest By HMPS',
           active: false,
           label: 'Arrest By HMPS',
@@ -503,6 +547,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49324',
         },
         {
+          id: '195194',
           code: 'Arrest By Police',
           active: false,
           label: 'Arrest By Police',
@@ -511,6 +556,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49324',
         },
         {
+          id: '195195',
           code: 'Other (Provide Details)',
           active: false,
           label: 'Other (Provide Details)',
@@ -529,6 +575,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195196',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -537,6 +584,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49325',
         },
         {
+          id: '195197',
           code: 'No',
           active: false,
           label: 'No',
@@ -554,6 +602,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195198',
           code: 'Alcohol',
           active: false,
           label: 'Alcohol',
@@ -562,6 +611,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49326',
         },
         {
+          id: '195199',
           code: 'Gambling',
           active: false,
           label: 'Gambling',
@@ -570,6 +620,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49326',
         },
         {
+          id: '195200',
           code: 'Drugs',
           active: false,
           label: 'Drugs',
@@ -578,6 +629,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49326',
         },
         {
+          id: '195201',
           code: 'Location',
           active: false,
           label: 'Location',
@@ -586,6 +638,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49326',
         },
         {
+          id: '195202',
           code: 'Social Media',
           active: false,
           label: 'Social Media',
@@ -594,6 +647,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49326',
         },
         {
+          id: '195203',
           code: 'Bad Behaviour',
           active: false,
           label: 'Bad Behaviour',
@@ -602,6 +656,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49326',
         },
         {
+          id: '195204',
           code: 'Media Contact',
           active: false,
           label: 'Media Contact',
@@ -610,6 +665,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49326',
         },
         {
+          id: '195205',
           code: 'Other (Provide Details)',
           active: false,
           label: 'Other (Provide Details)',
@@ -627,6 +683,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195223',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -635,6 +692,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49327',
         },
         {
+          id: '195224',
           code: 'No',
           active: false,
           label: 'No',
@@ -652,6 +710,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195225',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -660,6 +719,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49328',
         },
         {
+          id: '195226',
           code: 'No',
           active: false,
           label: 'No',
@@ -668,6 +728,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49328',
         },
         {
+          id: '195227',
           code: 'No',
           active: false,
           label: 'No',
@@ -685,6 +746,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195228',
           code: 'Violence Against The Person',
           active: false,
           label: 'Violence Against The Person',
@@ -693,6 +755,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49331',
         },
         {
+          id: '195229',
           code: 'Sexual Offences',
           active: false,
           label: 'Sexual Offences',
@@ -701,6 +764,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49331',
         },
         {
+          id: '195230',
           code: 'Robbery',
           active: false,
           label: 'Robbery',
@@ -709,6 +773,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49331',
         },
         {
+          id: '195231',
           code: 'Burglary',
           active: false,
           label: 'Burglary',
@@ -717,6 +782,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49331',
         },
         {
+          id: '195232',
           code: 'Theft And Handling',
           active: false,
           label: 'Theft And Handling',
@@ -725,6 +791,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49331',
         },
         {
+          id: '195233',
           code: 'Fraud And Forgery',
           active: false,
           label: 'Fraud And Forgery',
@@ -733,6 +800,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49331',
         },
         {
+          id: '195234',
           code: 'Drug Offences',
           active: false,
           label: 'Drug Offences',
@@ -741,6 +809,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49331',
         },
         {
+          id: '195235',
           code: 'Motoring Offences',
           active: false,
           label: 'Motoring Offences',
@@ -749,6 +818,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49331',
         },
         {
+          id: '195236',
           code: 'Failure To Return From ROTL',
           active: false,
           label: 'Failure To Return From ROTL',
@@ -757,6 +827,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49331',
         },
         {
+          id: '195237',
           code: 'Other Offence',
           active: false,
           label: 'Other Offence',
@@ -774,6 +845,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195249',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -782,6 +854,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49334',
         },
         {
+          id: '195250',
           code: 'No',
           active: false,
           label: 'No',
@@ -799,6 +872,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '195238',
           code: 'Violence Against The Person',
           active: false,
           label: 'Violence Against The Person',
@@ -807,6 +881,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49335',
         },
         {
+          id: '195239',
           code: 'Sexual Offences',
           active: false,
           label: 'Sexual Offences',
@@ -815,6 +890,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49335',
         },
         {
+          id: '195240',
           code: 'Robbery',
           active: false,
           label: 'Robbery',
@@ -823,6 +899,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49335',
         },
         {
+          id: '195241',
           code: 'Burglary',
           active: false,
           label: 'Burglary',
@@ -831,6 +908,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49335',
         },
         {
+          id: '195242',
           code: 'Theft And Handling',
           active: false,
           label: 'Theft And Handling',
@@ -839,6 +917,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49335',
         },
         {
+          id: '195243',
           code: 'Fraud And Forgery',
           active: false,
           label: 'Fraud And Forgery',
@@ -847,6 +926,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49335',
         },
         {
+          id: '195244',
           code: 'Drug Offences',
           active: false,
           label: 'Drug Offences',
@@ -855,6 +935,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49335',
         },
         {
+          id: '195245',
           code: 'Motoring Offences',
           active: false,
           label: 'Motoring Offences',
@@ -863,6 +944,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49335',
         },
         {
+          id: '195246',
           code: 'Failure To Return From ROTL',
           active: false,
           label: 'Failure To Return From ROTL',
@@ -871,6 +953,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
           nextQuestionId: '49335',
         },
         {
+          id: '195247',
           code: 'Other Offence',
           active: false,
           label: 'Other Offence',
@@ -889,6 +972,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE1: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '195248',
           code: 'Yes (Date)',
           active: false,
           label: 'Yes (Date)',

--- a/server/reportConfiguration/types/OLD_TEMPORARY_RELEASE_FAILURE2.ts
+++ b/server/reportConfiguration/types/OLD_TEMPORARY_RELEASE_FAILURE2.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:10.700Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:36.915Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '206684',
           code: 'No further action',
           active: false,
           label: 'No further action',
@@ -23,6 +24,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55180',
         },
         {
+          id: '206685',
           code: 'IEP Regression',
           active: false,
           label: 'IEP Regression',
@@ -31,6 +33,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55180',
         },
         {
+          id: '206686',
           code: 'Placed on report/adjudication referal',
           active: false,
           label: 'Placed on report/adjudication referal',
@@ -39,6 +42,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55180',
         },
         {
+          id: '206687',
           code: 'Police referral',
           active: false,
           label: 'Police referral',
@@ -47,6 +51,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55180',
         },
         {
+          id: '206688',
           code: 'CPS referral',
           active: false,
           label: 'CPS referral',
@@ -55,6 +60,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55180',
         },
         {
+          id: '206689',
           code: 'Prosecution referral',
           active: false,
           label: 'Prosecution referral',
@@ -72,6 +78,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206690',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -80,6 +87,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55181',
         },
         {
+          id: '206691',
           code: 'No',
           active: false,
           label: 'No',
@@ -97,6 +105,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206692',
           code: 'Standard ROTL',
           active: false,
           label: 'Standard ROTL',
@@ -105,6 +114,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55182',
         },
         {
+          id: '206693',
           code: 'Restricted ROTL',
           active: false,
           label: 'Restricted ROTL',
@@ -122,6 +132,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206694',
           code: 'Resettlement Day',
           active: false,
           label: 'Resettlement Day',
@@ -130,6 +141,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55183',
         },
         {
+          id: '206695',
           code: 'Resettlement Overnight',
           active: false,
           label: 'Resettlement Overnight',
@@ -138,6 +150,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55183',
         },
         {
+          id: '206696',
           code: 'Childcare Resettlement',
           active: false,
           label: 'Childcare Resettlement',
@@ -146,6 +159,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55183',
         },
         {
+          id: '206697',
           code: 'Special Purpose (medical)',
           active: false,
           label: 'Special Purpose (medical)',
@@ -154,6 +168,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55183',
         },
         {
+          id: '206698',
           code: 'Special Purpose (other)',
           active: false,
           label: 'Special Purpose (other)',
@@ -171,6 +186,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206699',
           code: 'Court / Legal / Police',
           active: false,
           label: 'Court / Legal / Police',
@@ -179,6 +195,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55184',
         },
         {
+          id: '206700',
           code: 'Maintaining Family Ties',
           active: false,
           label: 'Maintaining Family Ties',
@@ -187,6 +204,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55184',
         },
         {
+          id: '206701',
           code: 'Other Compassionate Reason (emergency child care, attend funeral etc.)',
           active: false,
           label: 'Other Compassionate Reason (emergency child care, attend funeral etc.)',
@@ -195,6 +213,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55184',
         },
         {
+          id: '206702',
           code: 'Other RDR Linked to Sentence Plan',
           active: false,
           label: 'Other RDR Linked to Sentence Plan',
@@ -203,6 +222,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55184',
         },
         {
+          id: '206703',
           code: 'Training Or Education',
           active: false,
           label: 'Training Or Education',
@@ -211,6 +231,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55184',
         },
         {
+          id: '206704',
           code: 'Medical',
           active: false,
           label: 'Medical',
@@ -219,6 +240,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55184',
         },
         {
+          id: '206705',
           code: 'Paid and unpaid work placements',
           active: false,
           label: 'Paid and unpaid work placements',
@@ -227,6 +249,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55184',
         },
         {
+          id: '206706',
           code: 'Marriage or civil partnership of the offender',
           active: false,
           label: 'Marriage or civil partnership of the offender',
@@ -235,6 +258,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55184',
         },
         {
+          id: '206707',
           code: 'Inter-prison transfers',
           active: false,
           label: 'Inter-prison transfers',
@@ -252,6 +276,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206708',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -260,6 +285,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55185',
         },
         {
+          id: '206709',
           code: 'No',
           active: false,
           label: 'No',
@@ -277,6 +303,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206710',
           code: 'Apparent failure to return',
           active: false,
           label: 'Apparent failure to return',
@@ -285,6 +312,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55186',
         },
         {
+          id: '206711',
           code: "Revocation of the prisoner's licence",
           active: false,
           label: "Revocation of the prisoner's licence",
@@ -302,6 +330,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206712',
           code: 'Yes (Enter Date)',
           active: false,
           label: 'Yes (Enter Date)',
@@ -310,6 +339,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55187',
         },
         {
+          id: '206713',
           code: 'No',
           active: false,
           label: 'No',
@@ -327,6 +357,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206714',
           code: 'Surrendered before midnight on return date',
           active: false,
           label: 'Surrendered before midnight on return date',
@@ -335,6 +366,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55188',
         },
         {
+          id: '206715',
           code: 'Surrender To HMPS (after midnight on return date)',
           active: false,
           label: 'Surrender To HMPS (after midnight on return date)',
@@ -343,6 +375,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55188',
         },
         {
+          id: '206716',
           code: 'Surrender To Police  (after midnight on return date)',
           active: false,
           label: 'Surrender To Police  (after midnight on return date)',
@@ -351,6 +384,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55188',
         },
         {
+          id: '206717',
           code: 'Arrest By HMPS',
           active: false,
           label: 'Arrest By HMPS',
@@ -359,6 +393,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55188',
         },
         {
+          id: '206718',
           code: 'Arrest By Police',
           active: false,
           label: 'Arrest By Police',
@@ -367,6 +402,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55188',
         },
         {
+          id: '206719',
           code: 'Admitted to hospital for treatment',
           active: false,
           label: 'Admitted to hospital for treatment',
@@ -375,6 +411,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55188',
         },
         {
+          id: '206720',
           code: 'Deceased',
           active: false,
           label: 'Deceased',
@@ -383,6 +420,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55188',
         },
         {
+          id: '206721',
           code: 'Other (Provide Details)',
           active: false,
           label: 'Other (Provide Details)',
@@ -400,6 +438,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206722',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -408,6 +447,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55189',
         },
         {
+          id: '206723',
           code: 'No',
           active: false,
           label: 'No',
@@ -425,6 +465,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206724',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -433,6 +474,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55190',
         },
         {
+          id: '206725',
           code: 'No',
           active: false,
           label: 'No',
@@ -450,6 +492,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '206726',
           code: 'Violence Against The Person',
           active: false,
           label: 'Violence Against The Person',
@@ -458,6 +501,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55191',
         },
         {
+          id: '206727',
           code: 'Sexual Offences',
           active: false,
           label: 'Sexual Offences',
@@ -466,6 +510,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55191',
         },
         {
+          id: '206728',
           code: 'Robbery',
           active: false,
           label: 'Robbery',
@@ -474,6 +519,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55191',
         },
         {
+          id: '206729',
           code: 'Burglary',
           active: false,
           label: 'Burglary',
@@ -482,6 +528,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55191',
         },
         {
+          id: '206730',
           code: 'Theft And Handling',
           active: false,
           label: 'Theft And Handling',
@@ -490,6 +537,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55191',
         },
         {
+          id: '206731',
           code: 'Fraud And Forgery',
           active: false,
           label: 'Fraud And Forgery',
@@ -498,6 +546,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55191',
         },
         {
+          id: '206732',
           code: 'Drug Offences',
           active: false,
           label: 'Drug Offences',
@@ -506,6 +555,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55191',
         },
         {
+          id: '206733',
           code: 'Motoring Offences',
           active: false,
           label: 'Motoring Offences',
@@ -514,6 +564,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55191',
         },
         {
+          id: '206734',
           code: 'Failure To Return From ROTL',
           active: false,
           label: 'Failure To Return From ROTL',
@@ -522,6 +573,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55191',
         },
         {
+          id: '206735',
           code: 'Other Offence',
           active: false,
           label: 'Other Offence',
@@ -539,6 +591,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206736',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -547,6 +600,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55192',
         },
         {
+          id: '206737',
           code: 'No',
           active: false,
           label: 'No',
@@ -564,6 +618,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '206738',
           code: 'Violence Against The Person',
           active: false,
           label: 'Violence Against The Person',
@@ -572,6 +627,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55193',
         },
         {
+          id: '206739',
           code: 'Sexual Offences',
           active: false,
           label: 'Sexual Offences',
@@ -580,6 +636,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55193',
         },
         {
+          id: '206740',
           code: 'Robbery',
           active: false,
           label: 'Robbery',
@@ -588,6 +645,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55193',
         },
         {
+          id: '206741',
           code: 'Burglary',
           active: false,
           label: 'Burglary',
@@ -596,6 +654,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55193',
         },
         {
+          id: '206742',
           code: 'Theft And Handling',
           active: false,
           label: 'Theft And Handling',
@@ -604,6 +663,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55193',
         },
         {
+          id: '206743',
           code: 'Fraud And Forgery',
           active: false,
           label: 'Fraud And Forgery',
@@ -612,6 +672,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55193',
         },
         {
+          id: '206744',
           code: 'Drug Offences',
           active: false,
           label: 'Drug Offences',
@@ -620,6 +681,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55193',
         },
         {
+          id: '206745',
           code: 'Motoring Offences',
           active: false,
           label: 'Motoring Offences',
@@ -628,6 +690,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55193',
         },
         {
+          id: '206746',
           code: 'Failure To Return From ROTL',
           active: false,
           label: 'Failure To Return From ROTL',
@@ -636,6 +699,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55193',
         },
         {
+          id: '206747',
           code: 'Other Offence',
           active: false,
           label: 'Other Offence',
@@ -653,6 +717,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206748',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -661,6 +726,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55194',
         },
         {
+          id: '206749',
           code: 'No',
           active: false,
           label: 'No',
@@ -678,6 +744,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '206750',
           code: 'Location',
           active: false,
           label: 'Location',
@@ -686,6 +753,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55195',
         },
         {
+          id: '206751',
           code: 'Alcohol/drugs (under influence)',
           active: false,
           label: 'Alcohol/drugs (under influence)',
@@ -694,6 +762,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55195',
         },
         {
+          id: '206752',
           code: 'Gambling',
           active: false,
           label: 'Gambling',
@@ -702,6 +771,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55195',
         },
         {
+          id: '206753',
           code: 'Finds (fill in separate report)',
           active: false,
           label: 'Finds (fill in separate report)',
@@ -710,6 +780,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55195',
         },
         {
+          id: '206754',
           code: 'Social Media',
           active: false,
           label: 'Social Media',
@@ -718,6 +789,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55195',
         },
         {
+          id: '206755',
           code: 'Bad Behaviour',
           active: false,
           label: 'Bad Behaviour',
@@ -726,6 +798,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55195',
         },
         {
+          id: '206756',
           code: 'Media Contact',
           active: false,
           label: 'Media Contact',
@@ -734,6 +807,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55195',
         },
         {
+          id: '206757',
           code: 'Other (Provide Details)',
           active: false,
           label: 'Other (Provide Details)',
@@ -751,6 +825,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206758',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -759,6 +834,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55196',
         },
         {
+          id: '206759',
           code: 'No',
           active: false,
           label: 'No',
@@ -777,6 +853,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206760',
           code: 'Yes (Enter Date)',
           active: false,
           label: 'Yes (Enter Date)',
@@ -785,6 +862,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55197',
         },
         {
+          id: '206761',
           code: 'No (Enter Reason)',
           active: false,
           label: 'No (Enter Reason)',
@@ -802,6 +880,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206762',
           code: 'Yes (Enter Date)',
           active: false,
           label: 'Yes (Enter Date)',
@@ -810,6 +889,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: '55198',
         },
         {
+          id: '206763',
           code: 'No (Enter Reason)',
           active: false,
           label: 'No (Enter Reason)',
@@ -827,6 +907,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '206764',
           code: 'Yes (Enter Date)',
           active: false,
           label: 'Yes (Enter Date)',
@@ -835,6 +916,7 @@ const OLD_TEMPORARY_RELEASE_FAILURE2: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '206765',
           code: 'No (Enter Reasons)',
           active: false,
           label: 'No (Enter Reasons)',

--- a/server/reportConfiguration/types/RADIO_COMPROMISE.ts
+++ b/server/reportConfiguration/types/RADIO_COMPROMISE.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:18.967Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:45.827Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178897',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -23,6 +24,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44811',
         },
         {
+          id: '178896',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -40,6 +42,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '178928',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -48,6 +51,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '45123',
         },
         {
+          id: '178929',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -65,6 +69,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179072',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -73,6 +78,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44916',
         },
         {
+          id: '179071',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -90,6 +96,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179097',
           code: 'MALICIOUS',
           active: true,
           label: 'MALICIOUS',
@@ -98,6 +105,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '179098',
           code: 'UNINTENTIONAL',
           active: true,
           label: 'UNINTENTIONAL',
@@ -115,6 +123,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179328',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -123,6 +132,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44282',
         },
         {
+          id: '179327',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -140,6 +150,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179403',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -148,6 +159,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44618',
         },
         {
+          id: '179402',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -165,6 +177,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179991',
           code: 'INTERFERENCE',
           active: true,
           label: 'INTERFERENCE',
@@ -173,6 +186,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44648',
         },
         {
+          id: '179992',
           code: 'NET JAM',
           active: true,
           label: 'NET JAM',
@@ -181,6 +195,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44648',
         },
         {
+          id: '179993',
           code: 'MISSING RADIO',
           active: true,
           label: 'MISSING RADIO',
@@ -198,6 +213,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180653',
           code: 'FULL SEARCH',
           active: true,
           label: 'FULL SEARCH',
@@ -206,6 +222,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44132',
         },
         {
+          id: '180654',
           code: 'PARTIAL SEARCH',
           active: true,
           label: 'PARTIAL SEARCH',
@@ -223,6 +240,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180744',
           code: 'INTERNAL',
           active: true,
           label: 'INTERNAL',
@@ -231,6 +249,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44184',
         },
         {
+          id: '180743',
           code: 'EXTERNAL',
           active: true,
           label: 'EXTERNAL',
@@ -239,6 +258,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44184',
         },
         {
+          id: '180745',
           code: 'NOT KNOWN',
           active: true,
           label: 'NOT KNOWN',
@@ -256,6 +276,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180985',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -264,6 +285,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44252',
         },
         {
+          id: '180984',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -281,6 +303,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181256',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -289,6 +312,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44173',
         },
         {
+          id: '181255',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -306,6 +330,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181261',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -314,6 +339,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44125',
         },
         {
+          id: '181260',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -331,6 +357,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181262',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -339,6 +366,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44801',
         },
         {
+          id: '181263',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -356,6 +384,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181284',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -364,6 +393,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44799',
         },
         {
+          id: '181283',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -381,6 +411,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181355',
           code: 'LOST',
           active: true,
           label: 'LOST',
@@ -389,6 +420,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44856',
         },
         {
+          id: '181356',
           code: 'MISLAID',
           active: true,
           label: 'MISLAID',
@@ -397,6 +429,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44856',
         },
         {
+          id: '181357',
           code: 'STOLEN',
           active: true,
           label: 'STOLEN',
@@ -414,6 +447,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181415',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -422,6 +456,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44712',
         },
         {
+          id: '181414',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -439,6 +474,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181638',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -447,6 +483,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: '44453',
         },
         {
+          id: '181637',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -464,6 +501,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182450',
           code: 'PRISONER POSSESSION',
           active: true,
           label: 'PRISONER POSSESSION',
@@ -472,6 +510,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182446',
           code: 'CONCEALED',
           active: true,
           label: 'CONCEALED',
@@ -480,6 +519,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182447',
           code: 'DISCARDED',
           active: true,
           label: 'DISCARDED',
@@ -488,6 +528,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182448',
           code: 'MISLAID/LOST',
           active: true,
           label: 'MISLAID/LOST',
@@ -496,6 +537,7 @@ const RADIO_COMPROMISE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182449',
           code: 'OTHER',
           active: true,
           label: 'OTHER',

--- a/server/reportConfiguration/types/RELEASED_IN_ERROR.ts
+++ b/server/reportConfiguration/types/RELEASED_IN_ERROR.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:19.666Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:46.580Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182684',
           code: 'Bail',
           active: false,
           label: 'Bail',
@@ -23,6 +24,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182685',
           code: 'Final discharge/end of sentence',
           active: false,
           label: 'Final discharge/end of sentence',
@@ -31,6 +33,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182686',
           code: 'Police production',
           active: false,
           label: 'Police production',
@@ -39,6 +42,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182687',
           code: 'Court production/PEMS',
           active: false,
           label: 'Court production/PEMS',
@@ -47,6 +51,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182688',
           code: 'Escort - HMPS',
           active: false,
           label: 'Escort - HMPS',
@@ -55,6 +60,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182689',
           code: 'Other: Please explain',
           active: false,
           label: 'Other: Please explain',
@@ -63,6 +69,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183020',
           code: 'Bail',
           active: true,
           label: 'Bail',
@@ -71,6 +78,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45180',
         },
         {
+          id: '183021',
           code: 'Final discharge/end of sentence',
           active: true,
           label: 'Final discharge/end of sentence',
@@ -79,6 +87,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45180',
         },
         {
+          id: '183022',
           code: 'Police production',
           active: true,
           label: 'Police production',
@@ -87,6 +96,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45180',
         },
         {
+          id: '183023',
           code: 'Court production/PEMS',
           active: false,
           label: 'Court production/PEMS',
@@ -95,6 +105,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45180',
         },
         {
+          id: '183024',
           code: 'Escort – HMPS',
           active: true,
           label: 'Escort – HMPS',
@@ -103,6 +114,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45180',
         },
         {
+          id: '183025',
           code: 'Other : Please explain',
           active: true,
           label: 'Other : Please explain',
@@ -111,6 +123,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45180',
         },
         {
+          id: '184685',
           code: 'Court production/PEMS',
           active: true,
           label: 'Court production/PEMS',
@@ -128,6 +141,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182690',
           code: 'Establishment: Enter name',
           active: false,
           label: 'Establishment: Enter name',
@@ -136,6 +150,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182691',
           code: 'Court: Enter name',
           active: false,
           label: 'Court: Enter name',
@@ -144,6 +159,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182692',
           code: 'Other: Please enter details',
           active: false,
           label: 'Other: Please enter details',
@@ -152,6 +168,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183026',
           code: 'Establishment : Enter name',
           active: true,
           label: 'Establishment : Enter name',
@@ -160,6 +177,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45181',
         },
         {
+          id: '183027',
           code: 'Court : Enter name',
           active: true,
           label: 'Court : Enter name',
@@ -168,6 +186,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45181',
         },
         {
+          id: '183028',
           code: 'Other : Please enter details',
           active: true,
           label: 'Other : Please enter details',
@@ -185,6 +204,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182693',
           code: 'Wrong person released',
           active: false,
           label: 'Wrong person released',
@@ -193,6 +213,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182694',
           code: 'Sentence miscalculated',
           active: false,
           label: 'Sentence miscalculated',
@@ -201,6 +222,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182695',
           code: 'ADA not included in calculations',
           active: false,
           label: 'ADA not included in calculations',
@@ -209,6 +231,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182696',
           code: 'Immigration warrant not applied/misfiled/missing',
           active: false,
           label: 'Immigration warrant not applied/misfiled/missing',
@@ -217,6 +240,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182697',
           code: 'Remand warrant not applied/misfiled/missing',
           active: false,
           label: 'Remand warrant not applied/misfiled/missing',
@@ -225,6 +249,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182698',
           code: 'Imprisonment warrant not applied/misfiled/missing',
           active: false,
           label: 'Imprisonment warrant not applied/misfiled/missing',
@@ -233,6 +258,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182699',
           code: 'Civil/non payment of fines warrant not applied/misfiled/missing',
           active: false,
           label: 'Civil/non payment of fines warrant not applied/misfiled/missing',
@@ -241,6 +267,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182700',
           code: 'Bail conditions not fully met',
           active: false,
           label: 'Bail conditions not fully met',
@@ -249,6 +276,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182701',
           code: 'Release criteria not met',
           active: false,
           label: 'Release criteria not met',
@@ -257,6 +285,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182702',
           code: 'Recall procedures not applied',
           active: false,
           label: 'Recall procedures not applied',
@@ -265,6 +294,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182703',
           code: 'Other: Please explain',
           active: false,
           label: 'Other: Please explain',
@@ -273,6 +303,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183029',
           code: 'Wrong person released',
           active: true,
           label: 'Wrong person released',
@@ -281,6 +312,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45182',
         },
         {
+          id: '183030',
           code: 'Sentence Miscalculated',
           active: true,
           label: 'Sentence Miscalculated',
@@ -289,6 +321,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45182',
         },
         {
+          id: '183031',
           code: 'ADA not included on calculations',
           active: true,
           label: 'ADA not included on calculations',
@@ -297,6 +330,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45182',
         },
         {
+          id: '183032',
           code: 'Immigration warrant not applied/misfiled/missing',
           active: true,
           label: 'Immigration warrant not applied/misfiled/missing',
@@ -305,6 +339,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45182',
         },
         {
+          id: '183033',
           code: 'Remand warrant not applied/misfiled/missing',
           active: true,
           label: 'Remand warrant not applied/misfiled/missing',
@@ -313,6 +348,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45182',
         },
         {
+          id: '183034',
           code: 'Imprisonment warrant not applied/misfiled/missing',
           active: true,
           label: 'Imprisonment warrant not applied/misfiled/missing',
@@ -321,6 +357,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45182',
         },
         {
+          id: '183035',
           code: 'Civil/non payment of fines warrant not applied/misfiled/missing',
           active: true,
           label: 'Civil/non payment of fines warrant not applied/misfiled/missing',
@@ -329,6 +366,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45182',
         },
         {
+          id: '183036',
           code: 'Bail conditions not fully met',
           active: true,
           label: 'Bail conditions not fully met',
@@ -337,6 +375,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45182',
         },
         {
+          id: '183037',
           code: 'Release criteria not met',
           active: true,
           label: 'Release criteria not met',
@@ -345,6 +384,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45182',
         },
         {
+          id: '183038',
           code: 'Recall procedures not applied',
           active: true,
           label: 'Recall procedures not applied',
@@ -353,6 +393,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45182',
         },
         {
+          id: '183039',
           code: 'Other : Please explain',
           active: true,
           label: 'Other : Please explain',
@@ -370,6 +411,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182704',
           code: 'Recall procedures',
           active: false,
           label: 'Recall procedures',
@@ -378,6 +420,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182705',
           code: 'Home Probation Officer',
           active: false,
           label: 'Home Probation Officer',
@@ -386,6 +429,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182706',
           code: 'Prisoner contacted',
           active: false,
           label: 'Prisoner contacted',
@@ -394,6 +438,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182707',
           code: 'Court contacted',
           active: false,
           label: 'Court contacted',
@@ -402,6 +447,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182708',
           code: 'Police contacted',
           active: false,
           label: 'Police contacted',
@@ -410,6 +456,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182709',
           code: 'Other: Please explain',
           active: false,
           label: 'Other: Please explain',
@@ -418,6 +465,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182710',
           code: 'None - explain why none of the above procedures have been actioned',
           active: false,
           label: 'None - explain why none of the above procedures have been actioned',
@@ -426,6 +474,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183040',
           code: 'Recall procedures',
           active: true,
           label: 'Recall procedures',
@@ -434,6 +483,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45183',
         },
         {
+          id: '183041',
           code: 'Home Probation Officer',
           active: true,
           label: 'Home Probation Officer',
@@ -442,6 +492,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45183',
         },
         {
+          id: '183042',
           code: 'Prisoner contacted',
           active: true,
           label: 'Prisoner contacted',
@@ -450,6 +501,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45183',
         },
         {
+          id: '183043',
           code: 'Court contacted',
           active: true,
           label: 'Court contacted',
@@ -458,6 +510,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45183',
         },
         {
+          id: '183044',
           code: 'Police contacted',
           active: true,
           label: 'Police contacted',
@@ -466,6 +519,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45183',
         },
         {
+          id: '183045',
           code: 'Other : Please explain',
           active: true,
           label: 'Other : Please explain',
@@ -474,6 +528,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45183',
         },
         {
+          id: '183046',
           code: 'None - explain why none of the above procedures have been actioned',
           active: true,
           label: 'None - explain why none of the above procedures have been actioned',
@@ -491,6 +546,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182711',
           code: 'Contact from PEMS',
           active: false,
           label: 'Contact from PEMS',
@@ -499,6 +555,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182712',
           code: 'Contact from Courts',
           active: false,
           label: 'Contact from Courts',
@@ -507,6 +564,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182713',
           code: 'Contact from UKBA',
           active: false,
           label: 'Contact from UKBA',
@@ -515,6 +573,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182714',
           code: 'Contact from Police',
           active: false,
           label: 'Contact from Police',
@@ -523,6 +582,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182715',
           code: 'Post release check by Establishment',
           active: false,
           label: 'Post release check by Establishment',
@@ -531,6 +591,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182716',
           code: 'Contact from other agency: Please enter details',
           active: false,
           label: 'Contact from other agency: Please enter details',
@@ -539,6 +600,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182717',
           code: 'Sentence calculations',
           active: false,
           label: 'Sentence calculations',
@@ -547,6 +609,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182718',
           code: 'Other: Please explain',
           active: false,
           label: 'Other: Please explain',
@@ -555,6 +618,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183047',
           code: 'Contact from PEMS',
           active: false,
           label: 'Contact from PEMS',
@@ -563,6 +627,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45184',
         },
         {
+          id: '183048',
           code: 'Contact from courts',
           active: true,
           label: 'Contact from courts',
@@ -571,6 +636,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45184',
         },
         {
+          id: '183049',
           code: 'Contact from UKBA',
           active: true,
           label: 'Contact from UKBA',
@@ -579,6 +645,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45184',
         },
         {
+          id: '183050',
           code: 'Contact from police',
           active: true,
           label: 'Contact from police',
@@ -587,6 +654,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45184',
         },
         {
+          id: '183051',
           code: 'Post release check by Establishment',
           active: true,
           label: 'Post release check by Establishment',
@@ -595,6 +663,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45184',
         },
         {
+          id: '183052',
           code: 'Contact from other agency : Please enter details',
           active: true,
           label: 'Contact from other agency : Please enter details',
@@ -603,6 +672,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45184',
         },
         {
+          id: '183053',
           code: 'Sentence calculations (new receptions)',
           active: true,
           label: 'Sentence calculations (new receptions)',
@@ -611,6 +681,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45184',
         },
         {
+          id: '183054',
           code: 'Other: Please explain',
           active: true,
           label: 'Other: Please explain',
@@ -619,6 +690,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45184',
         },
         {
+          id: '184686',
           code: 'Contact from PEMS',
           active: true,
           label: 'Contact from PEMS',
@@ -636,6 +708,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182719',
           code: 'Date:',
           active: false,
           label: 'Date:',
@@ -644,6 +717,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183055',
           code: 'Date:',
           active: true,
           label: 'Date:',
@@ -661,6 +735,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182720',
           code: 'Enter details:',
           active: false,
           label: 'Enter details:',
@@ -669,6 +744,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183056',
           code: 'Enter details:',
           active: true,
           label: 'Enter details:',
@@ -686,6 +762,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182721',
           code: 'Sentenced prisoner',
           active: false,
           label: 'Sentenced prisoner',
@@ -694,6 +771,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182722',
           code: 'Remand prisoner',
           active: false,
           label: 'Remand prisoner',
@@ -702,6 +780,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182723',
           code: 'Immigration detainee',
           active: false,
           label: 'Immigration detainee',
@@ -710,6 +789,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182724',
           code: 'Recall prisoner',
           active: false,
           label: 'Recall prisoner',
@@ -718,6 +798,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182725',
           code: 'Civil prisoner',
           active: false,
           label: 'Civil prisoner',
@@ -726,6 +807,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183057',
           code: 'Sentenced prisoner',
           active: true,
           label: 'Sentenced prisoner',
@@ -734,6 +816,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45189',
         },
         {
+          id: '183058',
           code: 'Remand prisoner',
           active: true,
           label: 'Remand prisoner',
@@ -742,6 +825,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45189',
         },
         {
+          id: '183059',
           code: 'Immigration detainee',
           active: true,
           label: 'Immigration detainee',
@@ -750,6 +834,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45189',
         },
         {
+          id: '183060',
           code: 'Recall prisoner',
           active: true,
           label: 'Recall prisoner',
@@ -758,6 +843,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45189',
         },
         {
+          id: '183061',
           code: 'Civil prisoner',
           active: true,
           label: 'Civil prisoner',
@@ -775,6 +861,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182726',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -783,6 +870,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182727',
           code: 'Police Incident Number:',
           active: false,
           label: 'Police Incident Number:',
@@ -791,6 +879,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182728',
           code: 'No',
           active: false,
           label: 'No',
@@ -808,6 +897,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182729',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -816,6 +906,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182730',
           code: 'No',
           active: false,
           label: 'No',
@@ -824,6 +915,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182731',
           code: 'Incident Ref No:',
           active: false,
           label: 'Incident Ref No:',
@@ -832,6 +924,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183065',
           code: 'Yes: Date',
           active: true,
           label: 'Yes: Date',
@@ -840,6 +933,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45190',
         },
         {
+          id: '183066',
           code: 'Incident Ref No:',
           active: true,
           label: 'Incident Ref No:',
@@ -848,6 +942,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45190',
         },
         {
+          id: '183067',
           code: 'No',
           active: true,
           label: 'No',
@@ -865,6 +960,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182732',
           code: 'Yes: Date',
           active: false,
           label: 'Yes: Date',
@@ -873,6 +969,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182733',
           code: 'Police Incident Number:',
           active: false,
           label: 'Police Incident Number:',
@@ -881,6 +978,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182734',
           code: 'No',
           active: false,
           label: 'No',
@@ -889,6 +987,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183062',
           code: 'Yes: Date',
           active: true,
           label: 'Yes: Date',
@@ -897,6 +996,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45188',
         },
         {
+          id: '183063',
           code: 'Police Incident Number:',
           active: true,
           label: 'Police Incident Number:',
@@ -905,6 +1005,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45188',
         },
         {
+          id: '183064',
           code: 'No',
           active: true,
           label: 'No',
@@ -922,6 +1023,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182735',
           code: 'Yes',
           active: false,
           label: 'Yes',
@@ -930,6 +1032,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182736',
           code: 'No',
           active: false,
           label: 'No',
@@ -938,6 +1041,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182737',
           code: 'Other: Please enter details',
           active: false,
           label: 'Other: Please enter details',
@@ -946,6 +1050,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183068',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -954,6 +1059,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45191',
         },
         {
+          id: '183069',
           code: 'No',
           active: false,
           label: 'No',
@@ -962,6 +1068,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45191',
         },
         {
+          id: '183070',
           code: 'Other: Please enter details',
           active: true,
           label: 'Other: Please enter details',
@@ -970,6 +1077,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45191',
         },
         {
+          id: '184684',
           code: 'No',
           active: true,
           label: 'No',
@@ -987,6 +1095,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182738',
           code: 'Date:',
           active: false,
           label: 'Date:',
@@ -995,6 +1104,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183071',
           code: 'Date:',
           active: true,
           label: 'Date:',
@@ -1012,6 +1122,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182739',
           code: 'Yes: Please enter details of offence',
           active: false,
           label: 'Yes: Please enter details of offence',
@@ -1020,6 +1131,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182740',
           code: 'No',
           active: false,
           label: 'No',
@@ -1028,6 +1140,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183072',
           code: 'Yes: Please enter details of offence',
           active: true,
           label: 'Yes: Please enter details of offence',
@@ -1036,6 +1149,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: '45193',
         },
         {
+          id: '183073',
           code: 'No',
           active: true,
           label: 'No',
@@ -1053,6 +1167,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182741',
           code: 'Enter details:',
           active: false,
           label: 'Enter details:',
@@ -1061,6 +1176,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183074',
           code: 'Enter details:',
           active: true,
           label: 'Enter details:',
@@ -1078,6 +1194,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182742',
           code: 'Enter value',
           active: false,
           label: 'Enter value',
@@ -1095,6 +1212,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182743',
           code: 'Hours',
           active: false,
           label: 'Hours',
@@ -1103,6 +1221,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182744',
           code: 'Days',
           active: false,
           label: 'Days',
@@ -1111,6 +1230,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182745',
           code: 'Weeks',
           active: false,
           label: 'Weeks',
@@ -1119,6 +1239,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182746',
           code: 'Months',
           active: false,
           label: 'Months',
@@ -1127,6 +1248,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '182747',
           code: 'Other',
           active: false,
           label: 'Other',
@@ -1144,6 +1266,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '183075',
           code: 'Hours',
           active: true,
           label: 'Hours',
@@ -1152,6 +1275,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183076',
           code: 'Days',
           active: true,
           label: 'Days',
@@ -1160,6 +1284,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183077',
           code: 'Weeks',
           active: true,
           label: 'Weeks',
@@ -1168,6 +1293,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183078',
           code: 'Months',
           active: true,
           label: 'Months',
@@ -1176,6 +1302,7 @@ const RELEASED_IN_ERROR: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '183079',
           code: 'Other',
           active: true,
           label: 'Other',

--- a/server/reportConfiguration/types/SELF_HARM.ts
+++ b/server/reportConfiguration/types/SELF_HARM.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:55.183Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:21.940Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179012',
           code: 'NO TREATMENT',
           active: true,
           label: 'NO TREATMENT',
@@ -23,6 +24,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44733',
         },
         {
+          id: '179014',
           code: 'STERI STRIPS OR SUTURES',
           active: true,
           label: 'STERI STRIPS OR SUTURES',
@@ -31,6 +33,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44733',
         },
         {
+          id: '179011',
           code: 'CLEANED AND DRESSED',
           active: true,
           label: 'CLEANED AND DRESSED',
@@ -39,6 +42,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44733',
         },
         {
+          id: '179013',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -56,6 +60,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179187',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -64,6 +69,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44583',
         },
         {
+          id: '179188',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -81,6 +87,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179201',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -89,6 +96,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44944',
         },
         {
+          id: '179200',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -106,6 +114,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179302',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -114,6 +123,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44653',
         },
         {
+          id: '179303',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -131,6 +141,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '179620',
           code: 'NON HEALTHCARE STAFF',
           active: true,
           label: 'NON HEALTHCARE STAFF',
@@ -139,6 +150,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44214',
         },
         {
+          id: '179621',
           code: 'NURSE/HCO',
           active: true,
           label: 'NURSE/HCO',
@@ -147,6 +159,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44214',
         },
         {
+          id: '179619',
           code: 'MEDICAL OFFICER',
           active: true,
           label: 'MEDICAL OFFICER',
@@ -155,6 +168,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44214',
         },
         {
+          id: '179622',
           code: 'PARAMEDICS/AMBULANCE',
           active: true,
           label: 'PARAMEDICS/AMBULANCE',
@@ -172,6 +186,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179641',
           code: 'SINGLE',
           active: true,
           label: 'SINGLE',
@@ -180,6 +195,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44244',
         },
         {
+          id: '179638',
           code: 'DOUBLE',
           active: true,
           label: 'DOUBLE',
@@ -188,6 +204,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44244',
         },
         {
+          id: '179639',
           code: 'DOUBLE BUT ALONE',
           active: true,
           label: 'DOUBLE BUT ALONE',
@@ -196,6 +213,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44244',
         },
         {
+          id: '179640',
           code: 'MULTIPLE (3 OR  MORE)',
           active: true,
           label: 'MULTIPLE (3 OR  MORE)',
@@ -213,6 +231,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179843',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -221,6 +240,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44435',
         },
         {
+          id: '179842',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -238,6 +258,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179935',
           code: 'WITHIN ONE MONTH',
           active: true,
           label: 'WITHIN ONE MONTH',
@@ -246,6 +267,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44965',
         },
         {
+          id: '179933',
           code: 'MORE THAN ONE MONTH',
           active: true,
           label: 'MORE THAN ONE MONTH',
@@ -254,6 +276,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44965',
         },
         {
+          id: '179934',
           code: 'NOT APPLICABLE',
           active: true,
           label: 'NOT APPLICABLE',
@@ -271,6 +294,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180256',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -279,6 +303,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44332',
         },
         {
+          id: '180257',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -296,6 +321,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180436',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -304,6 +330,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '45105',
         },
         {
+          id: '180437',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -321,6 +348,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180498',
           code: 'OWN MEDICATION',
           active: true,
           label: 'OWN MEDICATION',
@@ -329,6 +357,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '45167',
         },
         {
+          id: '180497',
           code: 'OTHER PERSONS MEDICATION',
           active: true,
           label: 'OTHER PERSONS MEDICATION',
@@ -337,6 +366,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '45167',
         },
         {
+          id: '180495',
           code: 'ILLEGAL DRUGS',
           active: true,
           label: 'ILLEGAL DRUGS',
@@ -345,6 +375,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '45167',
         },
         {
+          id: '180494',
           code: 'CLEANING MATERIALS',
           active: true,
           label: 'CLEANING MATERIALS',
@@ -353,6 +384,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '45167',
         },
         {
+          id: '180499',
           code: 'RAZOR BLADES',
           active: true,
           label: 'RAZOR BLADES',
@@ -361,6 +393,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '45167',
         },
         {
+          id: '180493',
           code: 'BATTERIES',
           active: true,
           label: 'BATTERIES',
@@ -369,6 +402,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '45167',
         },
         {
+          id: '180496',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -386,6 +420,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180526',
           code: 'BEDDING',
           active: true,
           label: 'BEDDING',
@@ -394,6 +429,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44753',
         },
         {
+          id: '180530',
           code: 'SHOELACES',
           active: true,
           label: 'SHOELACES',
@@ -402,6 +438,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44753',
         },
         {
+          id: '180531',
           code: 'TOWEL',
           active: true,
           label: 'TOWEL',
@@ -410,6 +447,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44753',
         },
         {
+          id: '180528',
           code: 'CLOTHING',
           active: true,
           label: 'CLOTHING',
@@ -418,6 +456,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44753',
         },
         {
+          id: '180527',
           code: 'BELT',
           active: true,
           label: 'BELT',
@@ -426,6 +465,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44753',
         },
         {
+          id: '180529',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -443,6 +483,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180532',
           code: 'A AND E',
           active: true,
           label: 'A AND E',
@@ -451,6 +492,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44400',
         },
         {
+          id: '180534',
           code: 'IN PATIENT (OVERNIGHT ONLY)',
           active: true,
           label: 'IN PATIENT (OVERNIGHT ONLY)',
@@ -459,6 +501,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44400',
         },
         {
+          id: '180533',
           code: 'IN PATIENT (OVER 24HR)',
           active: true,
           label: 'IN PATIENT (OVER 24HR)',
@@ -467,6 +510,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44400',
         },
         {
+          id: '180535',
           code: 'LIFE SUPPORT',
           active: true,
           label: 'LIFE SUPPORT',
@@ -484,6 +528,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180734',
           code: 'SUPERFICIAL E.G. CIGARETTE',
           active: true,
           label: 'SUPERFICIAL E.G. CIGARETTE',
@@ -492,6 +537,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44552',
         },
         {
+          id: '180733',
           code: 'NON SUPERFICIAL CELL/SELF FIRE',
           active: true,
           label: 'NON SUPERFICIAL CELL/SELF FIRE',
@@ -509,6 +555,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180760',
           code: 'WINDOW',
           active: true,
           label: 'WINDOW',
@@ -517,6 +564,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44718',
         },
         {
+          id: '180755',
           code: 'BED',
           active: true,
           label: 'BED',
@@ -525,6 +573,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44718',
         },
         {
+          id: '180756',
           code: 'DOOR',
           active: true,
           label: 'DOOR',
@@ -533,6 +582,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44718',
         },
         {
+          id: '180758',
           code: 'PIPES',
           active: true,
           label: 'PIPES',
@@ -541,6 +591,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44718',
         },
         {
+          id: '180759',
           code: 'TOILET AREA',
           active: true,
           label: 'TOILET AREA',
@@ -549,6 +600,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44718',
         },
         {
+          id: '180757',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -566,6 +618,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180997',
           code: 'FEET OFF FLOOR',
           active: true,
           label: 'FEET OFF FLOOR',
@@ -574,6 +627,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '45020',
         },
         {
+          id: '180998',
           code: 'KNEELING OR OTHER',
           active: true,
           label: 'KNEELING OR OTHER',
@@ -582,6 +636,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '45020',
         },
         {
+          id: '180999',
           code: 'NEITHER OF ABOVE',
           active: true,
           label: 'NEITHER OF ABOVE',
@@ -599,6 +654,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181062',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -607,6 +663,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44573',
         },
         {
+          id: '181063',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -624,6 +681,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181110',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -632,6 +690,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44991',
         },
         {
+          id: '181111',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -649,6 +708,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181230',
           code: 'ORDINARY',
           active: true,
           label: 'ORDINARY',
@@ -657,6 +717,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44339',
         },
         {
+          id: '181229',
           code: 'GATED',
           active: true,
           label: 'GATED',
@@ -665,6 +726,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44339',
         },
         {
+          id: '181232',
           code: 'SAFE ANTI-LIGATURE',
           active: true,
           label: 'SAFE ANTI-LIGATURE',
@@ -673,6 +735,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44339',
         },
         {
+          id: '181233',
           code: 'TIME OUT ROOM',
           active: true,
           label: 'TIME OUT ROOM',
@@ -681,6 +744,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44339',
         },
         {
+          id: '181228',
           code: 'CARE SUITE',
           active: true,
           label: 'CARE SUITE',
@@ -689,6 +753,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44339',
         },
         {
+          id: '181234',
           code: 'UNFURNISHED/STRONG BOX',
           active: true,
           label: 'UNFURNISHED/STRONG BOX',
@@ -697,6 +762,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44339',
         },
         {
+          id: '181235',
           code: 'WARD/DORM',
           active: true,
           label: 'WARD/DORM',
@@ -705,6 +771,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44339',
         },
         {
+          id: '181231',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -722,6 +789,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181555',
           code: 'RAZOR',
           active: true,
           label: 'RAZOR',
@@ -730,6 +798,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44155',
         },
         {
+          id: '181552',
           code: 'BROKEN GLASS',
           active: true,
           label: 'BROKEN GLASS',
@@ -738,6 +807,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44155',
         },
         {
+          id: '181554',
           code: 'PLASTIC MATERIAL',
           active: true,
           label: 'PLASTIC MATERIAL',
@@ -746,6 +816,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44155',
         },
         {
+          id: '181553',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -763,6 +834,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181774',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -771,6 +843,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44954',
         },
         {
+          id: '181773',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -779,6 +852,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44954',
         },
         {
+          id: '181772',
           code: 'ALREADY IN HEALTHCARE',
           active: true,
           label: 'ALREADY IN HEALTHCARE',
@@ -796,6 +870,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181810',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -804,6 +879,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44584',
         },
         {
+          id: '181811',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -821,6 +897,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181836',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -829,6 +906,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '181835',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -846,6 +924,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181933',
           code: 'WRIST',
           active: true,
           label: 'WRIST',
@@ -854,6 +933,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44890',
         },
         {
+          id: '181929',
           code: 'ARMS/LEGS',
           active: true,
           label: 'ARMS/LEGS',
@@ -862,6 +942,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44890',
         },
         {
+          id: '181932',
           code: 'TORSO',
           active: true,
           label: 'TORSO',
@@ -870,6 +951,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44890',
         },
         {
+          id: '181931',
           code: 'THROAT',
           active: true,
           label: 'THROAT',
@@ -878,6 +960,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44890',
         },
         {
+          id: '181930',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -895,6 +978,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182015',
           code: 'BEDDING',
           active: true,
           label: 'BEDDING',
@@ -903,6 +987,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44207',
         },
         {
+          id: '182019',
           code: 'SHOELACES',
           active: true,
           label: 'SHOELACES',
@@ -911,6 +996,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44207',
         },
         {
+          id: '182020',
           code: 'TOWEL',
           active: true,
           label: 'TOWEL',
@@ -919,6 +1005,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44207',
         },
         {
+          id: '182017',
           code: 'CLOTHING',
           active: true,
           label: 'CLOTHING',
@@ -927,6 +1014,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44207',
         },
         {
+          id: '182016',
           code: 'BELT',
           active: true,
           label: 'BELT',
@@ -935,6 +1023,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44207',
         },
         {
+          id: '182018',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -952,6 +1041,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182179',
           code: 'ORDINARY',
           active: true,
           label: 'ORDINARY',
@@ -960,6 +1050,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44791',
         },
         {
+          id: '182183',
           code: 'VPU/OTHER PROTECTED',
           active: true,
           label: 'VPU/OTHER PROTECTED',
@@ -968,6 +1059,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44791',
         },
         {
+          id: '182177',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -976,6 +1068,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44791',
         },
         {
+          id: '182178',
           code: "INDCT'N/RECP'N/1ST NIGHTCENTRE",
           active: true,
           label: "INDCT'N/RECP'N/1ST NIGHTCENTRE",
@@ -984,6 +1077,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44791',
         },
         {
+          id: '182182',
           code: 'SEGREGATION UNIT',
           active: true,
           label: 'SEGREGATION UNIT',
@@ -992,6 +1086,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44791',
         },
         {
+          id: '182176',
           code: 'DETOX UNIT',
           active: true,
           label: 'DETOX UNIT',
@@ -1000,6 +1095,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44791',
         },
         {
+          id: '182181',
           code: 'PRISON ESCORT VEHICLE',
           active: true,
           label: 'PRISON ESCORT VEHICLE',
@@ -1008,6 +1104,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44791',
         },
         {
+          id: '182175',
           code: 'COURT CELL',
           active: true,
           label: 'COURT CELL',
@@ -1016,6 +1113,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44791',
         },
         {
+          id: '182180',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1033,6 +1131,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '182366',
           code: 'HEAD BANGING',
           active: true,
           label: 'HEAD BANGING',
@@ -1041,6 +1140,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44511',
         },
         {
+          id: '182368',
           code: 'SUFFOCATION',
           active: true,
           label: 'SUFFOCATION',
@@ -1049,6 +1149,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44511',
         },
         {
+          id: '182369',
           code: 'WOUND',
           active: true,
           label: 'WOUND',
@@ -1057,6 +1158,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44511',
         },
         {
+          id: '182367',
           code: 'NOOSE LIGATURE MAKING',
           active: true,
           label: 'NOOSE LIGATURE MAKING',
@@ -1065,6 +1167,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44511',
         },
         {
+          id: '3901',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -1082,6 +1185,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182616',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -1090,6 +1194,7 @@ const SELF_HARM: IncidentTypeConfiguration = {
           nextQuestionId: '44643',
         },
         {
+          id: '182617',
           code: 'NO',
           active: true,
           label: 'NO',

--- a/server/reportConfiguration/types/TEMPORARY_RELEASE_FAILURE.ts
+++ b/server/reportConfiguration/types/TEMPORARY_RELEASE_FAILURE.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:26:11.433Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:37.686Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '210684',
           code: 'No further action',
           active: true,
           label: 'No further action',
@@ -23,6 +24,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59180',
         },
         {
+          id: '210685',
           code: 'IEP Regression',
           active: true,
           label: 'IEP Regression',
@@ -31,6 +33,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59180',
         },
         {
+          id: '210686',
           code: 'Placed on report/adjudication referral',
           active: true,
           label: 'Placed on report/adjudication referral',
@@ -39,6 +42,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59180',
         },
         {
+          id: '210687',
           code: 'Police referral',
           active: true,
           label: 'Police referral',
@@ -47,6 +51,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59180',
         },
         {
+          id: '210688',
           code: 'CPS referral',
           active: true,
           label: 'CPS referral',
@@ -55,6 +60,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59180',
         },
         {
+          id: '210689',
           code: 'Prosecution referral',
           active: true,
           label: 'Prosecution referral',
@@ -72,6 +78,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210690',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -80,6 +87,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59181',
         },
         {
+          id: '210691',
           code: 'No',
           active: true,
           label: 'No',
@@ -97,6 +105,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210692',
           code: 'Standard ROTL',
           active: true,
           label: 'Standard ROTL',
@@ -105,6 +114,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59182',
         },
         {
+          id: '210693',
           code: 'Restricted ROTL',
           active: true,
           label: 'Restricted ROTL',
@@ -122,6 +132,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210694',
           code: 'Resettlement Day',
           active: true,
           label: 'Resettlement Day',
@@ -130,6 +141,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59183',
         },
         {
+          id: '210695',
           code: 'Resettlement Overnight',
           active: true,
           label: 'Resettlement Overnight',
@@ -138,6 +150,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59183',
         },
         {
+          id: '210696',
           code: 'Childcare Resettlement',
           active: true,
           label: 'Childcare Resettlement',
@@ -146,6 +159,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59183',
         },
         {
+          id: '210697',
           code: 'Special Purpose (medical)',
           active: true,
           label: 'Special Purpose (medical)',
@@ -154,6 +168,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59183',
         },
         {
+          id: '210698',
           code: 'Special Purpose (other)',
           active: true,
           label: 'Special Purpose (other)',
@@ -171,6 +186,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210699',
           code: 'Training or Education',
           active: true,
           label: 'Training or Education',
@@ -179,6 +195,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210700',
           code: 'Unpaid Work Placements',
           active: true,
           label: 'Unpaid Work Placements',
@@ -187,6 +204,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210701',
           code: 'Paid Work Placements',
           active: true,
           label: 'Paid Work Placements',
@@ -195,6 +213,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210702',
           code: 'Maintain Family Ties',
           active: true,
           label: 'Maintain Family Ties',
@@ -203,6 +222,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210703',
           code: 'Outside Prison Activity',
           active: true,
           label: 'Outside Prison Activity',
@@ -211,6 +231,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210704',
           code: 'Accommodation Related',
           active: true,
           label: 'Accommodation Related',
@@ -219,6 +240,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210705',
           code: 'Other Day Release linked to Sentence/Resettlement Plan',
           active: true,
           label: 'Other Day Release linked to Sentence/Resettlement Plan',
@@ -227,6 +249,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210706',
           code: 'Resettlement Overnight Release',
           active: true,
           label: 'Resettlement Overnight Release',
@@ -235,6 +258,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210707',
           code: 'Childcare Resettlement Leave',
           active: true,
           label: 'Childcare Resettlement Leave',
@@ -243,6 +267,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210708',
           code: 'Funeral/Visiting Dying Relative',
           active: true,
           label: 'Funeral/Visiting Dying Relative',
@@ -251,6 +276,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210709',
           code: 'Medical Treatment',
           active: true,
           label: 'Medical Treatment',
@@ -259,6 +285,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210710',
           code: 'Other Compassionate Reason',
           active: true,
           label: 'Other Compassionate Reason',
@@ -267,6 +294,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59184',
         },
         {
+          id: '210711',
           code: 'Court/Legal/Police',
           active: true,
           label: 'Court/Legal/Police',
@@ -284,6 +312,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210712',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -292,6 +321,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59185',
         },
         {
+          id: '210713',
           code: 'No',
           active: true,
           label: 'No',
@@ -309,6 +339,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210714',
           code: 'Apparent failure to return',
           active: true,
           label: 'Apparent failure to return',
@@ -317,6 +348,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59186',
         },
         {
+          id: '210715',
           code: "Revocation of the prisoner's licence",
           active: true,
           label: "Revocation of the prisoner's licence",
@@ -334,6 +366,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210716',
           code: 'Yes (Enter Date)',
           active: true,
           label: 'Yes (Enter Date)',
@@ -342,6 +375,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59187',
         },
         {
+          id: '210717',
           code: 'No',
           active: true,
           label: 'No',
@@ -359,6 +393,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210718',
           code: 'Surrendered before midnight on return date',
           active: true,
           label: 'Surrendered before midnight on return date',
@@ -367,6 +402,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59188',
         },
         {
+          id: '210719',
           code: 'Surrender To HMPS (after midnight on return date)',
           active: true,
           label: 'Surrender To HMPS (after midnight on return date)',
@@ -375,6 +411,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59188',
         },
         {
+          id: '210720',
           code: 'Surrender To Police (after midnight on return date)',
           active: true,
           label: 'Surrender To Police (after midnight on return date)',
@@ -383,6 +420,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59188',
         },
         {
+          id: '210721',
           code: 'Arrest By HMPS',
           active: true,
           label: 'Arrest By HMPS',
@@ -391,6 +429,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59188',
         },
         {
+          id: '210722',
           code: 'Arrest By Police',
           active: true,
           label: 'Arrest By Police',
@@ -399,6 +438,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59188',
         },
         {
+          id: '210723',
           code: 'Admitted to hospital for treatment',
           active: true,
           label: 'Admitted to hospital for treatment',
@@ -407,6 +447,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59188',
         },
         {
+          id: '210724',
           code: 'Deceased',
           active: true,
           label: 'Deceased',
@@ -415,6 +456,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59188',
         },
         {
+          id: '210725',
           code: 'Other (Provide Details)',
           active: true,
           label: 'Other (Provide Details)',
@@ -432,6 +474,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210726',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -440,6 +483,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59189',
         },
         {
+          id: '210727',
           code: 'No',
           active: true,
           label: 'No',
@@ -458,6 +502,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210728',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -466,6 +511,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59190',
         },
         {
+          id: '210729',
           code: 'No',
           active: true,
           label: 'No',
@@ -483,6 +529,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '210730',
           code: 'Violence Against The Person',
           active: true,
           label: 'Violence Against The Person',
@@ -491,6 +538,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59191',
         },
         {
+          id: '210731',
           code: 'Sexual Offences',
           active: true,
           label: 'Sexual Offences',
@@ -499,6 +547,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59191',
         },
         {
+          id: '210732',
           code: 'Robbery',
           active: true,
           label: 'Robbery',
@@ -507,6 +556,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59191',
         },
         {
+          id: '210733',
           code: 'Burglary',
           active: true,
           label: 'Burglary',
@@ -515,6 +565,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59191',
         },
         {
+          id: '210734',
           code: 'Theft And Handling',
           active: true,
           label: 'Theft And Handling',
@@ -523,6 +574,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59191',
         },
         {
+          id: '210735',
           code: 'Fraud And Forgery',
           active: true,
           label: 'Fraud And Forgery',
@@ -531,6 +583,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59191',
         },
         {
+          id: '210736',
           code: 'Drug Offences',
           active: true,
           label: 'Drug Offences',
@@ -539,6 +592,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59191',
         },
         {
+          id: '210737',
           code: 'Motoring Offences',
           active: true,
           label: 'Motoring Offences',
@@ -547,6 +601,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59191',
         },
         {
+          id: '210738',
           code: 'Other Offence (Please specify)',
           active: true,
           label: 'Other Offence (Please specify)',
@@ -555,6 +610,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59191',
         },
         {
+          id: '210739',
           code: 'Unknown',
           active: true,
           label: 'Unknown',
@@ -572,6 +628,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210740',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -580,6 +637,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59192',
         },
         {
+          id: '210741',
           code: 'No',
           active: true,
           label: 'No',
@@ -597,6 +655,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '210742',
           code: 'Violence Against The Person',
           active: true,
           label: 'Violence Against The Person',
@@ -605,6 +664,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59193',
         },
         {
+          id: '210743',
           code: 'Sexual Offences',
           active: true,
           label: 'Sexual Offences',
@@ -613,6 +673,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59193',
         },
         {
+          id: '210744',
           code: 'Robbery',
           active: true,
           label: 'Robbery',
@@ -621,6 +682,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59193',
         },
         {
+          id: '210745',
           code: 'Burglary',
           active: true,
           label: 'Burglary',
@@ -629,6 +691,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59193',
         },
         {
+          id: '210746',
           code: 'Theft And Handling',
           active: true,
           label: 'Theft And Handling',
@@ -637,6 +700,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59193',
         },
         {
+          id: '210747',
           code: 'Fraud And Forgery',
           active: true,
           label: 'Fraud And Forgery',
@@ -645,6 +709,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59193',
         },
         {
+          id: '210748',
           code: 'Drug Offences',
           active: true,
           label: 'Drug Offences',
@@ -653,6 +718,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59193',
         },
         {
+          id: '210749',
           code: 'Motoring Offences',
           active: true,
           label: 'Motoring Offences',
@@ -661,6 +727,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59193',
         },
         {
+          id: '210750',
           code: 'Other Offence (Please specify)',
           active: true,
           label: 'Other Offence (Please specify)',
@@ -678,6 +745,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210751',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -686,6 +754,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59194',
         },
         {
+          id: '210752',
           code: 'No',
           active: true,
           label: 'No',
@@ -703,6 +772,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '210753',
           code: 'Violence Against The Person',
           active: true,
           label: 'Violence Against The Person',
@@ -711,6 +781,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59195',
         },
         {
+          id: '210754',
           code: 'Sexual Offences',
           active: true,
           label: 'Sexual Offences',
@@ -719,6 +790,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59195',
         },
         {
+          id: '210755',
           code: 'Robbery',
           active: true,
           label: 'Robbery',
@@ -727,6 +799,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59195',
         },
         {
+          id: '210756',
           code: 'Burglary',
           active: true,
           label: 'Burglary',
@@ -735,6 +808,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59195',
         },
         {
+          id: '210757',
           code: 'Theft And Handling',
           active: true,
           label: 'Theft And Handling',
@@ -743,6 +817,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59195',
         },
         {
+          id: '210758',
           code: 'Fraud And Forgery',
           active: true,
           label: 'Fraud And Forgery',
@@ -751,6 +826,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59195',
         },
         {
+          id: '210759',
           code: 'Drug Offences',
           active: true,
           label: 'Drug Offences',
@@ -759,6 +835,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59195',
         },
         {
+          id: '210760',
           code: 'Motoring Offences',
           active: true,
           label: 'Motoring Offences',
@@ -767,6 +844,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59195',
         },
         {
+          id: '210761',
           code: 'Failure To Return From ROTL',
           active: true,
           label: 'Failure To Return From ROTL',
@@ -775,6 +853,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59195',
         },
         {
+          id: '210762',
           code: 'Other Offence (Please specify)',
           active: true,
           label: 'Other Offence (Please specify)',
@@ -792,6 +871,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210763',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -800,6 +880,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59196',
         },
         {
+          id: '210764',
           code: 'No',
           active: true,
           label: 'No',
@@ -817,6 +898,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '210765',
           code: 'Location',
           active: true,
           label: 'Location',
@@ -825,6 +907,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59197',
         },
         {
+          id: '210766',
           code: 'Alcohol/drugs (under influence)',
           active: true,
           label: 'Alcohol/drugs (under influence)',
@@ -833,6 +916,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59197',
         },
         {
+          id: '210767',
           code: 'Gambling',
           active: true,
           label: 'Gambling',
@@ -841,6 +925,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59197',
         },
         {
+          id: '210768',
           code: 'Finds (fill in separate report)',
           active: true,
           label: 'Finds (fill in separate report)',
@@ -849,6 +934,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59197',
         },
         {
+          id: '210769',
           code: 'Social Media',
           active: true,
           label: 'Social Media',
@@ -857,6 +943,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59197',
         },
         {
+          id: '210770',
           code: 'Bad Behaviour',
           active: true,
           label: 'Bad Behaviour',
@@ -865,6 +952,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59197',
         },
         {
+          id: '210771',
           code: 'Media Contact',
           active: true,
           label: 'Media Contact',
@@ -873,6 +961,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59197',
         },
         {
+          id: '210772',
           code: 'Other (Provide Details)',
           active: true,
           label: 'Other (Provide Details)',
@@ -890,6 +979,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210773',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -898,6 +988,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59198',
         },
         {
+          id: '210774',
           code: 'No',
           active: true,
           label: 'No',
@@ -915,6 +1006,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210775',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -923,6 +1015,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59199',
         },
         {
+          id: '210776',
           code: 'No',
           active: true,
           label: 'No',
@@ -940,6 +1033,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210777',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -948,6 +1042,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59200',
         },
         {
+          id: '210778',
           code: 'No',
           active: true,
           label: 'No',
@@ -965,6 +1060,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210779',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -973,6 +1069,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59201',
         },
         {
+          id: '210780',
           code: 'No',
           active: true,
           label: 'No',
@@ -990,6 +1087,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210781',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -998,6 +1096,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59202',
         },
         {
+          id: '210782',
           code: 'No',
           active: true,
           label: 'No',
@@ -1015,6 +1114,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210783',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -1023,6 +1123,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: '59203',
         },
         {
+          id: '210784',
           code: 'No',
           active: true,
           label: 'No',
@@ -1040,6 +1141,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '210785',
           code: 'Yes',
           active: true,
           label: 'Yes',
@@ -1048,6 +1150,7 @@ const TEMPORARY_RELEASE_FAILURE: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '210786',
           code: 'No',
           active: true,
           label: 'No',

--- a/server/reportConfiguration/types/TOOL_LOSS.ts
+++ b/server/reportConfiguration/types/TOOL_LOSS.ts
@@ -1,4 +1,4 @@
-// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-09-25T09:25:51.916Z
+// Generated with ./scripts/updateNomisIncidentTypeConfigurations.ts at 2024-10-15T17:17:18.664Z
 
 import { type IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 
@@ -15,6 +15,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179154',
           code: 'FULL CLOSE DOWN SEARCH',
           active: true,
           label: 'FULL CLOSE DOWN SEARCH',
@@ -23,6 +24,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44565',
         },
         {
+          id: '179156',
           code: 'PARTIAL SEARCH',
           active: true,
           label: 'PARTIAL SEARCH',
@@ -31,6 +33,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44565',
         },
         {
+          id: '179155',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -48,6 +51,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179749',
           code: 'LOST',
           active: true,
           label: 'LOST',
@@ -56,6 +60,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44445',
         },
         {
+          id: '179750',
           code: 'MISLAID',
           active: true,
           label: 'MISLAID',
@@ -64,6 +69,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44445',
         },
         {
+          id: '179751',
           code: 'STOLEN',
           active: true,
           label: 'STOLEN',
@@ -81,6 +87,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179883',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -89,6 +96,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44593',
         },
         {
+          id: '179882',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -106,6 +114,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '179974',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -114,6 +123,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44195',
         },
         {
+          id: '179973',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -131,6 +141,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180133',
           code: 'SHADOW BOARD',
           active: true,
           label: 'SHADOW BOARD',
@@ -139,6 +150,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44509',
         },
         {
+          id: '180131',
           code: 'SECURE CABINET',
           active: true,
           label: 'SECURE CABINET',
@@ -147,6 +159,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44509',
         },
         {
+          id: '180132',
           code: 'SECURE ROOM',
           active: true,
           label: 'SECURE ROOM',
@@ -155,6 +168,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44509',
         },
         {
+          id: '180130',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -172,6 +186,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180170',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -180,6 +195,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44993',
         },
         {
+          id: '180169',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -197,6 +213,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180253',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -205,6 +222,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: null,
         },
         {
+          id: '180252',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -222,6 +240,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180473',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -230,6 +249,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '45169',
         },
         {
+          id: '180474',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -247,6 +267,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '180563',
           code: 'KNIFE',
           active: true,
           label: 'KNIFE',
@@ -255,6 +276,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180562',
           code: 'HACKSAW',
           active: true,
           label: 'HACKSAW',
@@ -263,6 +285,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180565',
           code: 'OTHER SAW',
           active: true,
           label: 'OTHER SAW',
@@ -271,6 +294,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180570',
           code: 'SPADE',
           active: true,
           label: 'SPADE',
@@ -279,6 +303,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180560',
           code: 'AXE',
           active: true,
           label: 'AXE',
@@ -287,6 +312,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180566',
           code: 'PICKAXE',
           active: true,
           label: 'PICKAXE',
@@ -295,6 +321,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180567',
           code: 'PLIERS',
           active: true,
           label: 'PLIERS',
@@ -303,6 +330,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180569',
           code: 'SCREWDRIVER',
           active: true,
           label: 'SCREWDRIVER',
@@ -311,6 +339,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180571',
           code: 'WIRE CUTTERS',
           active: true,
           label: 'WIRE CUTTERS',
@@ -319,6 +348,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180561',
           code: 'BOLT CROPPERS',
           active: true,
           label: 'BOLT CROPPERS',
@@ -327,6 +357,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180568',
           code: 'SCISSORS',
           active: true,
           label: 'SCISSORS',
@@ -335,6 +366,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44950',
         },
         {
+          id: '180564',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -352,6 +384,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180609',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -360,6 +393,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44672',
         },
         {
+          id: '180608',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -377,6 +411,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '180830',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -385,6 +420,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44412',
         },
         {
+          id: '180829',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -402,6 +438,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181276',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -410,6 +447,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44489',
         },
         {
+          id: '181275',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -427,6 +465,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: true,
       answers: [
         {
+          id: '181796',
           code: 'WORKS DEPARTMENT',
           active: true,
           label: 'WORKS DEPARTMENT',
@@ -435,6 +474,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44372',
         },
         {
+          id: '181788',
           code: 'CONTRACTORS',
           active: true,
           label: 'CONTRACTORS',
@@ -443,6 +483,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44372',
         },
         {
+          id: '181789',
           code: 'EDUCATION',
           active: true,
           label: 'EDUCATION',
@@ -451,6 +492,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44372',
         },
         {
+          id: '181792',
           code: 'HEALTH CARE CENTRE',
           active: true,
           label: 'HEALTH CARE CENTRE',
@@ -459,6 +501,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44372',
         },
         {
+          id: '181790',
           code: 'FARMS AND GARDENS',
           active: true,
           label: 'FARMS AND GARDENS',
@@ -467,6 +510,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44372',
         },
         {
+          id: '181791',
           code: 'GYMNASIUM/SPORTSFIELD',
           active: true,
           label: 'GYMNASIUM/SPORTSFIELD',
@@ -475,6 +519,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44372',
         },
         {
+          id: '181797',
           code: 'WORKSHOP',
           active: true,
           label: 'WORKSHOP',
@@ -483,6 +528,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44372',
         },
         {
+          id: '181793',
           code: 'KITCHEN',
           active: true,
           label: 'KITCHEN',
@@ -491,6 +537,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44372',
         },
         {
+          id: '181787',
           code: 'CELL HOBBIES',
           active: true,
           label: 'CELL HOBBIES',
@@ -499,6 +546,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44372',
         },
         {
+          id: '181795',
           code: 'WING OFFICE',
           active: true,
           label: 'WING OFFICE',
@@ -507,6 +555,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44372',
         },
         {
+          id: '181794',
           code: 'OTHER',
           active: true,
           label: 'OTHER',
@@ -524,6 +573,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '181941',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -532,6 +582,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44603',
         },
         {
+          id: '181940',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -549,6 +600,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182533',
           code: 'YES',
           active: true,
           label: 'YES',
@@ -557,6 +609,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44808',
         },
         {
+          id: '182534',
           code: 'NO',
           active: true,
           label: 'NO',
@@ -574,6 +627,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
       multipleAnswers: false,
       answers: [
         {
+          id: '182624',
           code: 'PRISONERS POSSESSION',
           active: true,
           label: 'PRISONERS POSSESSION',
@@ -582,6 +636,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44477',
         },
         {
+          id: '182621',
           code: 'CONCEALED',
           active: true,
           label: 'CONCEALED',
@@ -590,6 +645,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44477',
         },
         {
+          id: '182622',
           code: 'DISCARDED',
           active: true,
           label: 'DISCARDED',
@@ -598,6 +654,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44477',
         },
         {
+          id: '182625',
           code: 'WHERE MISLAID/LOST',
           active: true,
           label: 'WHERE MISLAID/LOST',
@@ -606,6 +663,7 @@ const TOOL_LOSS: IncidentTypeConfiguration = {
           nextQuestionId: '44477',
         },
         {
+          id: '182623',
           code: 'OTHER',
           active: true,
           label: 'OTHER',


### PR DESCRIPTION
NOMIS has a concept of "answer id" which we didn't copy. 

This is very useful when building forms inputs as we can use these IDs to generate unique names
for things like comment/date inputs.

Forms can use these IDs to generate unique names for input that we can use to discriminate submitted values.

### For example:


**Question (id: '12345'): Which part were injured?**
  - [X] Answer (id: 'A1'): Neck
    - Comment required (input name: "12345-A1-comment"): `[ lorem ipsum ]`
  - [X] Answer (id: 'A2'): Leg
    - Comment required (input name: "12345-A2-comment"): `[ lorem ipsum ]`

**Question (id: '6789'): Was it a serious injury?**
  - [ ] Answer (id: 'A1'): Yes
    - Comment required (input name: "6789-A1-comment"): `[ lorem ipsum ]`
  - [ ] Answer (id: 'A2'): No
    - Comment required (input name: "6789-A2-comment"): `[ lorem ipsum ]`

(in this example the answer ids are only locally unique, in NOMIS answers' ids are globally unique. Our config would use these IDs but in practice it shouldn't matter as long as the names for these comment/date fields are unique and can be used to determine what question/answer they refer to)