### PR TITLE
IR-548: Integration tests for basic create report journey

### DIFF
--- a/integration_tests/e2e/createReport.cy.ts
+++ b/integration_tests/e2e/createReport.cy.ts
@@ -23,6 +23,7 @@ context('Creating a new report', () => {
     cy.visit('/create-report')
 
     const typePage = Page.verifyOnPage(TypePage)
+    typePage.checkBackLink('/')
     typePage.selectType(reportWithDetails.type)
     typePage.submit()
 
@@ -43,6 +44,7 @@ context('Creating a new report', () => {
     cy.task('stubManageKnownUsers')
 
     const detailsPage = Page.verifyOnPage(DetailsPage)
+    typePage.checkBackLink('/create-report')
     detailsPage.enterDate(new Date(reportWithDetails.incidentDateAndTime))
     const time = /(?<hours>\d\d):(?<minutes>\d\d)/.exec(reportWithDetails.incidentDateAndTime)
     detailsPage.enterTime(time.groups.hours, time.groups.minutes)

--- a/integration_tests/e2e/createReport.cy.ts
+++ b/integration_tests/e2e/createReport.cy.ts
@@ -5,23 +5,23 @@ import TypePage from '../pages/createReport/type'
 import DetailsPage from '../pages/createReport/details'
 
 context('Creating a new report', () => {
+  const now = new Date()
+  const reportWithDetails = mockReport({
+    type: 'DAMAGE',
+    reportReference: '6544',
+    reportDateAndTime: now,
+    withDetails: true,
+  })
+
   beforeEach(() => {
     cy.resetBasicStubs()
+
+    cy.signIn()
+    // TODO: start on home page and click through to:
+    cy.visit('/create-report')
   })
 
   it('should allow entering the basic information', () => {
-    const now = new Date()
-    const reportWithDetails = mockReport({
-      type: 'DAMAGE',
-      reportReference: '6544',
-      reportDateAndTime: now,
-      withDetails: true,
-    })
-
-    cy.signIn()
-    // TODO: start on home page and navigate to:
-    cy.visit('/create-report')
-
     const typePage = Page.verifyOnPage(TypePage)
     typePage.checkBackLink('/')
     typePage.selectType(reportWithDetails.type)
@@ -50,5 +50,19 @@ context('Creating a new report', () => {
     detailsPage.enterTime(time.groups.hours, time.groups.minutes)
     detailsPage.enterDescription(reportWithDetails.description)
     detailsPage.submit()
+  })
+
+  it('should show errors if information is missing', () => {
+    const typePage = Page.verifyOnPage(TypePage)
+    typePage.submit()
+    typePage.errorSummary.contains('There is a problem')
+    typePage.selectType(reportWithDetails.type)
+    typePage.submit()
+
+    const detailsPage = Page.verifyOnPage(DetailsPage)
+    detailsPage.enterDescription(reportWithDetails.description)
+    detailsPage.submit()
+    detailsPage.errorSummary.contains('There is a problem')
+    Page.verifyOnPage(DetailsPage)
   })
 })

--- a/integration_tests/e2e/createReport.cy.ts
+++ b/integration_tests/e2e/createReport.cy.ts
@@ -1,0 +1,52 @@
+import { mockReport } from '../../server/data/testData/incidentReporting'
+import { andrew, barry } from '../../server/data/testData/offenderSearch'
+import Page from '../pages/page'
+import TypePage from '../pages/createReport/type'
+import DetailsPage from '../pages/createReport/details'
+
+context('Creating a new report', () => {
+  beforeEach(() => {
+    cy.resetBasicStubs()
+  })
+
+  it('should allow entering the basic information', () => {
+    const now = new Date()
+    const reportWithDetails = mockReport({
+      type: 'DAMAGE',
+      reportReference: '6544',
+      reportDateAndTime: now,
+      withDetails: true,
+    })
+
+    cy.signIn()
+    // TODO: start on home page and navigate to:
+    cy.visit('/create-report')
+
+    const typePage = Page.verifyOnPage(TypePage)
+    typePage.selectType(reportWithDetails.type)
+    typePage.submit()
+
+    cy.task('stubIncidentReportingApiCreateReport', {
+      request: {
+        type: reportWithDetails.type,
+        incidentDateAndTime: reportWithDetails.incidentDateAndTime,
+        prisonId: 'MDI',
+        title: 'Report: damage',
+        description: reportWithDetails.description,
+        createNewEvent: true,
+      },
+      report: reportWithDetails,
+    })
+    cy.task('stubIncidentReportingApiGetReportWithDetailsById', { report: reportWithDetails })
+    cy.task('stubOffenderSearchByNumber', [andrew, barry])
+    cy.task('stubPrisonApiMockPrisons')
+    cy.task('stubManageKnownUsers')
+
+    const detailsPage = Page.verifyOnPage(DetailsPage)
+    detailsPage.enterDate(new Date(reportWithDetails.incidentDateAndTime))
+    const time = /(?<hours>\d\d):(?<minutes>\d\d)/.exec(reportWithDetails.incidentDateAndTime)
+    detailsPage.enterTime(time.groups.hours, time.groups.minutes)
+    detailsPage.enterDescription(reportWithDetails.description)
+    detailsPage.submit()
+  })
+})

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -5,5 +5,10 @@ declare namespace Cypress {
      * @example cy.signIn({ failOnStatusCode: boolean })
      */
     signIn(options?: { failOnStatusCode: boolean }): Chainable<AUTWindow>
+
+    /**
+     * Set up stubs needed for all interactions
+     */
+    resetBasicStubs(options?: { roles?: string[] }): Chainable<AUTWindow>
   }
 }

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -108,7 +108,7 @@ const token = (roles: string[] = []) =>
       jsonBody: {
         access_token: createUserToken(roles),
         token_type: 'bearer',
-        user_name: 'USER1',
+        user_name: 'user1',
         expires_in: 599,
         scope: 'read,write',
         internalUser: true,

--- a/integration_tests/mockApis/incidentReportingApi.ts
+++ b/integration_tests/mockApis/incidentReportingApi.ts
@@ -1,8 +1,181 @@
 import type { SuperAgentRequest } from 'superagent'
 
 import { stubFor } from './wiremock'
+import type {
+  GetReportsParams,
+  PaginatedBasicReports,
+  ReportBasic,
+  ReportWithDetails,
+  CreateReportRequest,
+  UpdateReportRequest,
+  ChangeStatusRequest,
+  ChangeTypeRequest,
+} from '../../server/data/incidentReportingApi'
+import { defaultPageSize } from '../../server/data/incidentReportingApi'
 
 export default {
+  stubIncidentReportingApiGetReports: ({
+    request,
+    reports,
+  }: {
+    request: Partial<DatesAsStrings<GetReportsParams>>
+    reports: ReportBasic[]
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: '/incidentReportingApi/incident-reports',
+        queryParameters: request,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          content: reports,
+          number: 0,
+          size: defaultPageSize,
+          numberOfElements: reports.length,
+          totalElements: reports.length,
+          totalPages: 1,
+          sort: ['incidentDateAndTime,DESC'],
+        } satisfies PaginatedBasicReports,
+      },
+    }),
+
+  stubIncidentReportingApiGetReportById: ({ report }: { report: ReportBasic }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `/incidentReportingApi/incident-reports/${report.id}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: report,
+      },
+    }),
+  stubIncidentReportingApiGetReportWithDetailsById: ({ report }: { report: ReportWithDetails }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `/incidentReportingApi/incident-reports/${report.id}/with-details`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: report,
+      },
+    }),
+
+  stubIncidentReportingApiGetReportByReference: ({ report }: { report: ReportBasic }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `/incidentReportingApi/incident-reports/reference/${report.reportReference}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: report,
+      },
+    }),
+  stubIncidentReportingApiGetReportWithDetailsByReference: ({
+    report,
+  }: {
+    report: ReportWithDetails
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `/incidentReportingApi/incident-reports/reference/${report.reportReference}/with-details`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: report,
+      },
+    }),
+
+  stubIncidentReportingApiCreateReport: ({
+    request,
+    report,
+  }: {
+    request: DatesAsStrings<CreateReportRequest>
+    report: ReportWithDetails
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        urlPath: '/incidentReportingApi/incident-reports',
+        bodyPatterns: [{ equalToJson: request }],
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: report,
+      },
+    }),
+
+  stubIncidentReportingApiUpdateReport: ({
+    request,
+    report,
+  }: {
+    request: DatesAsStrings<UpdateReportRequest>
+    report: ReportWithDetails
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'PATCH',
+        urlPath: `/incidentReportingApi/incident-reports/${report.id}`,
+        bodyPatterns: [{ equalToJson: request }],
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: report,
+      },
+    }),
+
+  stubIncidentReportingApiChangeReportStatus: ({
+    request,
+    report,
+  }: {
+    request: ChangeStatusRequest
+    report: ReportWithDetails
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'PATCH',
+        urlPath: `/incidentReportingApi/incident-reports/${report.id}/status`,
+        bodyPatterns: [{ equalToJson: request }],
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: report,
+      },
+    }),
+
+  stubIncidentReportingApiChangeReportType: ({
+    request,
+    report,
+  }: {
+    request: ChangeTypeRequest
+    report: ReportWithDetails
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'PATCH',
+        urlPath: `/incidentReportingApi/incident-reports/${report.id}/type`,
+        bodyPatterns: [{ equalToJson: request }],
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: report,
+      },
+    }),
+
   stubIncidentReportingApiPing: (): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -1,7 +1,8 @@
