### PR TITLE
IR-548: Simple error message handling for form wizard pages

### DIFF
--- a/server/@types/hmpo-form-wizard/index.d.ts
+++ b/server/@types/hmpo-form-wizard/index.d.ts
@@ -159,6 +159,8 @@ declare module 'hmpo-form-wizard' {
                 arguments?: unknown[]
               }
             | {
+                /** Custom validator name */
+                type?: string
                 /** Validator function */
                 fn: Validator
               }
@@ -240,8 +242,8 @@ declare module 'hmpo-form-wizard' {
       route: string
       steps: Steps
       fields: Fields
-      allFields: Fields
-      defaultFormatters: DefaultFormatter[]
+      allFields?: Fields
+      defaultFormatters?: DefaultFormatter[]
     }
 
     interface Form {
@@ -340,9 +342,9 @@ declare module 'hmpo-form-wizard' {
      * Class with various mixins which instantiates a request handler for each form step
      */
     class Controller extends BaseController {
-      validators: Record<string, Validator>
+      validators: Record<DefaultValidator, Validator>
 
-      formatters: Record<string, Formatter>
+      formatters: Record<DefaultFormatter, Formatter>
 
       resolvePath(base: string, url: string, forceRelative: boolean): void
 
@@ -505,7 +507,7 @@ declare module 'hmpo-form-wizard' {
 }
 
 declare module 'hmpo-form-wizard/lib/formatting' {
-  import FormWizard from 'hmpo-form-wizard'
+  import type FormWizard from 'hmpo-form-wizard'
 
   export function format<T>(
     fields: FormWizard.Fields,
@@ -532,11 +534,11 @@ declare module 'hmpo-form-wizard/lib/formatting' {
     base64decode(value: FormWizard.Value): string
   } // satisfies Record<string, FormWizard.Formatter>
 
-  type DefaultFormatter = keyof typeof formatters
+  export type DefaultFormatter = keyof typeof formatters
 }
 
 declare module 'hmpo-form-wizard/lib/validation' {
-  import FormWizard from 'hmpo-form-wizard'
+  import type FormWizard from 'hmpo-form-wizard'
 
   export function isAllowedDependent(fields: FormWizard.Fields, key: string, values: FormWizard.Values): boolean
 
@@ -603,5 +605,5 @@ declare module 'hmpo-form-wizard/lib/validation' {
     ): boolean
   } // satisfies Record<string, FormWizard.Validator>
 
-  type DefaultValidator = keyof typeof validators
+  export type DefaultValidator = keyof typeof validators
 }

--- a/server/controllers/index.test.ts
+++ b/server/controllers/index.test.ts
@@ -1,0 +1,72 @@
+import type Express from 'express'
+import FormWizard from 'hmpo-form-wizard'
+
+import { BaseController } from './index'
+
+describe('Base form wizard controller', () => {
+  describe('Error messages', () => {
+    class TestController extends BaseController {
+      protected errorMessage(error: FormWizard.Error): string {
+        if (error.key === 'name' && error.type === 'required') {
+          return 'Enter your name'
+        }
+        return super.errorMessage(error)
+      }
+    }
+
+    it.each([
+      { messageSource: 'generic', fieldName: 'email', expectedError: 'This field is required' },
+      { messageSource: 'controller-overridden', fieldName: 'name', expectedError: 'Enter your name' },
+    ])('should add $messageSource human-readable message to error', ({ fieldName, expectedError }) => {
+      const options: FormWizard.Options = {
+        route: '/',
+        steps: { '/': { fields: ['name', 'email'] } },
+        fields: {
+          name: { name: 'name', validate: ['required'] },
+          email: { name: 'email', validate: ['required', 'email'] },
+        },
+      }
+      const controller = new TestController(options)
+
+      const req = {
+        method: 'POST',
+        sessionModel: jest.fn(),
+        form: {
+          options,
+          values: { name: '', email: '' },
+          errors: {},
+        },
+      } as unknown as FormWizard.Request
+      const res = {} as Express.Response
+
+      const error = controller.validateField(fieldName, req, res)
+      expect(error).toHaveProperty('message', expectedError)
+    })
+
+    it('should throw an error when no generic human-readable message is found for error type', () => {
+      const options: FormWizard.Options = {
+        route: '/',
+        steps: { '/': { fields: ['mobile'] } },
+        fields: {
+          mobile: { name: 'mobile', validate: ['ukmobilephone'] },
+        },
+      }
+      const controller = new TestController(options)
+
+      const req = {
+        method: 'POST',
+        sessionModel: jest.fn(),
+        form: {
+          options,
+          values: { mobile: 'n/a' },
+          errors: {},
+        },
+      } as unknown as FormWizard.Request
+      const res = {} as Express.Response
+
+      expect(() => {
+        controller.validateField('mobile', req, res)
+      }).toThrow('Error message not set for type')
+    })
+  })
+})

--- a/server/controllers/index.test.ts
+++ b/server/controllers/index.test.ts
@@ -1,19 +1,19 @@
 import type Express from 'express'
-import FormWizard from 'hmpo-form-wizard'
+import type FormWizard from 'hmpo-form-wizard'
 
 import { BaseController } from './index'
 
+class TestController extends BaseController {
+  protected errorMessage(error: FormWizard.Error): string {
+    if (error.key === 'name' && error.type === 'required') {
+      return 'Enter your name'
+    }
+    return super.errorMessage(error)
+  }
+}
+
 describe('Base form wizard controller', () => {
   describe('Error messages', () => {
-    class TestController extends BaseController {
-      protected errorMessage(error: FormWizard.Error): string {
-        if (error.key === 'name' && error.type === 'required') {
-          return 'Enter your name'
-        }
-        return super.errorMessage(error)
-      }
-    }
-
     it.each([
       { messageSource: 'generic', fieldName: 'email', expectedError: 'This field is required' },
       { messageSource: 'controller-overridden', fieldName: 'name', expectedError: 'Enter your name' },

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -1,0 +1,41 @@
+import type Express from 'express'
+import FormWizard from 'hmpo-form-wizard'
+
+/**
+ * The super-class form wizard controller with functionality that should be shared
+ * amongst all forms in this application.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export abstract class BaseController extends FormWizard.Controller {
+  /**
+   * Generic human-readable error messages for default form wizard validators.
+   */
+  protected readonly errorMessages: Record<keyof BaseController['validators'], string> = {
+    required: 'This field is required',
+    email: 'Enter an email address',
+    date: 'Enter a date',
+  }
+
+  /**
+   * Turns a form wizard error into a human-readable message.
+   * Sub-classes can override this behaviour on a per-field basis by accessing error.field or error.key.
+   */
+  protected errorMessage(error: FormWizard.Error): string {
+    const errorMessage = this.errorMessages[error.type]
+    if (!errorMessage) {
+      throw new Error(`Error message not set for type “${error.type}” on controller ${this.constructor.name}`)
+    }
+    return errorMessage
+  }
+
+  /**
+   * Adds a human-readable message to errors if they are missing.
+   */
+  validateField(key: string, req: FormWizard.Request, res: Express.Response): FormWizard.Error | false | undefined {
+    const error = super.validateField(key, req, res)
+    if (error && !error.message) {
+      error.message = this.errorMessage(error)
+    }
+    return error
+  }
+}

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -7,6 +7,14 @@ import FormWizard from 'hmpo-form-wizard'
  */
 // eslint-disable-next-line import/prefer-default-export
 export abstract class BaseController extends FormWizard.Controller {
+  constructor(options: FormWizard.Options) {
+    if (!('defaultFormatters' in options)) {
+      // eslint-disable-next-line no-param-reassign
+      options.defaultFormatters = ['trim']
+    }
+    super(options)
+  }
+
   /**
    * Generic human-readable error messages for default form wizard validators.
    */

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -1,3 +1,3 @@
-import FormWizard from 'hmpo-form-wizard'
+import { BaseController } from '../index'
 
-export default class QuestionsController extends FormWizard.Controller {}
+export default class QuestionsController extends BaseController {}

--- a/server/views/pages/wip/questions/questionPage.njk
+++ b/server/views/pages/wip/questions/questionPage.njk
@@ -1,10 +1,7 @@
-{% extends "../../../partials/layout.njk" %}
+{% extends "partials/layout.njk" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-
-{% set title = "TODO: Test nunjucks template" %}
 
 {% block pageTitle %}
   TODO: Test nunjucks template
@@ -17,18 +14,6 @@
       href: backLink
     }) }}
   {% endif %}
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% if errorlist.length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: validationErrors,
-          classes: "govuk-!-margin-top-7 govuk-!-margin-bottom-0"
-        }) }}
-      {% endif %}
-    </div>
-  </div>
 {% endblock %}
 
 {% block content %}
@@ -38,6 +23,10 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% include "partials/errorSummary.njk" %}
+
+      {# TODO: page heading goes here, unless this is a 1-question page whose label is promoted to heading #}
+
       <form method="{{ formMethod }}" action="{{ formAction }}"
           {% if formEnctype %}
             enctype="{{ formEnctype }}"
@@ -75,12 +64,6 @@
           {% endblock %}
         </div>
       </form>
-
-      <p>
-        <a href="{{ cancelLink }}" class="govuk-link--no-visited-state">
-          Cancel
-        </a>
-      </p>
     </div>
   </div>
 

--- a/server/views/partials/errorSummary.njk
+++ b/server/views/partials/errorSummary.njk
@@ -1,0 +1,18 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{# NB: use with form wizard BaseController pages #}
+
+{% if errorlist.length %}
+  {% set errorSummaryItems = [] %}
+  {% for error in errorlist %}
+    {% set fieldHref %}#{{ error.field or error.key }}{% endset %}
+    {% set _ = errorSummaryItems.push({
+      text: error.message,
+      href: fieldHref
+    }) %}
+  {% endfor %}
+  {{ govukErrorSummary({
+    titleText: "There is a problem",
+    errorList: errorSummaryItems
+  }) }}
+{% endif %}

--- a/server/views/partials/formErrorSummary.njk
+++ b/server/views/partials/formErrorSummary.njk
@@ -1,5 +1,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
+{# NB: this does not work with form wizard, used with /server/forms #}
+
 {% if form and form.submitted and form.hasErrors %}
   {{ govukErrorSummary({
     titleText: "There is a problem",


### PR DESCRIPTION
Add an abstract form wizard controller that adds human-readable messages to errors if they're missing. The new “questions” wizard now extends it.