### PR TITLE
IR-68: Import default express namespace types using a name that is not itself exported as well

### DIFF
--- a/server/@types/hmpo-form-wizard/index.d.ts
+++ b/server/@types/hmpo-form-wizard/index.d.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line max-classes-per-file
-import type Express from 'express'
+import type express from 'express'
 
 /** HMPO form wizard types based on version 14.1 */
 declare module 'hmpo-form-wizard' {
@@ -11,7 +11,7 @@ declare module 'hmpo-form-wizard' {
     steps: FormWizard.Steps<V>,
     fields: FormWizard.Fields<V>,
     config: FormWizard.Config<V>,
-  ): Express.Router
+  ): express.Router
 
   export namespace FormWizard {
     /** String submitted to a form field that does not allow multiple values */
@@ -30,7 +30,7 @@ declare module 'hmpo-form-wizard' {
     type OperatorFunction = (
       submittedValue: Value | MultiValue,
       req: Request,
-      res: Express.Response,
+      res: express.Response,
       condition: unknown,
     ) => boolean
 
@@ -64,7 +64,7 @@ declare module 'hmpo-form-wizard' {
         }
       | {
           /** a condition can be a function specified by fn */
-          fn: (req: Request, res: Express.Response, con: unknown) => boolean
+          fn: (req: Request, res: express.Response, con: unknown) => boolean
           next: string
         }
       | {
@@ -76,7 +76,7 @@ declare module 'hmpo-form-wizard' {
           /** the next option can be a function to return a dynamic next step */
           field: string
           value: Value
-          next: (req: Request, res: Express.Response, con: unknown) => string
+          next: (req: Request, res: express.Response, con: unknown) => string
         }
 
     type NextStep =
@@ -225,7 +225,7 @@ declare module 'hmpo-form-wizard' {
       name?: string
     }
 
-    interface Request<V extends object = Values, K extends keyof V = keyof V> extends Express.Request {
+    interface Request<V extends object = Values, K extends keyof V = keyof V> extends express.Request {
       isEditing: boolean
       journeyModel: JourneyModel<JourneyValues>
       sessionModel: WizardModel<
@@ -305,7 +305,7 @@ declare module 'hmpo-form-wizard' {
       nextPage: Step<V>
       isEditing: boolean
       editSuffix: string
-      baseUrl: Express.Request['baseUrl']
+      baseUrl: express.Request['baseUrl']
       backLink: string | undefined
       ['csrf-token']: string
     }
@@ -323,7 +323,7 @@ declare module 'hmpo-form-wizard' {
 
       options: Options<V, K>
 
-      router: Express.Router
+      router: express.Router
 
       middlewareSetup(): void
 
@@ -335,54 +335,54 @@ declare module 'hmpo-form-wizard' {
 
       middlewareMixins(): void
 
-      use(...requestHandlers: Express.RequestHandler[]): void
+      use(...requestHandlers: express.RequestHandler[]): void
 
       useWithMethod(
         method: 'all' | 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head',
-        ...requestHandlers: Express.RequestHandler[]
+        ...requestHandlers: express.RequestHandler[]
       ): void
 
-      requestHandler(): Express.Router
+      requestHandler(): express.Router
 
-      rejectUnsupportedMethods(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      rejectUnsupportedMethods(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      methodNotSupported(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      methodNotSupported(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      configure(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      configure(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      get(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      get(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      post(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      post(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      getErrors(req: Request<V, K>, res: Express.Response): Errors<K>
+      getErrors(req: Request<V, K>, res: express.Response): Errors<K>
 
-      getValues(req: Request<V, K>, res: Express.Response, callback: Callback<V>): void
+      getValues(req: Request<V, K>, res: express.Response, callback: Callback<V>): void
 
-      locals(req: Request<V, K>, res: Express.Response, callback?: Callback<V>): Partial<Locals<V, K>>
+      locals(req: Request<V, K>, res: express.Response, callback?: Callback<V>): Partial<Locals<V, K>>
 
-      render(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      render(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      setErrors(err: Errors<K> | null, req: Request<V, K>, res: Express.Response): void
+      setErrors(err: Errors<K> | null, req: Request<V, K>, res: express.Response): void
 
-      process(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      process(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      validateFields(req: Request<V, K>, res: Express.Response, callback: Callback<V>): void
+      validateFields(req: Request<V, K>, res: express.Response, callback: Callback<V>): void
 
-      validateField(key: K, req: Request<V, K>, res: Express.Response): Error | false | undefined
+      validateField(key: K, req: Request<V, K>, res: express.Response): Error | false | undefined
 
-      validate(req: Request<Pick<V, K>>, res: Express.Response, next: Express.NextFunction): void
+      validate(req: Request<Pick<V, K>>, res: express.Response, next: express.NextFunction): void
 
-      saveValues(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      saveValues(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      successHandler(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      successHandler(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
       isValidationError(err: unknown): err is Record<string, Error>
 
       errorHandler(
         err: Errors<K> | undefined,
         req: Request<V, K>,
-        res: Express.Response,
-        next: Express.NextFunction,
+        res: express.Response,
+        next: express.NextFunction,
       ): void
     }
 
@@ -399,87 +399,87 @@ declare module 'hmpo-form-wizard' {
 
       resolvePath(base: string, url: string, forceRelative: boolean): void
 
-      setBaseUrlLocal(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      setBaseUrlLocal(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      setTranslateEngine(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      setTranslateEngine(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      createJourneyModel(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      createJourneyModel(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      createSessionModel(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      createSessionModel(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      resetSessionModel(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      resetSessionModel(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      checkSession(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      checkSession(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      checkJourneyProgress(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      checkJourneyProgress(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      checkProceedToNextStep(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      checkProceedToNextStep(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
       walkJourneyHistory(
         req: Request<V, K>,
-        res: Express.Response,
+        res: express.Response,
         fn: (this: Controller, step: Step<V>, next: Step<V> | undefined) => boolean,
         stopAtInvalid: boolean = true,
         start: Step<V> | null = null,
       ): Step<V> | false
 
-      completedJourneyStep(req: Request<V, K>, res: Express.Response, path: string): Step<V> | false
+      completedJourneyStep(req: Request<V, K>, res: express.Response, path: string): Step<V> | false
 
-      allowedJourneyStep(req: Request<V, K>, res: Express.Response, path: string): Step<V> | false
+      allowedJourneyStep(req: Request<V, K>, res: express.Response, path: string): Step<V> | false
 
-      allowedPrereqStep(req: Request<V, K>, res: Express.Response, prereqs: string[]): Step<V> | false
+      allowedPrereqStep(req: Request<V, K>, res: express.Response, prereqs: string[]): Step<V> | false
 
-      lastAllowedStep(req: Request<V, K>, res: Express.Response): Step<V> | false
+      lastAllowedStep(req: Request<V, K>, res: express.Response): Step<V> | false
 
       getJourneyFieldNames(
         req: Request<V, K>,
-        res: Express.Response,
+        res: express.Response,
         fields: (keyof V)[],
         ignoreLocalFields = false,
         undefinedIfEmpty = false,
       ): string[] | undefined
 
-      setStepComplete(req: Request<V, K>, res: Express.Response, path?: string): void
+      setStepComplete(req: Request<V, K>, res: express.Response, path?: string): void
 
-      addJourneyHistoryStep(req: Request<V, K>, res: Express.Response, step: Step<V>): void
+      addJourneyHistoryStep(req: Request<V, K>, res: express.Response, step: Step<V>): void
 
-      invalidateJourneyHistoryStep(req: Request<V, K>, res: Express.Response, path: string): void
+      invalidateJourneyHistoryStep(req: Request<V, K>, res: express.Response, path: string): void
 
-      removeJourneyHistoryStep(req: Request<V, K>, res: Express.Response, path: string): void
+      removeJourneyHistoryStep(req: Request<V, K>, res: express.Response, path: string): void
 
-      resetJourneyHistory(req: Request<V, K>, res: Express.Response): void
+      resetJourneyHistory(req: Request<V, K>, res: express.Response): void
 
-      csrfGenerateSecret(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      csrfGenerateSecret(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      csrfCheckToken(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      csrfCheckToken(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      csrfSetToken(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      csrfSetToken(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      checkJourneyInvalidations(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      checkJourneyInvalidations(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      invalidateFields(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      invalidateFields(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      backlinksSetLocals(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      backlinksSetLocals(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      getBackLink(req: Request<V, K>, res: Express.Response): string | undefined
+      getBackLink(req: Request<V, K>, res: express.Response): string | undefined
 
       decodeConditions(
         req: Request<V, K>,
-        res: Express.Response,
+        res: express.Response,
         nextStep: NextStep,
       ): { condition: NextStep | null; fields: (keyof V)[]; url: string | null } | undefined
 
-      getNextStepObject(req: Request<V, K>, res: Express.Response): ReturnType<Controller['decodeConditions']>
+      getNextStepObject(req: Request<V, K>, res: express.Response): ReturnType<Controller['decodeConditions']>
 
-      getNextStep(req: Request<V, K>, res: Express.Response): string | undefined
+      getNextStep(req: Request<V, K>, res: express.Response): string | undefined
 
-      getErrorStep(err: Errors<K>, req: Request<V, K>, res: Express.Response): string | undefined
+      getErrorStep(err: Errors<K>, req: Request<V, K>, res: express.Response): string | undefined
 
-      editing(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      editing(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      checkEditing(req: Request<V, K>, res: Express.Response, next: Express.NextFunction): void
+      checkEditing(req: Request<V, K>, res: express.Response, next: express.NextFunction): void
 
-      clearEditing(req: Request<V, K>, res: Express.Response): void
+      clearEditing(req: Request<V, K>, res: express.Response): void
     }
 
     interface SessionModelOptions extends LocalModelOptions {

--- a/server/@types/hmpo-form-wizard/index.test.ts
+++ b/server/@types/hmpo-form-wizard/index.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-empty-function */
 
 // eslint-disable-next-line max-classes-per-file
-import type Express from 'express'
+import type express from 'express'
 import FormWizard from 'hmpo-form-wizard'
 
 // NB: fields defition must not have a type annotation! but it's helpful to ensure it satisfies the fields requirement
@@ -17,7 +17,7 @@ type Values = FormWizard.ValuesFromFields<typeof fields>
 it('Deriving controller values type', () => {
   // controller for a step which only deals with the `name` field (not `emails`)
   class TypedController1 extends FormWizard.Controller<Values, 'name'> {
-    saveValues(req: FormWizard.Request<Values, 'name'>, res: Express.Response, next: Express.NextFunction): void {
+    saveValues(req: FormWizard.Request<Values, 'name'>, res: express.Response, next: express.NextFunction): void {
       // `name` exists in this step as derived by FormWizard.ValuesFromFields
       // `name` must be a string value otherwise the next line would fail type checking
       mustBeString(req.form.values.name)
@@ -32,7 +32,7 @@ it('Deriving controller values type', () => {
 
   // controller for a step which only deals with the `emails` field (not `name`)
   class TypedController2 extends FormWizard.Controller<Values, 'emails'> {
-    saveValues(req: FormWizard.Request<Values, 'emails'>, res: Express.Response, next: Express.NextFunction): void {
+    saveValues(req: FormWizard.Request<Values, 'emails'>, res: express.Response, next: express.NextFunction): void {
       // `emails` exists in this step as derived by FormWizard.ValuesFromFields
       // `emails` must be a string array value otherwise the next line would fail type checking
       mustBeStringArray(req.form.values.emails)

--- a/server/controllers/addPrisoner/addPrisoner.ts
+++ b/server/controllers/addPrisoner/addPrisoner.ts
@@ -1,4 +1,4 @@
-import type Express from 'express'
+import type express from 'express'
 import type FormWizard from 'hmpo-form-wizard'
 
 import FormInitialStep from '../base/formInitialStep'
@@ -16,7 +16,7 @@ export default class AddPrisoner extends FormInitialStep {
     this.use(this.setOptions)
   }
 
-  async setOptions(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  async setOptions(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     req.form.options.fields.prisonerRole.items = Object.values(prisonerInvolvementRoles).map(
       ({ code, description }) => ({
         value: code,
@@ -34,7 +34,7 @@ export default class AddPrisoner extends FormInitialStep {
     next()
   }
 
-  locals(req: FormWizard.Request, res: Express.Response): object {
+  locals(req: FormWizard.Request, res: express.Response): object {
     const locals = super.locals(req, res)
     const incidentId = res.locals.incident.id
 
@@ -46,7 +46,7 @@ export default class AddPrisoner extends FormInitialStep {
     }
   }
 
-  async saveValues(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  async saveValues(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     try {
       const { prisonerRole, prisonerOutcome, prisonerComment } = req.form.values
 
@@ -77,7 +77,7 @@ export default class AddPrisoner extends FormInitialStep {
     }
   }
 
-  successHandler(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  successHandler(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     const incidentId = res.locals.incident.id
 
     req.journeyModel.reset()

--- a/server/controllers/base/formInitialStep.ts
+++ b/server/controllers/base/formInitialStep.ts
@@ -1,4 +1,4 @@
-import type Express from 'express'
+import type express from 'express'
 import FormWizard from 'hmpo-form-wizard'
 
 import type { GovukErrorSummaryItem } from '../../utils/govukFrontend'
@@ -12,12 +12,12 @@ export default class FormInitialStep extends FormWizard.Controller {
     this.use(this.setupConditionalFields)
   }
 
-  getInitialValues(_req: FormWizard.Request, _res: Express.Response): FormWizard.Values {
+  getInitialValues(_req: FormWizard.Request, _res: express.Response): FormWizard.Values {
     // Override in subclass to return initial values for form
     return {}
   }
 
-  getValues(req: FormWizard.Request, res: Express.Response, callback: FormWizard.Callback): void {
+  getValues(req: FormWizard.Request, res: express.Response, callback: FormWizard.Callback): void {
     return super.getValues(req, res, (err, values) => {
       if (err) {
         return callback(err)
@@ -40,7 +40,7 @@ export default class FormInitialStep extends FormWizard.Controller {
     return typeof arg === 'number' ? arg : `the ${fields[arg?.field]?.label?.toLowerCase()}`
   }
 
-  getErrorDetail(error: FormWizard.Error, res: Express.Response): GovukErrorSummaryItem {
+  getErrorDetail(error: FormWizard.Error, res: express.Response): GovukErrorSummaryItem {
     const { fields } = res.locals.options
     const field = fields[error.key]
     const fieldName: string = field.nameForErrors || field?.label
@@ -74,7 +74,7 @@ export default class FormInitialStep extends FormWizard.Controller {
     }
   }
 
-  renderConditionalFields(req: FormWizard.Request, res: Express.Response): void {
+  renderConditionalFields(req: FormWizard.Request, res: express.Response): void {
     const { options } = req.form
 
     options.fields = Object.fromEntries(
@@ -85,7 +85,7 @@ export default class FormInitialStep extends FormWizard.Controller {
     res.locals.fields = options.fields
   }
 
-  setupConditionalFields(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction): void {
+  setupConditionalFields(req: FormWizard.Request, res: express.Response, next: express.NextFunction): void {
     const { options } = req.form
 
     const stepFieldsArray = Object.entries(options.fields)
@@ -100,8 +100,8 @@ export default class FormInitialStep extends FormWizard.Controller {
     next()
   }
 
-  locals(req: FormWizard.Request, res: Express.Response): Partial<FormWizard.Locals> {
-    const locals = res.locals as Express.Locals & FormWizard.Locals
+  locals(req: FormWizard.Request, res: express.Response): Partial<FormWizard.Locals> {
+    const locals = res.locals as express.Locals & FormWizard.Locals
     const { options } = locals
     if (!options?.fields) {
       return {}
@@ -143,7 +143,7 @@ export default class FormInitialStep extends FormWizard.Controller {
     return fields
   }
 
-  render(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction): void {
+  render(req: FormWizard.Request, res: express.Response, next: express.NextFunction): void {
     this.renderConditionalFields(req, res)
 
     return super.render(req, res, next)

--- a/server/controllers/generic/genericPage1.ts
+++ b/server/controllers/generic/genericPage1.ts
@@ -1,10 +1,10 @@
-import type Express from 'express'
+import type express from 'express'
 import type FormWizard from 'hmpo-form-wizard'
 
 import FormInitialStep from '../base/formInitialStep'
 
 export default class GenericPage1 extends FormInitialStep {
-  locals(req: FormWizard.Request, res: Express.Response): object {
+  locals(req: FormWizard.Request, res: express.Response): object {
     const locals = super.locals(req, res)
 
     const backLink = '/incidents'
@@ -16,7 +16,7 @@ export default class GenericPage1 extends FormInitialStep {
   }
 
   /**
-  async saveValues(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  async saveValues(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     try {
       const { user } = res.locals
       // const { locationsService } = req.services
@@ -43,7 +43,7 @@ export default class GenericPage1 extends FormInitialStep {
     }
   }
 
-  successHandler(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  successHandler(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     const { prisonId } = res.locals
 
     req.journeyModel.reset()

--- a/server/controllers/generic/genericPage2.ts
+++ b/server/controllers/generic/genericPage2.ts
@@ -1,10 +1,10 @@
-import type Express from 'express'
+import type express from 'express'
 import type FormWizard from 'hmpo-form-wizard'
 
 import FormInitialStep from '../base/formInitialStep'
 
 export default class GenericPage2 extends FormInitialStep {
-  locals(req: FormWizard.Request, res: Express.Response): object {
+  locals(req: FormWizard.Request, res: express.Response): object {
     const locals = super.locals(req, res)
 
     const backLink = '/incidents'
@@ -16,7 +16,7 @@ export default class GenericPage2 extends FormInitialStep {
   }
 
   /**
-  async saveValues(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  async saveValues(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     try {
       const { user } = res.locals
       // const { locationsService } = req.services
@@ -43,7 +43,7 @@ export default class GenericPage2 extends FormInitialStep {
     }
   }
 
-  successHandler(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  successHandler(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     const { prisonId } = res.locals
 
     req.journeyModel.reset()

--- a/server/controllers/generic/genericPage3.ts
+++ b/server/controllers/generic/genericPage3.ts
@@ -1,10 +1,10 @@
-import type Express from 'express'
+import type express from 'express'
 import type FormWizard from 'hmpo-form-wizard'
 
 import FormInitialStep from '../base/formInitialStep'
 
 export default class GenericPage3 extends FormInitialStep {
-  locals(req: FormWizard.Request, res: Express.Response): object {
+  locals(req: FormWizard.Request, res: express.Response): object {
     const locals = super.locals(req, res)
 
     const backLink = '/incidents'
@@ -16,7 +16,7 @@ export default class GenericPage3 extends FormInitialStep {
   }
 
   /**
-  async saveValues(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  async saveValues(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     try {
       const { user } = res.locals
       // const { locationsService } = req.services
@@ -43,7 +43,7 @@ export default class GenericPage3 extends FormInitialStep {
     }
   }
 
-  successHandler(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  successHandler(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     const { prisonId } = res.locals
 
     req.journeyModel.reset()

--- a/server/controllers/generic/involvedParties.ts
+++ b/server/controllers/generic/involvedParties.ts
@@ -1,10 +1,10 @@
-import type Express from 'express'
+import type express from 'express'
 import type FormWizard from 'hmpo-form-wizard'
 
 import FormInitialStep from '../base/formInitialStep'
 
 export default class TestNewIncidentPage2 extends FormInitialStep {
-  locals(req: FormWizard.Request, res: Express.Response): object {
+  locals(req: FormWizard.Request, res: express.Response): object {
     const locals = super.locals(req, res)
 
     const backLink = '/incidents'
@@ -16,7 +16,7 @@ export default class TestNewIncidentPage2 extends FormInitialStep {
   }
 
   /**
-  async saveValues(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  async saveValues(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     try {
       const { user } = res.locals
       // const { locationsService } = req.services
@@ -43,7 +43,7 @@ export default class TestNewIncidentPage2 extends FormInitialStep {
     }
   }
 
-  successHandler(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  successHandler(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     const { prisonId } = res.locals
 
     req.journeyModel.reset()

--- a/server/controllers/generic/policeInformed.ts
+++ b/server/controllers/generic/policeInformed.ts
@@ -1,10 +1,10 @@
-import type Express from 'express'
+import type express from 'express'
 import type FormWizard from 'hmpo-form-wizard'
 
 import FormInitialStep from '../base/formInitialStep'
 
 export default class TestNewIncidentPage3 extends FormInitialStep {
-  locals(req: FormWizard.Request, res: Express.Response): object {
+  locals(req: FormWizard.Request, res: express.Response): object {
     const locals = super.locals(req, res)
 
     const backLink = '/incidents'
@@ -16,7 +16,7 @@ export default class TestNewIncidentPage3 extends FormInitialStep {
   }
 
   /**
-  async saveValues(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  async saveValues(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     try {
       const { policeInformed } = req.form.values
       console.log('Page 3 activated')
@@ -35,7 +35,7 @@ export default class TestNewIncidentPage3 extends FormInitialStep {
     }
   }
 
-  successHandler(req: FormWizard.Request, res: Express.Response, next: Express.NextFunction) {
+  successHandler(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
     const { prisonId } = res.locals
 
     req.journeyModel.reset()

--- a/server/controllers/index.test.ts
+++ b/server/controllers/index.test.ts
@@ -1,4 +1,4 @@
-import type Express from 'express'
+import type express from 'express'
 import type FormWizard from 'hmpo-form-wizard'
 
 import { mockThrownError } from '../data/testData/thrownErrors'
@@ -87,7 +87,7 @@ describe('Base form wizard controller', () => {
           errors: {},
         },
       } as unknown as FormWizard.Request
-      const res = {} as Express.Response
+      const res = {} as express.Response
 
       const error = controller.validateField(fieldName, req, res)
       expect(error).toHaveProperty('message', expectedError)
@@ -112,7 +112,7 @@ describe('Base form wizard controller', () => {
           errors: {},
         },
       } as unknown as FormWizard.Request
-      const res = {} as Express.Response
+      const res = {} as express.Response
 
       expect(() => {
         controller.validateField('mobile', req, res)
@@ -151,7 +151,7 @@ describe('Base form wizard controller', () => {
           errors: {},
         },
       } as unknown as FormWizard.Request
-      const res = {} as Express.Response
+      const res = {} as express.Response
 
       const error = controller.validateField('date', req, res)
       expect(error).toHaveProperty('message', 'Enter a date')
@@ -176,7 +176,7 @@ describe('Base form wizard controller', () => {
           errors: {},
         },
       } as unknown as FormWizard.Request
-      const res = {} as Express.Response
+      const res = {} as express.Response
 
       const error = controller.validateField('date', req, res)
       expect(error).toBeUndefined()
@@ -201,7 +201,7 @@ describe('Base form wizard controller', () => {
           errors: {},
         },
       } as unknown as FormWizard.Request
-      const res = {} as Express.Response
+      const res = {} as express.Response
 
       const error = controller.validateField('time', req, res)
       expect(error).toHaveProperty('message', 'Enter a time')
@@ -226,7 +226,7 @@ describe('Base form wizard controller', () => {
           errors: {},
         },
       } as unknown as FormWizard.Request
-      const res = {} as Express.Response
+      const res = {} as express.Response
 
       const error = controller.validateField('time', req, res)
       expect(error).toBeUndefined()

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -1,4 +1,4 @@
-import type Express from 'express'
+import type express from 'express'
 import FormWizard from 'hmpo-form-wizard'
 
 import { parseDateInput, parseTimeInput } from '../utils/utils'
@@ -48,7 +48,7 @@ export abstract class BaseController<
   /**
    * Adds a human-readable message to errors if they are missing.
    */
-  validateField(key: K, req: FormWizard.Request<V, K>, res: Express.Response): FormWizard.Error | false | undefined {
+  validateField(key: K, req: FormWizard.Request<V, K>, res: express.Response): FormWizard.Error | false | undefined {
     const error = super.validateField(key, req, res)
     if (error && !error.message) {
       error.message = this.errorMessage(error)
@@ -64,7 +64,7 @@ export abstract class BaseController<
     return new BaseController.Error(null, { message: 'Sorry, there was a problem with your request' })
   }
 
-  csrfGenerateSecret(req: FormWizard.Request<V, K>, res: Express.Response, next: Express.NextFunction): void {
+  csrfGenerateSecret(req: FormWizard.Request<V, K>, res: express.Response, next: express.NextFunction): void {
     // copy application middleware CSRF token into form wizard for sanity
     req.sessionModel.set('csrf-secret', res.locals.csrfToken)
     next()

--- a/server/data/incidentTypeConfiguration/formWizard.test.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.test.ts
@@ -1,4 +1,6 @@
+import type express from 'express'
 import { type FormWizard } from 'hmpo-form-wizard'
+
 import QuestionsController from '../../controllers/wip/questionsController'
 import { checkMultipleValues, generateFields, generateSteps } from './formWizard'
 import { type IncidentTypeConfiguration } from './types'
@@ -358,7 +360,7 @@ describe('checkMultipleValues()', () => {
   ])('returns $expected when $desc', ({ submittedValues, expected }) => {
     const condition = { value: ['dog', 'turtle'] }
 
-    const result = checkMultipleValues(submittedValues, null as FormWizard.Request, null as Express.Response, condition)
+    const result = checkMultipleValues(submittedValues, null as FormWizard.Request, null as express.Response, condition)
     expect(result).toEqual(expected)
   })
 })

--- a/server/data/incidentTypeConfiguration/formWizard.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.ts
@@ -1,4 +1,5 @@
-import FormWizard from 'hmpo-form-wizard'
+import type express from 'express'
+import type FormWizard from 'hmpo-form-wizard'
 
 import type { AnswerConfiguration, IncidentTypeConfiguration, QuestionConfiguration } from './types'
 import QuestionsController from '../../controllers/wip/questionsController'
@@ -367,7 +368,7 @@ function conditionalFieldName(question: QuestionConfiguration, answer: AnswerCon
 export function checkMultipleValues(
   submittedValues: string[],
   _req: FormWizard.Request,
-  _res: Express.Response,
+  _res: express.Response,
   condition: { value: string[] },
 ): boolean {
   // Don't check values if nothing has been submitted

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -1,4 +1,4 @@
-import type { Router } from 'express'
+import type { Express, Router } from 'express'
 import express from 'express'
 import passport from 'passport'
 import { Strategy } from 'passport-oauth2'

--- a/server/routes/forms/get.ts
+++ b/server/routes/forms/get.ts
@@ -1,4 +1,4 @@
-import type { Router, Request, RequestHandler, Response, NextFunction } from 'express'
+import type { Express, Router, Request, RequestHandler, Response, NextFunction } from 'express'
 import type { ParamsDictionary, PathParams, Query } from 'express-serve-static-core'
 import { BadRequest, MethodNotAllowed } from 'http-errors'
 

--- a/server/routes/forms/post.ts
+++ b/server/routes/forms/post.ts
@@ -1,4 +1,4 @@
-import type { Router, Request, RequestHandler, Response, NextFunction } from 'express'
+import type { Express, Router, Request, RequestHandler, Response, NextFunction } from 'express'
 import type { ParamsDictionary, PathParams, Query } from 'express-serve-static-core'
 import { BadRequest, MethodNotAllowed } from 'http-errors'
 

--- a/server/routes/reports/createReport.ts
+++ b/server/routes/reports/createReport.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line max-classes-per-file
-import type Express from 'express'
+import type express from 'express'
 import FormWizard from 'hmpo-form-wizard'
 
 import logger from '../../../logger'
@@ -17,8 +17,8 @@ class TypeController extends BaseTypeController<CreateReportValues> {}
 class DetailsController extends BaseDetailsController<CreateReportValues> {
   async successHandler(
     req: FormWizard.Request<CreateReportValues, DetailsFieldNames>,
-    res: Express.Response,
-    next: Express.NextFunction,
+    res: express.Response,
+    next: express.NextFunction,
   ): Promise<void> {
     const allValues = this.getAllValues(req)
 
@@ -55,7 +55,7 @@ class DetailsController extends BaseDetailsController<CreateReportValues> {
 
   getNextStep(
     req: FormWizard.Request<CreateReportValues, DetailsFieldNames>,
-    res: Express.Response,
+    res: express.Response,
   ): string | undefined {
     // if a report was successfully created…
     if (res.locals.createdReport) {

--- a/server/routes/reports/detailsController.ts
+++ b/server/routes/reports/detailsController.ts
@@ -1,4 +1,4 @@
-import type Express from 'express'
+import type express from 'express'
 import type FormWizard from 'hmpo-form-wizard'
 
 import { parseDateInput, parseTimeInput } from '../../utils/utils'
@@ -14,7 +14,7 @@ import { type DetailsValues, type DetailsFieldNames, hoursFieldName, minutesFiel
 export abstract class BaseDetailsController<V extends DetailsValues> extends BaseController<V, DetailsFieldNames> {
   getValues(
     req: FormWizard.Request<V, DetailsFieldNames>,
-    res: Express.Response,
+    res: express.Response,
     callback: FormWizard.Callback<V>,
   ): void {
     super.getValues(req, res, (err, values) => {
@@ -37,7 +37,7 @@ export abstract class BaseDetailsController<V extends DetailsValues> extends Bas
     })
   }
 
-  process(req: FormWizard.Request<V, DetailsFieldNames>, res: Express.Response, next: Express.NextFunction): void {
+  process(req: FormWizard.Request<V, DetailsFieldNames>, res: express.Response, next: express.NextFunction): void {
     const hours = req.form.values[hoursFieldName]
     const minutes = req.form.values[minutesFieldName]
     const digits = /^\d{1,2}$/
@@ -50,8 +50,8 @@ export abstract class BaseDetailsController<V extends DetailsValues> extends Bas
 
   validate(
     req: FormWizard.Request<Pick<V, DetailsFieldNames>>,
-    res: Express.Response,
-    next: Express.NextFunction,
+    res: express.Response,
+    next: express.NextFunction,
   ): void {
     // if (and only if) incidentDate and incidentTime are valid, ensure that the combined date & time is in the past
     const { incidentDate, incidentTime } = req.form.values

--- a/server/routes/reports/updateReportDetails.ts
+++ b/server/routes/reports/updateReportDetails.ts
@@ -1,4 +1,4 @@
-import type Express from 'express'
+import type express from 'express'
 import FormWizard from 'hmpo-form-wizard'
 import { NotFound } from 'http-errors'
 
@@ -19,8 +19,8 @@ class DetailsController extends BaseDetailsController<DetailsValues> {
 
   async lookupReport(
     req: FormWizard.Request<DetailsValues, DetailsFieldNames>,
-    res: Express.Response,
-    next: Express.NextFunction,
+    res: express.Response,
+    next: express.NextFunction,
   ): Promise<void> {
     try {
       const { incidentReportingApi } = res.locals.apis
@@ -46,14 +46,14 @@ class DetailsController extends BaseDetailsController<DetailsValues> {
     }
   }
 
-  getBackLink(_req: FormWizard.Request<DetailsValues, DetailsFieldNames>, res: Express.Response): string {
+  getBackLink(_req: FormWizard.Request<DetailsValues, DetailsFieldNames>, res: express.Response): string {
     return res.locals.cancelUrl
   }
 
   async successHandler(
     req: FormWizard.Request<DetailsValues, DetailsFieldNames>,
-    res: Express.Response,
-    next: Express.NextFunction,
+    res: express.Response,
+    next: express.NextFunction,
   ): Promise<void> {
     const report = res.locals.report as ReportBasic
     const allValues = this.getAllValues(req)
@@ -82,7 +82,7 @@ class DetailsController extends BaseDetailsController<DetailsValues> {
     }
   }
 
-  getNextStep(_req: FormWizard.Request<DetailsValues, DetailsFieldNames>, res: Express.Response): string {
+  getNextStep(_req: FormWizard.Request<DetailsValues, DetailsFieldNames>, res: express.Response): string {
     // TODO: does this page have 2 save buttons? where do they both lead?
     return res.locals.cancelUrl
   }


### PR DESCRIPTION
This is good practice according to eslint because
```typescript
import type Express from 'express'
// and
import type { Express } from 'express'
```
refer to different things. It’s best that we use the package name `express` as the default import name instead.

This “problem” was spotted when [testing migrating to eslint 9](https://github.com/ministryofjustice/hmpps-incident-reporting/pull/255)