-import type { SuperAgentRequest } from 'superagent'
+import type { Response as SuperAgentResponse, SuperAgentRequest } from 'superagent'
 
 import { stubFor } from './wiremock'
-import { mockUser } from '../../server/data/testData/manageUsers'
+import { mockUser, mockSharedUser } from '../../server/data/testData/manageUsers'
+import { staffBarry, staffMary } from '../../server/data/testData/prisonApi'
 
 export default {
   /** Current user */
@@ -20,24 +21,27 @@ export default {
       },
     }),
 
-  /** Another user, looked up by username */
-  stubManageUserNamed: ({
-    username = 'jsmith',
-    name = 'john smith',
-  }: { username?: string; name?: string } = {}): SuperAgentRequest =>
-    stubFor({
-      request: {
-        method: 'GET',
-        urlPath: `/manage-users-api/users/${encodeURIComponent(username)}`,
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        jsonBody: mockUser(username, name),
-      },
-    }),
+  /** Add all known users from test data */
+  stubManageKnownUsers: (
+    users: { username: string; name?: string }[] = [mockSharedUser, staffBarry, staffMary],
+  ): Promise<SuperAgentResponse[]> =>
+    Promise.all(
+      users.map(user =>
+        stubFor({
+          request: {
+            method: 'GET',
+            urlPath: `/manage-users-api/users/${encodeURIComponent(user.username)}`,
+          },
+          response: {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json;charset=UTF-8',
+            },
+            jsonBody: mockUser(user.username, user.name),
+          },
+        }),
+      ),
+    ),
 
   stubManageUsersPing: (): SuperAgentRequest =>
     stubFor({

--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -1,11 +1,11 @@
 import type { SuperAgentRequest } from 'superagent'
 
 import { stubFor } from './wiremock'
-import type { User } from '../../server/data/manageUsersApiClient'
+import { mockUser } from '../../server/data/testData/manageUsers'
 
 export default {
   /** Current user */
-  stubManageUserMe: (name: string = 'john smith'): SuperAgentRequest =>
+  stubManageUserMe: (name: string = 'John Smith'): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
@@ -16,17 +16,15 @@ export default {
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },
-        jsonBody: {
-          staffId: 231232,
-          username: 'USER1',
-          active: true,
-          name,
-        } satisfies User,
+        jsonBody: mockUser('user1', name),
       },
     }),
 
   /** Another user, looked up by username */
