### PR TITLE
IR-519: Improve next step conditions

### DIFF
--- a/server/@types/hmpo-form-wizard/index.d.ts
+++ b/server/@types/hmpo-form-wizard/index.d.ts
@@ -25,20 +25,34 @@ declare module 'hmpo-form-wizard' {
     /** Use in complex generic forms that might allow multiple values in any fields; have checkbox components */
     type MultiValues = Record<string, MultiValue>
 
+    /** Operator function, returns true if submitted values matches condition */
+    type OperatorFunction = (
+      submittedValue: Value | MultiValue,
+      req: Request,
+      res: Express.Response,
+      condition: unknown,
+    ) => boolean
+
     /** Possible conditions for next steps */
     type NextStepCondition =
       | {
           /** field, op and value. op defaults to '===' */
           field: string
-          op?: '>' | '>=' | '<' | '<=' | '==' | '===' | '!=' | 'before' | 'after' | 'in' | 'all' | 'some'
-          value: Value
-          next: string
-        }
-      | {
-          /** an operator can be a function */
-          field: string
-          op: (fieldValue: Value, req: Request, res: Express.Response, con: unknown) => boolean
-          value: Value
+          op?:
+            | OperatorFunction
+            | '>'
+            | '>='
+            | '<'
+            | '<='
+            | '=='
+            | '==='
+            | '!='
+            | 'before'
+            | 'after'
+            | 'in'
+            | 'all'
+            | 'some'
+          value: Value | MultiValue
           next: string
         }
       | {

--- a/server/data/incidentTypeConfiguration/formWizard.test.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.test.ts
@@ -167,19 +167,13 @@ describe('generateSteps()', () => {
         next: [
           {
             field: 'qanimals',
-            value: 'DOG',
+            value: ['DOG'],
             op: checkMultipleValues,
             next: 'qdog',
           },
           {
             field: 'qanimals',
-            value: 'CAT',
-            op: checkMultipleValues,
-            next: 'icecream',
-          },
-          {
-            field: 'qanimals',
-            value: 'FOX',
+            value: ['CAT', 'FOX'],
             op: checkMultipleValues,
             next: 'icecream',
           },
@@ -192,14 +186,8 @@ describe('generateSteps()', () => {
         next: [
           {
             field: 'qdog',
-            op: '===',
-            value: 'YES',
-            next: 'qicecream',
-          },
-          {
-            field: 'qdog',
-            op: '===',
-            value: 'NO',
+            op: 'in',
+            value: ['YES', 'NO'],
             next: 'qicecream',
           },
         ],
@@ -211,14 +199,8 @@ describe('generateSteps()', () => {
         next: [
           {
             field: 'qicecream',
-            op: '===',
-            value: 'YES (SPECIFY FAVOURITE FLAVOUR)',
-            next: 'qend',
-          },
-          {
-            field: 'qicecream',
-            op: '===',
-            value: 'no',
+            op: 'in',
+            value: ['YES (SPECIFY FAVOURITE FLAVOUR)', 'no'],
             next: 'qend',
           },
         ],
@@ -230,14 +212,8 @@ describe('generateSteps()', () => {
         next: [
           {
             field: 'qend',
-            op: '===',
-            value: 'yes',
-            next: null,
-          },
-          {
-            field: 'qend',
-            op: '===',
-            value: 'no',
+            op: 'in',
+            value: ['yes', 'no'],
             next: null,
           },
         ],
@@ -381,7 +357,7 @@ describe('checkMultipleValues()', () => {
     { desc: 'submitted values do not match', submittedValues: ['cat', 'lizard'], expected: false },
     { desc: 'submitted values match', submittedValues: ['fox', 'dog'], expected: true },
   ])('returns $expected when $desc', ({ submittedValues, expected }) => {
-    const condition = { value: 'dog' }
+    const condition = { value: ['dog', 'turtle'] }
 
     const result = checkMultipleValues(submittedValues, null as FormWizard.Request, null as Express.Response, condition)
     expect(result).toEqual(expected)

--- a/server/data/incidentTypeConfiguration/formWizard.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.ts
@@ -3,7 +3,12 @@ import FormWizard from 'hmpo-form-wizard'
 import type { AnswerConfiguration, IncidentTypeConfiguration, QuestionConfiguration } from './types'
 import QuestionsController from '../../controllers/wip/questionsController'
 
-// TODO: Add tests once steps structure is more stable
+/**
+ * Generates Form Wizard's steps for the given config
+ *
+ * @param config questionnaire config
+ * @returns the Form Wizard's steps
+ */
 export function generateSteps(config: IncidentTypeConfiguration): FormWizard.Steps {
   const steps: FormWizard.Steps = {
     '/': {
@@ -58,8 +63,12 @@ export function generateSteps(config: IncidentTypeConfiguration): FormWizard.Ste
   return steps
 }
 
-// TODO: Deal with commentRequired/dateRequired
-// TODO: Add tests once fields structure is more stable
+/**
+ * Generates Form Wizard's fields for the given config
+ *
+ * @param config questionnaire config
+ * @returns the Form Wizard's fields
+ */
 export function generateFields(config: IncidentTypeConfiguration): FormWizard.Fields {
   const fields: FormWizard.Fields = {}
   Object.values(config.questions)

--- a/server/views/pages/wip/questions/questionPage.njk
+++ b/server/views/pages/wip/questions/questionPage.njk
@@ -7,15 +7,17 @@
 
   <h3>TODO: Debug</h3>
   <pre>
-    req.form {{ req.form | dump(2) }}
-    values {{ values | dump(2) }}
-    {# Cycle in options #}
-    {# options {{ options | dump(2) }} #}
-    options.step {{ options.step | dump(2) }}
-    options.fields {{ options.fields | dump(2) }}
     action {{ action | dump(2) }}
-    errors {{ errors | dump(2) }}
     nextPage {{ nextPage | dump(2) }}
+
+
+    errors {{ errors | dump(2) }}
+
+
+    values {{ values | dump(2) }}
+
+
+    options.fields {{ options.fields | dump(2) }}
   </pre>
 
 {% endblock %}


### PR DESCRIPTION
If multiple answers lead to the same next question they'll share the same next step condition.

For example:
- Q1 has 3 answers
- Answer 1 and 3 leads to Q2
- But Answer 2 leads to Q3

In this case Answer 1 and 3 would have the same next step condition.

For questions with a lot of answers leading to the same next question this means a much more compact steps object.

Also improved accuracy of some of the related Form Wizard types.