### PR TITLE
IR-631: Rename `prisonId` fields to `location` in reports and events

### DIFF
--- a/integration_tests/e2e/createReport.cy.ts
+++ b/integration_tests/e2e/createReport.cy.ts
@@ -39,7 +39,7 @@ context('Creating a new report', () => {
       request: {
         type: reportWithDetails.type,
         incidentDateAndTime: reportWithDetails.incidentDateAndTime,
-        prisonId: 'MDI',
+        location: 'MDI',
         title: 'Report: miscellaneous',
         description: reportWithDetails.description,
         createNewEvent: true,

--- a/server/data/incidentReportingApi.test.ts
+++ b/server/data/incidentReportingApi.test.ts
@@ -97,7 +97,7 @@ describe('Incident reporting API client', () => {
             title: 'Chewing gum',
             description: 'Chewing gum found in cell',
             incidentDateAndTime: now,
-            prisonId: 'MDI',
+            location: 'MDI',
           }),
       },
       {
@@ -408,7 +408,7 @@ describe('Incident reporting API client', () => {
             title: 'Chewing gum',
             description: 'Chewing gum found in cell',
             incidentDateAndTime: now,
-            prisonId: 'MDI',
+            location: 'MDI',
           }),
       },
       {
@@ -460,7 +460,7 @@ describe('Incident reporting API client', () => {
             title: 'Chewing gum',
             description: 'Chewing gum found in cell',
             incidentDateAndTime: now,
-            prisonId: 'MDI',
+            location: 'MDI',
           }),
         mockResponse: { status: 201, data: reportWithDetails },
         responseDateExtractor: (request: DatesAsStrings<CreateReportRequest>) => [request.incidentDateAndTime],

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -65,7 +65,7 @@ export type Event = {
   id: string
   eventReference: string
   eventDateAndTime: Date
-  prisonId: string
+  location: string
   title: string
   description: string
   createdAt: Date
@@ -82,7 +82,7 @@ export type ReportBasic = {
   reportReference: string
   type: Type
   incidentDateAndTime: Date
-  prisonId: string
+  location: string
   title: string
   description: string
   reportedBy: string
@@ -106,13 +106,13 @@ export type ReportWithDetails = ReportBasic & {
 }
 
 export type GetEventsParams = {
-  prisonId: string
+  location: string
   eventDateFrom: Date // Inclusive
   eventDateUntil: Date // Inclusive
 } & PaginationSortingParams
 
 export type GetReportsParams = {
-  prisonId: string
+  location: string
   source: InformationSource
   status: Status
   type: Type
@@ -183,7 +183,7 @@ export type CorrectionRequest = {
 export type CreateReportRequest = {
   type: string
   incidentDateAndTime: Date
-  prisonId: string
+  location: string
   title: string
   description: string
   createNewEvent: boolean
@@ -192,7 +192,7 @@ export type CreateReportRequest = {
 
 export type UpdateReportRequest = {
   incidentDateAndTime?: Date
-  prisonId?: string
+  location?: string
   title?: string
   description?: string
   updateEvent?: boolean
@@ -224,8 +224,8 @@ export class IncidentReportingApi extends RestClient {
   }
 
   async getEvents(
-    { prisonId, eventDateFrom, eventDateUntil, page, size, sort }: Partial<GetEventsParams> = {
-      prisonId: null,
+    { location, eventDateFrom, eventDateUntil, page, size, sort }: Partial<GetEventsParams> = {
+      location: null,
       eventDateFrom: null,
       eventDateUntil: null,
       page: 0,
@@ -238,8 +238,8 @@ export class IncidentReportingApi extends RestClient {
       size,
       sort,
     }
-    if (prisonId) {
-      query.prisonId = prisonId
+    if (location) {
+      query.location = location
     }
     if (eventDateFrom) {
       query.eventDateFrom = format.isoDate(eventDateFrom)
@@ -274,7 +274,7 @@ export class IncidentReportingApi extends RestClient {
 
   async getReports(
     {
-      prisonId,
+      location,
       source,
       status,
       type,
@@ -289,7 +289,7 @@ export class IncidentReportingApi extends RestClient {
       size,
       sort,
     }: Partial<GetReportsParams> = {
-      prisonId: null,
+      location: null,
       source: null,
       status: null,
       type: null,
@@ -310,8 +310,8 @@ export class IncidentReportingApi extends RestClient {
       size,
       sort,
     }
-    if (prisonId) {
-      query.prisonId = prisonId
+    if (location) {
+      query.location = location
     }
     if (source) {
       query.source = source

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -19,7 +19,7 @@ import { staffBarry, staffMary } from './prisonApi'
 interface MockEventConfig {
   eventReference: string
   reportDateAndTime: Date
-  prisonId?: string
+  location?: string
   reportingUsername?: string
 }
 
@@ -28,7 +28,7 @@ export function mockEvent(conf: MockEventConfig & { includeReports: number }): D
 export function mockEvent({
   eventReference,
   reportDateAndTime,
-  prisonId = 'MDI',
+  location = 'MDI',
   reportingUsername = 'user1',
   includeReports = 0,
 }: MockEventConfig & { includeReports?: number }): DatesAsStrings<Event | EventWithBasicReports> {
@@ -41,7 +41,7 @@ export function mockEvent({
     id: uuidFromDate({ msecs: reportDateAndTime.getTime() }),
     eventReference,
     eventDateAndTime: format.isoDateTime(incidentDateAndTime),
-    prisonId,
+    location,
     title: 'An event occurred',
     description: 'Details of the event',
     createdAt: format.isoDateTime(reportDateAndTime),
@@ -64,7 +64,7 @@ export function mockEvent({
 interface MockReportConfig {
   reportReference: string
   reportDateAndTime: Date
-  prisonId?: string
+  location?: string
   createdInNomis?: boolean
   status?: Status
   type?: Type
@@ -76,7 +76,7 @@ export function mockReport(conf: MockReportConfig & { withDetails: true }): Date
 export function mockReport({
   reportReference,
   reportDateAndTime,
-  prisonId = 'MDI',
+  location = 'MDI',
   createdInNomis = false,
   status = 'DRAFT',
   type = 'FINDS',
@@ -93,7 +93,7 @@ export function mockReport({
     reportReference,
     type,
     incidentDateAndTime: format.isoDateTime(incidentDateAndTime),
-    prisonId,
+    location,
     title: `Incident Report ${reportReference}`,
     description: `A new incident created in the new service of type ${type}`,
     reportedBy: reportingUsername,

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -13,7 +13,7 @@ import type { Services } from '../services'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 
 interface ListFormData {
-  prisonId?: string
+  location?: string
   fromDate?: string
   toDate?: string
   incidentType?: Type
@@ -33,7 +33,7 @@ export default function dashboard(service: Services): Router {
     const { incidentReportingApi, prisonApi } = res.locals.apis
 
     const {
-      prisonId,
+      location,
       fromDate: fromDateInput,
       toDate: toDateInput,
       incidentType,
@@ -51,7 +51,7 @@ export default function dashboard(service: Services): Router {
     }
 
     const formValues: ListFormData = {
-      prisonId,
+      location,
       fromDate: fromDateInput,
       toDate: toDateInput,
       incidentType: incidentType as Type,
@@ -125,7 +125,7 @@ export default function dashboard(service: Services): Router {
     const orderString = order as string
     // Get reports from API
     const reportsResponse = await incidentReportingApi.getReports({
-      prisonId,
+      location,
       incidentDateFrom: fromDate,
       incidentDateUntil: toDate,
       type: incidentType,
@@ -136,8 +136,8 @@ export default function dashboard(service: Services): Router {
     })
 
     const queryString = new URLSearchParams()
-    if (prisonId) {
-      queryString.append('prisonId', prisonId)
+    if (location) {
+      queryString.append('location', location)
     }
     if (fromDateInput) {
       queryString.append('fromDate', fromDateInput)
@@ -165,7 +165,7 @@ export default function dashboard(service: Services): Router {
     const urlPrefix = `/incidents?${queryString}&`
 
     const noFiltersSupplied = Boolean(
-      !prisonId && !fromDate && !toDate && !incidentType && !incidentStatuses && !reportingOfficer,
+      !location && !fromDate && !toDate && !incidentType && !incidentStatuses && !reportingOfficer,
     )
 
     const reports = reportsResponse.content

--- a/server/routes/reports/createReport.test.ts
+++ b/server/routes/reports/createReport.test.ts
@@ -243,7 +243,7 @@ describe('Creating a report', () => {
             createNewEvent: true,
             description: 'Disorder took place on A wing',
             incidentDateAndTime,
-            prisonId: 'MDI',
+            location: 'MDI',
             title: 'Report: disorder',
             type: 'DISORDER',
           })

--- a/server/routes/reports/createReport.ts
+++ b/server/routes/reports/createReport.ts
@@ -35,7 +35,7 @@ class DetailsController extends BaseDetailsController<CreateReportValues> {
         incidentDateAndTime,
         title,
         description,
-        prisonId: res.locals.user.activeCaseLoad.caseLoadId,
+        location: res.locals.user.activeCaseLoad.caseLoadId,
         createNewEvent: true,
       })
       logger.info(`Report ${report.reportReference} created`)

--- a/server/views/pages/dashboard.njk
+++ b/server/views/pages/dashboard.njk
@@ -24,13 +24,13 @@
 
     <form class="horizontal-form {% if errors.length > 0 %}horizontal-form--with-errors{% endif %} govuk-!-margin-bottom-3" method="get" novalidate>
       {{ govukSelect({
-        name: "prisonId",
-        id: "prisonId",
+        name: "location",
+        id: "location",
         label: {
           text: "Prison"
         },
-        items: prisons | govukSelectInsertDefault("All") | govukSelectSetSelected(formValues.prisonId),
-        errorMessage: errors | findFieldInGovukErrorSummary("prisonId")
+        items: prisons | govukSelectInsertDefault("All") | govukSelectSetSelected(formValues.location),
+        errorMessage: errors | findFieldInGovukErrorSummary("location")
       }) }}
 
       {{ mojDatePicker({

--- a/server/views/pages/debug/eventDetails.njk
+++ b/server/views/pages/debug/eventDetails.njk
@@ -31,10 +31,10 @@
       ],
       [
         {
-          text: "Prison"
+          text: "Location"
         },
         {
-          text: prisonsLookup[event.prisonId].description or event.prisonId
+          text: prisonsLookup[event.location].description or event.location
         }
       ],
       [

--- a/server/views/pages/debug/reportDetails.njk
+++ b/server/views/pages/debug/reportDetails.njk
@@ -47,10 +47,10 @@
     ],
     [
       {
-        text: "Prison"
+        text: "Location"
       },
       {
-        text: prisonsLookup[report.prisonId].description or report.prisonId
+        text: prisonsLookup[report.location].description or report.location
       }
     ],
     [


### PR DESCRIPTION
…to match api changes with respect to creating, retrieving and updating their models

Depends on [api#206](https://github.com/ministryofjustice/hmpps-incident-reporting-api/pull/206)