-  stubManageUserNamed: (username: string = 'jsmith', name: string = 'john smith'): SuperAgentRequest =>
+  stubManageUserNamed: ({
+    username = 'jsmith',
+    name = 'john smith',
+  }: { username?: string; name?: string } = {}): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
@@ -37,12 +35,7 @@ export default {
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },
-        jsonBody: {
-          staffId: 231232,
-          username: 'USER1',
-          active: true,
-          name,
-        } satisfies User,
+        jsonBody: mockUser(username, name),
       },
     }),
 

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -8,12 +8,11 @@ const wiremockAdminUrl = 'http://localhost:9091/__admin'
  */
 export interface Mapping {
   request?: Partial<
-    { method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'; queryParameters: object } & (
-      | { url: string }
-      | { urlPath: string }
-      | { urlPathPattern: string }
-      | { urlPattern: string }
-    )
+    {
+      method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+      queryParameters: object
+      bodyPatterns: { equalToJson: unknown }[]
+    } & ({ url: string } | { urlPath: string } | { urlPathPattern: string } | { urlPattern: string })
   >
   response?: Partial<
     {

--- a/integration_tests/pages/createReport/details.ts
+++ b/integration_tests/pages/createReport/details.ts
@@ -1,0 +1,26 @@
+import format from '../../../server/utils/format'
+import FormWizardPage from '../formWizard'
+
+export default class DetailsPage extends FormWizardPage {
+  constructor() {
+    super('Incident details')
+  }
+
+  enterDate(date: Date | string): void {
+    const value = date instanceof Date ? format.shortDate(date) : date
+    this.dateInput('incidentDate').type(value)
+  }
+
+  enterTime(hours: string, minutes: string): void {
+    this.timeInput('incidentTime', 'hours').type(hours)
+    this.timeInput('incidentTime', 'minutes').type(minutes)
+  }
+
+  enterDescription(description: string): void {
+    this.textareaInput('description').type(description)
+  }
+
+  submit(): void {
+    this.saveButton().click()
+  }
+}

--- a/integration_tests/pages/createReport/type.ts
+++ b/integration_tests/pages/createReport/type.ts
@@ -1,0 +1,16 @@
+import { type Type, getTypeDetails } from '../../../server/reportConfiguration/constants'
+import FormWizardPage from '../formWizard'
+
+export default class TypePage extends FormWizardPage {
+  constructor() {
+    super('Select incident type')
+  }
+
+  selectType(type: Type) {
+    this.radioOrCheckboxButton('type', getTypeDetails(type).description).click()
+  }
+
+  submit(): void {
+    this.saveButton('Continue').click()
+  }
+}

--- a/integration_tests/pages/formWizard.ts
+++ b/integration_tests/pages/formWizard.ts
@@ -1,0 +1,63 @@
+import Page, { type PageElement } from './page'
+
+export default abstract class FormWizardPage extends Page {
+  /**
+   * Find the form on a form wizard layout page
+   */
+  protected get form(): PageElement<HTMLFormElement> {
+    return cy.get('form#form-wizard')
+  }
+
+  private findFormInput<T extends HTMLElement>(name: string): PageElement<T> {
+    return this.form.find<T>(`[name="${name}"]`)
+  }
+
+  /**
+   * Find a regular text input box by name
+   */
+  protected textInput(name: string): PageElement<HTMLInputElement> {
+    return this.findFormInput<HTMLInputElement>(name).should('have.class', 'govuk-input')
+  }
+
+  /**
+   * Find a text input box with a date picker by name
+   */
+  protected dateInput(name: string): PageElement<HTMLInputElement> {
+    return this.findFormInput<HTMLInputElement>(name).should('have.class', 'moj-js-datepicker-input')
+  }
+
+  /**
+   * Find one of the text input boxes for time input by name
+   */
+  protected timeInput(name: string, part: 'hours' | 'minutes'): PageElement<HTMLInputElement> {
+    return this.findFormInput<HTMLInputElement>(`_${name}-${part}`).should('have.class', 'govuk-date-input__input')
+  }
+
+  /**
+   * Find a textarea box by name
+   */
+  protected textareaInput(name: string): PageElement<HTMLTextAreaElement> {
+    return this.findFormInput<HTMLTextAreaElement>(name).should('have.class', 'govuk-textarea')
+  }
+
+  /**
+   * Find a select input by name
+   */
+  protected selectInput(name: string): PageElement<HTMLSelectElement> {
+    return this.findFormInput<HTMLSelectElement>(name).should('have.class', 'govuk-select')
+  }
+
+  /**
+   * Find the label for a radio or checkbox button
+   */
+  protected radioOrCheckboxButton(name: string, label: string): PageElement<HTMLLabelElement> {
+    return this.form.find(`#${name}`).find<HTMLLabelElement>('label').contains(label)
+  }
+
+  /**
+   * Find a save button by label
+   */
+  protected saveButton(label = 'Save and continue'): PageElement<HTMLButtonElement> {
+    return this.form.find<HTMLButtonElement>('.govuk-button').contains(label)
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -38,6 +38,10 @@ export default abstract class Page {
     return cy.get<HTMLAnchorElement>('.govuk-back-link').should('have.attr', 'href', url)
   }
 
+  get errorSummary(): PageElement<HTMLDivElement> {
+    return cy.get('.govuk-error-summary')
+  }
+
   get footer(): PageElement {
     return cy.get('.govuk-footer')
   }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -25,6 +25,19 @@ export default abstract class Page {
     return cy.get('[data-qa=manageDetails]')
   }
 
+  get breadcrumbs(): PageElement<HTMLDivElement> {
+    return cy.get('.govuk-breadcrumbs__list-item')
+  }
+
+  checkLastBreadcrumb(label: string, url?: string): void {
+    this.breadcrumbs.last().should('contain.text', label)
+    this.breadcrumbs.last().find('a').should('have.attr', 'href', url)
+  }
+
+  checkBackLink(url: string): PageElement<HTMLAnchorElement> {
+    return cy.get<HTMLAnchorElement>('.govuk-back-link').should('have.attr', 'href', url)
+  }
+
   get footer(): PageElement {
     return cy.get('.govuk-footer')
   }

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -2,3 +2,10 @@ Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
   cy.request('/')
   return cy.task('getSignInUrl').then((url: string) => cy.visit(url, options))
 })
+
+Cypress.Commands.add('resetBasicStubs', ({ roles = [] }: { roles?: string[] } = {}) => {
+  cy.task('resetStubs')
+  cy.task('stubSignIn', roles)
+  cy.task('stubManageUserMe')
+  cy.task('stubFallbackHeaderAndFooter')
+})

--- a/server/@types/hmpo-form-wizard/index.d.ts
+++ b/server/@types/hmpo-form-wizard/index.d.ts
@@ -215,7 +215,6 @@ declare module 'hmpo-form-wizard' {
     type Fields<V extends object = Values> = Record<keyof V, Field>
 
     /** Type helper to extract a concrete narrowed Values extension from a fields object which has no type annotation */
-    // type ValuesFromFields<F extends Fields> = Record<keyof F, string>
     type ValuesFromFields<F extends Fields> = {
       [k in keyof F]: F[k] extends { multiple: true } ? string[] : string
     }

--- a/server/@types/hmpo-form-wizard/index.d.ts
+++ b/server/@types/hmpo-form-wizard/index.d.ts
@@ -189,7 +189,7 @@ declare module 'hmpo-form-wizard' {
                 fn: Validator
               }
           )[]
-      /** Array of select box or radio button options */
+      /** Array of select, checkbox or radio button options */
       items?: FieldItem[]
       /** Name of field to make this field conditional upon. This field will not be validated or stored if this condition is not met. Can also also be an object to specify a specific value instead of the default of true: */
       dependent?:

--- a/server/@types/hmpo-form-wizard/index.d.ts
+++ b/server/@types/hmpo-form-wizard/index.d.ts
@@ -214,6 +214,12 @@ declare module 'hmpo-form-wizard' {
     /** Definition of fields in a form across all steps */
     type Fields<V extends object = Values> = Record<keyof V, Field>
 
+    /** Type helper to extract a concrete narrowed Values extension from a fields object which has no type annotation */
+    // type ValuesFromFields<F extends Fields> = Record<keyof F, string>
+    type ValuesFromFields<F extends Fields> = {
+      [k in keyof F]: F[k] extends { multiple: true } ? string[] : string
+    }
+
     /** Base configuration for all steps */
     interface Config<V extends object = Values> extends Step<V> {
       name?: string

--- a/server/@types/hmpo-form-wizard/index.test.ts
+++ b/server/@types/hmpo-form-wizard/index.test.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable no-empty-function */
+
+// eslint-disable-next-line max-classes-per-file
+import type Express from 'express'
+import FormWizard from 'hmpo-form-wizard'
+
+// NB: fields defition must not have a type annotation! but it's helpful to ensure it satisfies the fields requirement
+const fields = {
+  name: {},
+  emails: { multiple: true },
+} satisfies FormWizard.Fields
+
+// the type of values handled by the form wizard can be derived
+type Values = FormWizard.ValuesFromFields<typeof fields>
+
+it('Deriving controller values type', () => {
+  // controller for a step which only deals with the `name` field (not `emails`)
+  class TypedController1 extends FormWizard.Controller<Values, 'name'> {
+    saveValues(req: FormWizard.Request<Values, 'name'>, res: Express.Response, next: Express.NextFunction): void {
+      // `name` exists in this step as derived by FormWizard.ValuesFromFields
+      // `name` must be a string value otherwise the next line would fail type checking
+      mustBeString(req.form.values.name)
+
+      // `emails` cannot exist on this step so expect an error
+      // @ts-expect-error if `emails` existed, the next line would fail type checking
+      mustNotExist(req.form.values.emails)
+
+      super.saveValues(req, res, next)
+    }
+  }
+
+  // controller for a step which only deals with the `emails` field (not `name`)
+  class TypedController2 extends FormWizard.Controller<Values, 'emails'> {
+    saveValues(req: FormWizard.Request<Values, 'emails'>, res: Express.Response, next: Express.NextFunction): void {
+      // `emails` exists in this step as derived by FormWizard.ValuesFromFields
+      // `emails` must be a string array value otherwise the next line would fail type checking
+      mustBeStringArray(req.form.values.emails)
+
+      // `name` cannot exist on this step so expect an error
+      // @ts-expect-error if `name` existed, the next line would fail type checking
+      mustNotExist(req.form.values.name)
+
+      super.saveValues(req, res, next)
+    }
+  }
+
+  function mustBeString(_value: string): void {}
+
+  function mustBeStringArray(_values: string[]): void {}
+
+  function mustNotExist(_nothing: never): void {}
+})

--- a/server/data/incidentReportingApi.test.ts
+++ b/server/data/incidentReportingApi.test.ts
@@ -136,7 +136,7 @@ describe('Incident reporting API client', () => {
         testCase: () =>
           apiClient.staffInvolved.addToReport(reportWithDetails.id, {
             staffRole: 'ACTIVELY_INVOLVED',
-            staffUsername: 'staff-1',
+            staffUsername: 'abc12a',
           }),
       },
       {
@@ -146,7 +146,7 @@ describe('Incident reporting API client', () => {
         testCase: () =>
           apiClient.staffInvolved.updateForReport(reportWithDetails.id, 1, {
             staffRole: 'ACTIVELY_INVOLVED',
-            staffUsername: 'staff-1',
+            staffUsername: 'abc12a',
           }),
       },
       {
@@ -593,18 +593,18 @@ describe('Incident reporting API client', () => {
         testCaseAbsentFields: () =>
           apiClient.staffInvolved.updateForReport(reportWithDetails.id, 2, {
             staffRole: 'ACTIVELY_INVOLVED',
-            staffUsername: 'staff-1',
+            staffUsername: 'abc12a',
           }),
         testCaseNullFields: () =>
           apiClient.staffInvolved.updateForReport(reportWithDetails.id, 2, {
             staffRole: 'ACTIVELY_INVOLVED',
-            staffUsername: 'staff-1',
+            staffUsername: 'abc12a',
             comment: null,
           }),
         testCaseNonNullFields: () =>
           apiClient.staffInvolved.updateForReport(reportWithDetails.id, 2, {
             staffRole: 'ACTIVELY_INVOLVED',
-            staffUsername: 'staff-1',
+            staffUsername: 'abc12a',
             comment: 'Staff member helped calm the situation',
           }),
       },

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -379,7 +379,7 @@ export class IncidentReportingApi extends RestClient {
   async createReport(data: CreateReportRequest): Promise<ReportWithDetails> {
     const dataWithDatesAsStrings: DatesAsStrings<CreateReportRequest> = {
       ...data,
-      incidentDateAndTime: data.incidentDateAndTime.toISOString(),
+      incidentDateAndTime: format.isoDateTime(data.incidentDateAndTime),
     }
     const report = await this.post<DatesAsStrings<ReportWithDetails>>({
       path: '/incident-reports',
@@ -391,7 +391,7 @@ export class IncidentReportingApi extends RestClient {
   async updateReport(id: string, data: UpdateReportRequest): Promise<ReportBasic> {
     const dataWithDatesAsStrings: DatesAsStrings<UpdateReportRequest> = {
       ...data,
-      incidentDateAndTime: data.incidentDateAndTime?.toISOString(),
+      incidentDateAndTime: format.isoDateTime(data.incidentDateAndTime),
     }
     const report = await this.patch<DatesAsStrings<ReportBasic>>({
       path: `/incident-reports/${encodeURIComponent(id)}`,
@@ -459,7 +459,7 @@ export class IncidentReportingApi extends RestClient {
       ...questionWithResponses,
       responses: questionWithResponses.responses.map(response => ({
         ...response,
-        responseDate: response.responseDate?.toISOString(),
+        responseDate: format.isoDateTime(response.responseDate),
       })),
     }
     const questions = await this.post<DatesAsStrings<Question[]>>({

--- a/server/data/incidentReportingApiUtils.test.ts
+++ b/server/data/incidentReportingApiUtils.test.ts
@@ -10,8 +10,8 @@ import {
 describe('Parsing dates in incident-reporting API responses', () => {
   // now, when incident was reported: 2023-12-05T12:34:56.000Z
   const reportDateAndTime = new Date(2023, 11, 5, 12, 34, 56)
-  // actual incident happened 1 hour before: 2023-12-05T11:34:56.000Z
-  const incidentDateAndTime = new Date(2023, 11, 5, 11, 34, 56)
+  // actual incident happened 1 hour before: 2023-12-05T11:34:00.000Z (NB: seconds are truncated to mimic designs)
+  const incidentDateAndTime = new Date(2023, 11, 5, 11, 34, 0)
 
   function expectCorrectDatesInEvent(event: Event) {
     expect(event.eventDateAndTime).toEqual(incidentDateAndTime)

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -28,7 +28,7 @@ export function mockEvent({
   eventReference,
   reportDateAndTime,
   prisonId = 'MDI',
-  reportingUsername = 'USER1',
+  reportingUsername = 'user1',
   includeReports = 0,
 }: MockEventConfig & { includeReports?: number }): DatesAsStrings<Event | EventWithBasicReports> {
   const incidentDateAndTime = new Date(reportDateAndTime)
@@ -77,7 +77,7 @@ export function mockReport({
   createdInNomis = false,
   status = 'DRAFT',
   type = 'FINDS',
-  reportingUsername = 'USER1',
+  reportingUsername = 'user1',
   withDetails = false,
 }: MockReportConfig & { withDetails?: boolean }): DatesAsStrings<ReportBasic | ReportWithDetails> {
   const incidentDateAndTime = new Date(reportDateAndTime)

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -34,6 +34,8 @@ export function mockEvent({
 }: MockEventConfig & { includeReports?: number }): DatesAsStrings<Event | EventWithBasicReports> {
   const incidentDateAndTime = new Date(reportDateAndTime)
   incidentDateAndTime.setHours(incidentDateAndTime.getHours() - 1)
+  incidentDateAndTime.setSeconds(0)
+  incidentDateAndTime.setMilliseconds(0)
 
   const event: DatesAsStrings<Event> = {
     id: uuidFromDate({ msecs: reportDateAndTime }),
@@ -83,6 +85,8 @@ export function mockReport({
 }: MockReportConfig & { withDetails?: boolean }): DatesAsStrings<ReportBasic | ReportWithDetails> {
   const incidentDateAndTime = new Date(reportDateAndTime)
   incidentDateAndTime.setHours(incidentDateAndTime.getHours() - 1)
+  incidentDateAndTime.setSeconds(0)
+  incidentDateAndTime.setMilliseconds(0)
 
   const basicReport: DatesAsStrings<ReportBasic> = {
     id: uuidFromDate({ msecs: reportDateAndTime }),

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -14,6 +14,7 @@ import type {
   CorrectionRequest,
   Question,
 } from '../incidentReportingApi'
+import { staffBarry, staffMary } from './prisonApi'
 
 interface MockEventConfig {
   eventReference: string
@@ -143,13 +144,13 @@ export function mockStaffInvolvement(index: number): DatesAsStrings<StaffInvolve
   switch (index) {
     case 0:
       return {
-        staffUsername: 'staff-1',
+        staffUsername: staffMary.username,
         staffRole: 'ACTIVELY_INVOLVED',
-        comment: 'Comment about staff-1',
+        comment: 'Comment about Mary',
       }
     case 1:
       return {
-        staffUsername: 'staff-2',
+        staffUsername: staffBarry.username,
         staffRole: 'PRESENT_AT_SCENE',
         comment: null,
       }

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -1,5 +1,6 @@
 import { v7 as uuidFromDate } from 'uuid'
 
+import format from '../../utils/format'
 import { buildArray } from '../../utils/utils'
 import type { ErrorCode, Status, Type } from '../../reportConfiguration/constants'
 import type {
@@ -36,12 +37,12 @@ export function mockEvent({
   const event: DatesAsStrings<Event> = {
     id: uuidFromDate({ msecs: reportDateAndTime }),
     eventReference,
-    eventDateAndTime: incidentDateAndTime.toISOString(),
+    eventDateAndTime: format.isoDateTime(incidentDateAndTime),
     prisonId,
     title: 'An event occurred',
     description: 'Details of the event',
-    createdAt: reportDateAndTime.toISOString(),
-    modifiedAt: reportDateAndTime.toISOString(),
+    createdAt: format.isoDateTime(reportDateAndTime),
+    modifiedAt: format.isoDateTime(reportDateAndTime),
     modifiedBy: reportingUsername,
   }
 
@@ -86,16 +87,16 @@ export function mockReport({
     id: uuidFromDate({ msecs: reportDateAndTime }),
     reportReference,
     type,
-    incidentDateAndTime: incidentDateAndTime.toISOString(),
+    incidentDateAndTime: format.isoDateTime(incidentDateAndTime),
     prisonId,
     title: `Incident Report ${reportReference}`,
     description: `A new incident created in the new service of type ${type}`,
     reportedBy: reportingUsername,
-    reportedAt: reportDateAndTime.toISOString(),
+    reportedAt: format.isoDateTime(reportDateAndTime),
     status,
     assignedTo: reportingUsername,
-    createdAt: reportDateAndTime.toISOString(),
-    modifiedAt: reportDateAndTime.toISOString(),
+    createdAt: format.isoDateTime(reportDateAndTime),
+    modifiedAt: format.isoDateTime(reportDateAndTime),
     modifiedBy: reportingUsername,
     createdInNomis,
   }
@@ -107,7 +108,7 @@ export function mockReport({
       historyOfStatuses: [
         {
           status,
-          changedAt: reportDateAndTime.toISOString(),
+          changedAt: format.isoDateTime(reportDateAndTime),
           changedBy: reportingUsername,
         },
       ],
@@ -117,7 +118,7 @@ export function mockReport({
       questions: buildArray(2, questionIndex => mockQuestion(questionIndex, reportDateAndTime, 2)),
       history: buildArray(2, () => ({
         type: 'MISCELLANEOUS',
-        changedAt: reportDateAndTime.toISOString(),
+        changedAt: format.isoDateTime(reportDateAndTime),
         changedBy: 'some-user-2',
         questions: buildArray(2, questionIndex => ({
           code: `QID-${(questionIndex + 1).toString().padStart(12, '0')}`,
@@ -125,10 +126,10 @@ export function mockReport({
           additionalInformation: '',
           responses: buildArray(2, responseIndex => ({
             response: `Historic response #${responseIndex + 1}`,
-            responseDate: reportDateAndTime.toISOString(),
+            responseDate: format.isoDateTime(reportDateAndTime),
             additionalInformation: `Historic comment #${responseIndex + 1}`,
             recordedBy: 'some-user-2',
-            recordedAt: reportDateAndTime.toISOString(),
+            recordedAt: format.isoDateTime(reportDateAndTime),
           })),
         })),
       })),
@@ -185,14 +186,14 @@ export function mockCorrectionRequest(index: number, correctionRequestedAt: Date
         reason: 'NOT_SPECIFIED',
         descriptionOfChange: 'Please amend question 2',
         correctionRequestedBy: 'USER2',
-        correctionRequestedAt: correctionRequestedAt.toISOString(),
+        correctionRequestedAt: format.isoDateTime(correctionRequestedAt),
       }
     case 1:
       return {
         reason: 'MISTAKE',
         descriptionOfChange: 'Name misspelled',
         correctionRequestedBy: 'USER2',
-        correctionRequestedAt: correctionRequestedAt.toISOString(),
+        correctionRequestedAt: format.isoDateTime(correctionRequestedAt),
       }
     default:
       throw new Error('not implemented')
@@ -210,9 +211,9 @@ export function mockQuestion(
     additionalInformation: `Explanation #${questionIndex + 1}`,
     responses: buildArray(numberOfResponses, responseIndex => ({
       response: `Response #${responseIndex + 1}`,
-      responseDate: responseDate.toISOString(),
+      responseDate: format.isoDateTime(responseDate),
       recordedBy: 'some-user',
-      recordedAt: responseDate.toISOString(),
+      recordedAt: format.isoDateTime(responseDate),
       additionalInformation: `comment #${responseIndex + 1}`,
     })),
   }

--- a/server/data/testData/manageUsers.ts
+++ b/server/data/testData/manageUsers.ts
@@ -1,0 +1,13 @@
+import type { User } from '../manageUsersApiClient'
+
+export function mockUser(username: string, name: string): User {
+  return {
+    staffId: 231232,
+    username,
+    active: true,
+    name,
+  }
+}
+
+/** The user who is performing actions during testing */
+export const mockSharedUser: User = mockUser('user1', 'John Smith')

--- a/server/routes/reports/createReport.test.ts
+++ b/server/routes/reports/createReport.test.ts
@@ -3,9 +3,9 @@ import request, { type Agent, type Response } from 'supertest'
 
 import format from '../../utils/format'
 import { appWithAllRoutes } from '../testutils/appSetup'
-import { type ErrorResponse, IncidentReportingApi } from '../../data/incidentReportingApi'
+import { IncidentReportingApi } from '../../data/incidentReportingApi'
 import { convertReportWithDetailsDates } from '../../data/incidentReportingApiUtils'
-import { mockReport } from '../../data/testData/incidentReporting'
+import { mockErrorResponse, mockReport } from '../../data/testData/incidentReporting'
 import { mockThrownError } from '../../data/testData/thrownErrors'
 
 jest.mock('../../data/incidentReportingApi')
@@ -257,11 +257,7 @@ describe('Creating a report', () => {
     })
 
     it('should show an error if API rejects request', () => {
-      const error = mockThrownError({
-        status: 400,
-        userMessage: 'Description is too short',
-        developerMessage: 'Description is too short',
-      } satisfies ErrorResponse)
+      const error = mockThrownError(mockErrorResponse({ message: 'Description is too short' }))
       incidentReportingApi.createReport.mockRejectedValueOnce(error)
 
       return agent

--- a/server/routes/reports/createReport.test.ts
+++ b/server/routes/reports/createReport.test.ts
@@ -221,7 +221,7 @@ describe('Creating a report', () => {
         })
     })
 
-    it('should send request to API if form is valid', async () => {
+    it('should send request to API if form is valid and proceed to next step', async () => {
       const reportWithDetails = convertReportWithDetailsDates(
         mockReport({
           reportReference: '6544',
@@ -254,6 +254,28 @@ describe('Creating a report', () => {
         // TODO: ideally, test would go to /create-report/details and be redirected,
         //       but throws “Missing prereq for this step” instead
       })
+    })
+
+    it('should send request to API if form is valid and return to home page is user chose to exit', () => {
+      const reportWithDetails = convertReportWithDetailsDates(
+        mockReport({
+          reportReference: '6544',
+          reportDateAndTime: incidentDateAndTime,
+          withDetails: true,
+        }),
+      )
+      incidentReportingApi.createReport.mockResolvedValueOnce(reportWithDetails)
+
+      return agent
+        .post('/create-report/details')
+        .send({ ...validPayload, submit: 'exit' })
+        .redirects(0)
+        .expect(302)
+        .expect(res => {
+          expect(res.redirect).toBeTruthy()
+          expect(res.header.location).toEqual('/')
+          expect(incidentReportingApi.createReport).toHaveBeenCalled()
+        })
     })
 
     it('should show an error if API rejects request', () => {

--- a/server/routes/reports/createReport.ts
+++ b/server/routes/reports/createReport.ts
@@ -202,11 +202,20 @@ class Step2Controller extends BaseController<CreateReport, Step2> {
   }
 
   getNextStep(req: FormWizard.Request<CreateReport, Step2>, res: Express.Response): string | undefined {
-    // if a report was successfully created, redirect to it
-    if ('createdReport' in res.locals && res.locals.createdReport) {
+    // if a report was successfully created…
+    if (res.locals.createdReport) {
       const report: ReportWithDetails = res.locals.createdReport
+
+      // …return to home page is user chose to exit
+      if (req.body.submit === 'exit') {
+        return '/'
+      }
+
+      // …or proceed with filling in the report if they chose to continue
+      // TODO: this should go to staff/prisoner involvements once that's designed
       return `/reports/${report.id}`
     }
+
     // otherwise let form wizard decide where to go next
     return super.getNextStep(req, res)
   }

--- a/server/routes/reports/createReport.ts
+++ b/server/routes/reports/createReport.ts
@@ -58,7 +58,7 @@ const fields = {
   },
 } satisfies FormWizard.Fields
 
-interface CreateReport extends Record<keyof typeof fields, string> {
+type CreateReport = FormWizard.ValuesFromFields<typeof fields> & {
   type: Type
 }
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -16,11 +16,11 @@ import { OffenderSearchApi } from '../../data/offenderSearchApi'
 import { PrisonApi } from '../../data/prisonApi'
 
 export const user: Express.User = {
-  name: 'FIRST LAST',
+  name: 'JOHN SMITH',
   userId: 'id',
   token: 'token',
   username: 'user1',
-  displayName: 'First Last',
+  displayName: 'John Smith',
   active: true,
   activeCaseLoadId: 'MDI',
   authSource: 'NOMIS',

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -16,7 +16,7 @@ describe('User service', () => {
 
     it('Retrieves and formats user name', async () => {
       const token = createUserToken([])
-      manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
+      manageUsersApiClient.getUser.mockResolvedValue({ name: 'John Smith' } as User)
 
       const result = await userService.getUser(token)
 
@@ -25,7 +25,7 @@ describe('User service', () => {
 
     it('Retrieves and formats roles', async () => {
       const token = createUserToken(['ROLE_ONE', 'ROLE_TWO'])
-      manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
+      manageUsersApiClient.getUser.mockResolvedValue({ name: 'John Smith' } as User)
 
       const result = await userService.getUser(token)
 

--- a/server/utils/format.test.ts
+++ b/server/utils/format.test.ts
@@ -128,16 +128,24 @@ describe('time(): Formats dates as time in Europe/London', () => {
   })
 })
 
-describe('isoDate(): Formats dates in ISO style, used when calling APIs', () => {
+describe('isoDate(): Formats dates in Europe/London ISO style, used when calling APIs', () => {
   it.each([
     ['2024-07-30T12:34:56', '2024-07-30'],
     ['2024-07-30T12:34:56Z', '2024-07-30'],
     ['2024-07-30T12:34:56+01:00', '2024-07-30'],
+
+    // near DST switch
+    ['2021-10-30T23:59:59Z', '2021-10-31'],
+    ['2021-10-31T00:00:00Z', '2021-10-31'],
+    ['2021-10-31T00:00:01Z', '2021-10-31'],
+    ['2021-10-31T00:59:59Z', '2021-10-31'],
+    ['2021-10-31T01:00:00Z', '2021-10-31'],
+    ['2021-10-31T01:00:01Z', '2021-10-31'],
   ])('new Date(%s) formats as %s in ISO date style', (date, expected) => {
     expect(format.isoDate(new Date(date))).toEqual(expected)
   })
 
   it.each([null, undefined])('preserves %s', input => {
-    expect(format.isoDate(input)).toEqual(input)
+    expect(format.isoDate(input)).toStrictEqual(input)
   })
 })

--- a/server/utils/format.test.ts
+++ b/server/utils/format.test.ts
@@ -149,3 +149,25 @@ describe('isoDate(): Formats dates in Europe/London ISO style, used when calling
     expect(format.isoDate(input)).toStrictEqual(input)
   })
 })
+
+describe('isoDateTime(): Formats dates with time-of-day in Europe/London ISO style, used when calling APIs', () => {
+  it.each([
+    ['2024-07-30T12:34:56', '2024-07-30T12:34:56'],
+    ['2024-07-30T12:34:56Z', '2024-07-30T13:34:56'],
+    ['2024-07-30T12:34:56+01:00', '2024-07-30T12:34:56'],
+
+    // near DST switch
+    ['2021-10-30T23:59:59Z', '2021-10-31T00:59:59'],
+    ['2021-10-31T00:00:00Z', '2021-10-31T01:00:00'],
+    ['2021-10-31T00:00:01Z', '2021-10-31T01:00:01'],
+    ['2021-10-31T00:59:59Z', '2021-10-31T01:59:59'],
+    ['2021-10-31T01:00:00Z', '2021-10-31T01:00:00'],
+    ['2021-10-31T01:00:01Z', '2021-10-31T01:00:01'],
+  ])('new Date(%s) formats as %s in ISO date style', (date, expected) => {
+    expect(format.isoDateTime(new Date(date))).toEqual(expected)
+  })
+
+  it.each([null, undefined])('preserves %s', input => {
+    expect(format.isoDateTime(input)).toStrictEqual(input)
+  })
+})

--- a/server/utils/format.ts
+++ b/server/utils/format.ts
@@ -71,11 +71,18 @@ export default {
   },
 
   /**
-   * Formats dates in ISO style, used when calling APIs
+   * Formats dates in Europe/London ISO style, used when calling APIs
    *
    * Example: `2024-07-30`
    */
   isoDate(date: Date): string {
-    return date && date.toISOString().split('T')[0]
+    if (!(date instanceof Date)) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore just in case value is not a Date
+      return date
+    }
+    const shortDate: string = this.shortDate(date)
+    const [day, month, year] = shortDate.split('/')
+    return `${year}-${month}-${day}`
   },
 }

--- a/server/utils/format.ts
+++ b/server/utils/format.ts
@@ -1,6 +1,6 @@
 export default {
   /**
-   * Format Date as Europe/London including time of day
+   * Format Date as Europe/London including time of day.
    *
    * Example: `22 February 2022, 11:00`
    */
@@ -21,7 +21,7 @@ export default {
   },
 
   /**
-   * Format Date as Europe/London ignoring time-of-day
+   * Format Date as Europe/London ignoring time-of-day.
    *
    * Example: `22 February 2022`
    */
@@ -38,7 +38,7 @@ export default {
   },
 
   /**
-   * Format Date as Europe/London ignoring time-of-day
+   * Format Date as Europe/London ignoring time-of-day.
    *
    * Example: `22/02/2022`
    */
@@ -55,7 +55,7 @@ export default {
   },
 
   /**
-   * Format Date as time in Europe/London
+   * Format Date as time in Europe/London.
    *
    * Example: `14:22`
    */
@@ -71,7 +71,7 @@ export default {
   },
 
   /**
-   * Formats dates in Europe/London ISO style, used when calling APIs
+   * Formats dates in Europe/London ISO style, used when calling APIs.
    *
    * Example: `2024-07-30`
    */
@@ -84,5 +84,29 @@ export default {
     const shortDate: string = this.shortDate(date)
     const [day, month, year] = shortDate.split('/')
     return `${year}-${month}-${day}`
+  },
+
+  /**
+   * Formats dates with time-of-day in Europe/London ISO style, used when calling APIs.
+   * NB: time zone is _not_ appended
+   *
+   * Example: `2024-07-30T14:22`
+   */
+  isoDateTime(date: Date): string {
+    if (!(date instanceof Date)) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore just in case value is not a Date
+      return date
+    }
+    const shortDate: string = this.shortDate(date)
+    const [day, month, year] = shortDate.split('/')
+    const time = date.toLocaleTimeString('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      timeZone: 'Europe/London',
+    })
+    const [hours, minutes, seconds] = time.split(':')
+    return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`
   },
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -57,6 +57,7 @@ export default function nunjucksSetup(app: express.Express): void {
   // misc utils
   njkEnv.addFilter('assetMap', (url: string) => assetManifest[url] || url)
   njkEnv.addGlobal('callAsMacro', callAsMacro)
+  njkEnv.addGlobal('now', () => new Date())
   njkEnv.addExtension('panic', new PanicExtension())
 
   // name formatting

--- a/server/views/macros/renderDateField.njk
+++ b/server/views/macros/renderDateField.njk
@@ -11,6 +11,7 @@
     },
     hint: { text: field.hint } if field.hint else undefined,
     leadingZeros: "true",
+    maxDate: now() | shortDate,
     value: values[fieldName],
     errorMessage: { text: errors[fieldName].message } if errors[fieldName] else undefined
   }) }}

--- a/server/views/pages/createReport/details.njk
+++ b/server/views/pages/createReport/details.njk
@@ -1,3 +1,4 @@
 {% set pageTitle = "Incident details" %}
+{% set allowSaveAndExit = true %}
 
 {% extends "partials/formWizardLayout.njk" %}

--- a/server/views/partials/formWizardLayout.njk
+++ b/server/views/partials/formWizardLayout.njk
@@ -32,9 +32,21 @@
         <div class="govuk-button-group">
           {{ govukButton({
             text: saveButtonText or "Save and continue",
+            name: "submit",
+            value: "continue",
             preventDoubleClick: true,
             type: "submit"
           }) }}
+
+          {% if allowSaveAndExit %}
+            {{ govukButton({
+              text: "Save and exit",
+              name: "submit",
+              value: "exit",
+              preventDoubleClick: true,
+              classes: "govuk-button--secondary"
+            }) }}
+          {% endif %}
 
           {% if cancelUrl %}
             <a href="{{ cancelUrl }}" class="govuk-link--no-visited-state">Cancel</a>


### PR DESCRIPTION
- add basic wiremock stubs for incident reporting endpoints
- add integration tests for creating a report successfully
- as usual, there are DST / timezone bugs 😩 – node likes to convert dates into UTC. this would be fine if our api was using timezone-aware dates, but since it uses naive dates during BST it was seeing all date/times with 1 hour subtracted
- improve test data so that prison-api and manage-users apis are aware of the same mock users