### PR TITLE
IR-68: Nunjucks utilities to help keep presentation logic within template files

### DIFF
--- a/server/utils/govukFrontend.test.ts
+++ b/server/utils/govukFrontend.test.ts
@@ -7,6 +7,7 @@ import {
   govukSelectSetSelected,
   govukCheckedItems,
   govukMultipleCheckedItems,
+  govukCheckedItemsConditional,
 } from './govukFrontend'
 
 describe('findFieldInGovukErrorSummary', () => {
@@ -87,6 +88,34 @@ describe('govukCheckedItems and govukMultipleCheckedItems', () => {
     ])
   })
 })
+
+describe('govukCheckedItemsConditional', () => {
+  const items: GovukRadiosItem[] = [
+    { text: 'A', value: 'a' },
+    { text: 'B', value: 'b' },
+    { text: 'C', value: 'c' },
+  ]
+
+  it.each([undefined, null, {}])('should ignore %p conditional', conditional => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(govukCheckedItemsConditional(items, conditional as any)).toStrictEqual(items)
+  })
+
+  it('should add conditional html property to item matching by value', () => {
+    expect(govukCheckedItemsConditional(items, { value: 'b', html: '<strong>info</strong>' })).toStrictEqual<
+      GovukRadiosItem[]
+    >([
+      { text: 'A', value: 'a' },
+      { text: 'B', value: 'b', conditional: { html: '<strong>info</strong>' } },
+      { text: 'C', value: 'c' },
+    ])
+  })
+
+  it('should not add conditional html property if no items match by value', () => {
+    expect(govukCheckedItemsConditional(items, { value: 'd', html: '<strong>info</strong>' })).toStrictEqual(items)
+  })
+})
+
 describe('govukSelectInsertDefault', () => {
   it.each([undefined, null])('should ignore item list %p', list => {
     expect(govukSelectInsertDefault(list, 'Select an option…')).toStrictEqual(list)

--- a/server/utils/govukFrontend.test.ts
+++ b/server/utils/govukFrontend.test.ts
@@ -8,7 +8,9 @@ import {
   govukCheckedItems,
   govukMultipleCheckedItems,
   govukCheckedItemsConditional,
+  govukCheckedItemsDivider,
 } from './govukFrontend'
+import { buildArray } from './utils'
 
 describe('findFieldInGovukErrorSummary', () => {
   it.each([undefined, null])('should return null if error list is %p', list => {
@@ -87,6 +89,16 @@ describe('govukCheckedItems and govukMultipleCheckedItems', () => {
       { text: 'C', value: 'c', checked: false },
     ])
   })
+
+  it('should leave dividers alone', () => {
+    const itemsWithDivider: GovukRadiosItem[] = [
+      { text: 'A', value: 'a' },
+      { divider: 'or' },
+      { text: 'B', value: 'b' },
+    ]
+    expect(govukCheckedItems(itemsWithDivider, 'a').at(1)).toStrictEqual({ divider: 'or' })
+    expect(govukMultipleCheckedItems(itemsWithDivider, ['a', 'b']).at(1)).toStrictEqual({ divider: 'or' })
+  })
 })
 
 describe('govukCheckedItemsConditional', () => {
@@ -113,6 +125,31 @@ describe('govukCheckedItemsConditional', () => {
 
   it('should not add conditional html property if no items match by value', () => {
     expect(govukCheckedItemsConditional(items, { value: 'd', html: '<strong>info</strong>' })).toStrictEqual(items)
+  })
+})
+
+describe('govukCheckedItemsDivider', () => {
+  function makeItems(length: number): GovukRadiosItem[] {
+    return buildArray(length, i => ({ text: i.toString(), value: i.toString() }))
+  }
+
+  it('should leave short items lists alone', () => {
+    const items = makeItems(3)
+    expect(govukCheckedItemsDivider(items)).toStrictEqual(items)
+  })
+
+  it('should add a divider to long items lists', () => {
+    const items = makeItems(5)
+    const newItems = govukCheckedItemsDivider(items)
+    expect(newItems).toHaveLength(6)
+    expect(newItems.at(-2)).toStrictEqual({ divider: 'or' })
+  })
+
+  it('should be customisable', () => {
+    const items = makeItems(3)
+    const newItems = govukCheckedItemsDivider(items, 2, 'neu')
+    expect(newItems).toHaveLength(4)
+    expect(newItems.at(-2)).toStrictEqual({ divider: 'neu' })
   })
 })
 

--- a/server/utils/govukFrontend.ts
+++ b/server/utils/govukFrontend.ts
@@ -164,7 +164,7 @@ export function govukCheckedItems<I extends GovukRadiosItem>(items: I[], singleV
 /**
  * Marks items as checked depending on values for use with GOV.UK radios and checkboxes components
  */
-export function govukMultipleCheckedItems<I extends GovukRadiosItem>(
+export function govukMultipleCheckedItems<I extends GovukCheckboxesItem>(
   items: I[],
   multipleValues: string[] | undefined,
 ): I[] {
@@ -173,6 +173,27 @@ export function govukMultipleCheckedItems<I extends GovukRadiosItem>(
       ...item,
       checked: Boolean(multipleValues?.includes(item.value)),
     }
+  })
+}
+
+/**
+ * Adds a conditional HTML property to matching item by value within GOV.UK radios and checkboxes components
+ */
+export function govukCheckedItemsConditional<I extends GovukRadiosItem>(
+  items: I[],
+  conditional?: { value: string; html: string } | undefined,
+): I[] {
+  if (!conditional?.html) {
+    return items
+  }
+  return items.map(item => {
+    if (item.value === conditional.value) {
+      return {
+        ...item,
+        conditional: { html: conditional.html },
+      }
+    }
+    return item
   })
 }
 

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -4,10 +4,8 @@ import nunjucks from 'nunjucks'
 import nunjucksSetup from './nunjucksSetup'
 
 describe('nunjucks context', () => {
-  let app: express.Express
-
-  beforeEach(() => {
-    app = express()
+  beforeAll(() => {
+    const app = express()
     nunjucksSetup(app)
   })
 
@@ -52,5 +50,18 @@ describe('nunjucks context', () => {
         }).toThrow(`Macro ${macroName} not found`)
       },
     )
+  })
+
+  describe('panic extension', () => {
+    it('should throw an error instead of rendering the template', () => {
+      expect(() => {
+        nunjucks.renderString(
+          `
+            {% panic "unreachable" %}
+          `,
+          {},
+        )
+      }).toThrow('unreachable')
+    })
   })
 })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -13,6 +13,7 @@ import {
   govukCheckedItems,
   govukMultipleCheckedItems,
   govukCheckedItemsConditional,
+  govukCheckedItemsDivider,
   govukSelectInsertDefault,
   govukSelectSetSelected,
 } from './govukFrontend'
@@ -79,6 +80,7 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addFilter('govukCheckedItems', govukCheckedItems)
   njkEnv.addFilter('govukMultipleCheckedItems', govukMultipleCheckedItems)
   njkEnv.addFilter('govukCheckedItemsConditional', govukCheckedItemsConditional)
+  njkEnv.addFilter('govukCheckedItemsDivider', govukCheckedItemsDivider)
   njkEnv.addFilter('govukSelectInsertDefault', govukSelectInsertDefault)
   njkEnv.addFilter('govukSelectSetSelected', govukSelectSetSelected)
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -12,6 +12,7 @@ import {
   findFieldInGovukErrorSummary,
   govukCheckedItems,
   govukMultipleCheckedItems,
+  govukCheckedItemsConditional,
   govukSelectInsertDefault,
   govukSelectSetSelected,
 } from './govukFrontend'
@@ -77,6 +78,7 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addFilter('findFieldInGovukErrorSummary', findFieldInGovukErrorSummary)
   njkEnv.addFilter('govukCheckedItems', govukCheckedItems)
   njkEnv.addFilter('govukMultipleCheckedItems', govukMultipleCheckedItems)
+  njkEnv.addFilter('govukCheckedItemsConditional', govukCheckedItemsConditional)
   njkEnv.addFilter('govukSelectInsertDefault', govukSelectInsertDefault)
   njkEnv.addFilter('govukSelectSetSelected', govukSelectSetSelected)
 }


### PR DESCRIPTION
The `govukCheckedItemsConditional` filter is used to add conditional html to GDS radio or checkbox components.

```typescript
res.render('template', {
  items: [
    { text: 'A', value: 'a' },
    { text: 'B', value: 'b' },
  ],
})
```

```nunjucks
{% set conditional %}
  {{ govukInput({
    name: 'comment',
    id: 'comment',
    label: { text: 'Comment' }
  }) }}
{% endset %}
{{ govukCheckboxes({
  id: 'sample',
  name: 'sample',
  fieldset: { legend: { text: 'Sample' } },
  items: items | govukCheckedItemsConditional({
    value: 'b',
    html: conditional
  })
}) }}
```

---

The `govukCheckedItemsDivider` filter adds a divider to GOVUK checkbox or radio component items.

```nunjucks
{{ govukCheckboxes({
  id: 'sample',
  name: 'sample',
  fieldset: { legend: { text: 'Sample' } },
  items: items | govukCheckedItemsDivider()
}) }}
```

---

The `panic` tag is used to unconditionally stop template rendering – useful to ensure we never reach an invalid condition.

```nunjucks
{% if expectedCondition1 %}
  render something
{% elif expectedCondition2 %}
  render something else
{% else %}
  {% panic 'this should never happen' %}
{% endif %}
```