### PR TITLE
IR-576: View report answers

### DIFF
--- a/server/controllers/addPrisoner/addPrisoner.ts
+++ b/server/controllers/addPrisoner/addPrisoner.ts
@@ -36,9 +36,9 @@ export default class AddPrisoner extends FormInitialStep {
 
   locals(req: FormWizard.Request, res: express.Response): object {
     const locals = super.locals(req, res)
-    const incidentId = res.locals.incident.id
+    const reportId = res.locals.report.id
 
-    const backLink = `/reports/${incidentId}/prisoner-search`
+    const backLink = `/reports/${reportId}/prisoner-search`
     return {
       ...locals,
       backLink,
@@ -69,7 +69,7 @@ export default class AddPrisoner extends FormInitialStep {
         comment,
       }
 
-      await incidentReportingApi.prisonersInvolved.addToReport(res.locals.incident.id, newPrisonerData)
+      await incidentReportingApi.prisonersInvolved.addToReport(res.locals.report.id, newPrisonerData)
 
       next()
     } catch (error) {
@@ -78,7 +78,7 @@ export default class AddPrisoner extends FormInitialStep {
   }
 
   successHandler(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
-    const incidentId = res.locals.incident.id
+    const reportId = res.locals.report.id
 
     req.journeyModel.reset()
     req.sessionModel.reset()
@@ -90,6 +90,6 @@ export default class AddPrisoner extends FormInitialStep {
     })
     */
 
-    res.redirect(`/reports/${incidentId}`)
+    res.redirect(`/reports/${reportId}`)
   }
 }

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -50,7 +50,11 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
         const fieldName = this.questionIdFromCode(question.code)
         const questionConfig: QuestionConfiguration = reportConfig.questions[fieldName]
         if (questionConfig === undefined) {
-          logger.warn(new Error(`Question with code '${fieldName}' not found in ${report.type}'s configuration.`))
+          logger.warn(
+            new Error(
+              `Report '${report.id}': Question with code '${fieldName}' not found in ${report.type}'s configuration.`,
+            ),
+          )
           // eslint-disable-next-line no-continue
           continue
         }
@@ -69,7 +73,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
           if (answerConfig === undefined) {
             logger.warn(
               new Error(
-                `answer with code '${answerCode}' not found in ${report.type}'s question '${questionConfig.id}' configuration.`,
+                `Report '${report.id}': Answer with code '${answerCode}' not found in ${report.type}'s question '${questionConfig.id}' configuration.`,
               ),
             )
             // eslint-disable-next-line no-continue

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -37,7 +37,8 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
   ) {
     return super.getValues(req, res, async (err, values) => {
       if (err) {
-        return callback(err)
+        callback(err)
+        return
       }
 
       const formValues = { ...values }
@@ -98,7 +99,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
         }
       }
 
-      return callback(null, formValues)
+      callback(null, formValues)
     })
   }
 

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -3,7 +3,6 @@ import type express from 'express'
 import { BaseController } from '../index'
 import { ReportWithDetails } from '../../data/incidentReportingApi'
 import format from '../../utils/format'
-import { getIncidentTypeConfiguration } from '../../reportConfiguration/types'
 import {
   AnswerConfiguration,
   IncidentTypeConfiguration,
@@ -17,17 +16,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
   }
 
   middlewareLocals(): void {
-    this.use(this.lookupReport)
     super.middlewareLocals()
-  }
-
-  async lookupReport(req: FormWizard.Request, res: express.Response, next: express.NextFunction): Promise<void> {
-    const { incidentReportingApi } = res.locals.apis
-    const reportId = req.params.id
-
-    res.locals.report = await incidentReportingApi.getReportWithDetailsById(reportId)
-    res.locals.reportConfig = await getIncidentTypeConfiguration(res.locals.report.type)
-    next()
   }
 
   getValues(

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -1,3 +1,10 @@
+import { FormWizard } from 'hmpo-form-wizard'
+import type express from 'express'
 import { BaseController } from '../index'
 
-export default class QuestionsController extends BaseController {}
+export default class QuestionsController extends BaseController {
+  getBackLink(_req: FormWizard.Request, _res: express.Response): string {
+    // TODO: Change to `/reports/` page once we have it
+    return '/incidents/'
+  }
+}

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -1,6 +1,15 @@
 import { FormWizard } from 'hmpo-form-wizard'
 import type express from 'express'
 import { BaseController } from '../index'
+import { ReportWithDetails } from '../../data/incidentReportingApi'
+import format from '../../utils/format'
+import { getIncidentTypeConfiguration } from '../../reportConfiguration/types'
+import {
+  AnswerConfiguration,
+  IncidentTypeConfiguration,
+  QuestionConfiguration,
+} from '../../data/incidentTypeConfiguration/types'
+import logger from '../../../logger'
 
 export default class QuestionsController extends BaseController<FormWizard.MultiValues> {
   getBackLink(_req: FormWizard.Request, _res: express.Response): string {
@@ -18,6 +27,86 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
     const reportId = req.params.id
 
     res.locals.report = await incidentReportingApi.getReportWithDetailsById(reportId)
+    res.locals.reportConfig = await getIncidentTypeConfiguration(res.locals.report.type)
     next()
+  }
+
+  getValues(
+    req: FormWizard.Request<FormWizard.MultiValues, string>,
+    res: express.Response,
+    callback: FormWizard.Callback<FormWizard.MultiValues>,
+  ) {
+    return super.getValues(req, res, async (err, values) => {
+      if (err) {
+        return callback(err)
+      }
+
+      const formValues = { ...values }
+
+      const report = res.locals.report as ReportWithDetails
+      const reportConfig = res.locals.reportConfig as IncidentTypeConfiguration
+
+      for (const question of report.questions) {
+        const fieldName = this.questionIdFromCode(question.code)
+        const questionConfig: QuestionConfiguration = reportConfig.questions[fieldName]
+        if (questionConfig === undefined) {
+          logger.warn(new Error(`Question with code '${fieldName}' not found in ${report.type}'s configuration.`))
+          // eslint-disable-next-line no-continue
+          continue
+        }
+
+        // Top-level answer(s)
+        if (formValues[fieldName] === undefined) {
+          const reportValues = question.responses.map(response => response.response)
+          formValues[fieldName] = questionConfig.multipleAnswers ? reportValues : reportValues[0]
+        }
+
+        // Populate comment/date fields for each response
+        // NOTE: Each response may have its own associated comment and/or date
+        for (const response of question.responses) {
+          const answerCode = response.response
+          const answerConfig = this.findAnswerConfigByCode(answerCode, questionConfig)
+          if (answerConfig === undefined) {
+            logger.warn(
+              new Error(
+                `answer with code '${answerCode}' not found in ${report.type}'s question '${questionConfig.id}' configuration.`,
+              ),
+            )
+            // eslint-disable-next-line no-continue
+            continue
+          }
+
+          // comment field
+          if (answerConfig.commentRequired) {
+            const commentFieldName = `${questionConfig.id}-${answerConfig.id}-comment`
+            if (formValues[commentFieldName] === undefined) {
+              formValues[commentFieldName] = response.additionalInformation
+            }
+          }
+
+          // date field
+          if (answerConfig.dateRequired) {
+            const dateFieldName = `${questionConfig.id}-${answerConfig.id}-date`
+            if (formValues[dateFieldName] === undefined) {
+              formValues[dateFieldName] = format.shortDate(response.responseDate)
+            }
+          }
+        }
+      }
+
+      return callback(null, formValues)
+    })
+  }
+
+  /** Finds the Answer config for a given the answer code */
+  private findAnswerConfigByCode(answerCode: string, questionConfig: QuestionConfiguration): AnswerConfiguration {
+    return questionConfig.answers.find(answerConfig => answerConfig.code.trim() === answerCode.trim())
+  }
+
+  /** Strips `QID-0...` prefix and returns the question ID */
+  private questionIdFromCode(code: string): string {
+    const re = /^QID-0*/
+
+    return code.replace(re, '')
   }
 }

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -2,7 +2,7 @@ import { FormWizard } from 'hmpo-form-wizard'
 import type express from 'express'
 import { BaseController } from '../index'
 
-export default class QuestionsController extends BaseController {
+export default class QuestionsController extends BaseController<FormWizard.MultiValues> {
   getBackLink(_req: FormWizard.Request, _res: express.Response): string {
     // TODO: Change to `/reports/` page once we have it
     return '/incidents/'

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -7,4 +7,17 @@ export default class QuestionsController extends BaseController {
     // TODO: Change to `/reports/` page once we have it
     return '/incidents/'
   }
+
+  middlewareLocals(): void {
+    this.use(this.lookupReport)
+    super.middlewareLocals()
+  }
+
+  async lookupReport(req: FormWizard.Request, res: express.Response, next: express.NextFunction): Promise<void> {
+    const { incidentReportingApi } = res.locals.apis
+    const reportId = req.params.id
+
+    res.locals.report = await incidentReportingApi.getReportWithDetailsById(reportId)
+    next()
+  }
 }

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -50,7 +50,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
         const fieldName = this.questionIdFromCode(question.code)
         const questionConfig: QuestionConfiguration = reportConfig.questions[fieldName]
         if (questionConfig === undefined) {
-          logger.warn(
+          logger.error(
             new Error(
               `Report '${report.id}': Question with code '${fieldName}' not found in ${report.type}'s configuration.`,
             ),
@@ -71,7 +71,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
           const answerCode = response.response
           const answerConfig = this.findAnswerConfigByCode(answerCode, questionConfig)
           if (answerConfig === undefined) {
-            logger.warn(
+            logger.error(
               new Error(
                 `Report '${report.id}': Answer with code '${answerCode}' not found in ${report.type}'s question '${questionConfig.id}' configuration.`,
               ),

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -46,6 +46,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
       const reportConfig = res.locals.reportConfig as IncidentTypeConfiguration
 
       for (const question of report.questions) {
+        // TODO: Remove QID-stripping logic once removed from API
         const fieldName = this.questionIdFromCode(question.code)
         const questionConfig: QuestionConfiguration = reportConfig.questions[fieldName]
         if (questionConfig === undefined) {
@@ -102,7 +103,10 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
     return questionConfig.answers.find(answerConfig => answerConfig.code.trim() === answerCode.trim())
   }
 
-  /** Strips `QID-0...` prefix and returns the question ID */
+  /** Strips `QID-0...` prefix and returns the question ID
+   *
+   * TODO: Remove QID-stripping logic once removed from API
+   */
   private questionIdFromCode(code: string): string {
     const re = /^QID-0*/
 

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -13,8 +13,7 @@ import logger from '../../../logger'
 
 export default class QuestionsController extends BaseController<FormWizard.MultiValues> {
   getBackLink(_req: FormWizard.Request, _res: express.Response): string {
-    // TODO: Change to `/reports/` page once we have it
-    return '/incidents/'
+    return '/reports/'
   }
 
   middlewareLocals(): void {

--- a/server/data/incidentTypeConfiguration/formWizard.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.ts
@@ -12,8 +12,8 @@ const MAX_ANSWERS_PER_PAGE = 20
  * @param config questionnaire config
  * @returns the Form Wizard's steps
  */
-export function generateSteps(config: IncidentTypeConfiguration): FormWizard.Steps {
-  const steps: FormWizard.Steps = {
+export function generateSteps(config: IncidentTypeConfiguration): FormWizard.Steps<FormWizard.MultiValues> {
+  const steps: FormWizard.Steps<FormWizard.MultiValues> = {
     '/': {
       entryPoint: true,
       reset: true,
@@ -85,7 +85,7 @@ export function generateSteps(config: IncidentTypeConfiguration): FormWizard.Ste
  *
  * @param steps to group
  */
-function groupSteps(steps: FormWizard.Steps) {
+function groupSteps(steps: FormWizard.Steps<FormWizard.MultiValues>) {
   const answersCounts: Map<string, number> = new Map()
   const stepsWithSingleParent: Set<string | null> = buildStepsWithSingleParent()
 

--- a/server/data/testData/FINDS.ts
+++ b/server/data/testData/FINDS.ts
@@ -4508,7 +4508,7 @@ export const config: IncidentTypeConfiguration = {
   ],
 } as const
 
-export const steps: FormWizard.Steps = {
+export const steps: FormWizard.Steps<FormWizard.MultiValues> = {
   '/': { entryPoint: true, reset: true, resetJourney: true, skip: true, next: '67179' },
   '/67179': {
     controller: QuestionsController,

--- a/server/middleware/populateReport.test.ts
+++ b/server/middleware/populateReport.test.ts
@@ -5,11 +5,12 @@ import config from '../config'
 import { mockReport } from '../data/testData/incidentReporting'
 import { populateReport } from './populateReport'
 import { IncidentReportingApi } from '../data/incidentReportingApi'
+import { type Type } from '../reportConfiguration/constants'
 
 describe('report-loading middleware', () => {
   // 2023-12-05T12:34:56.000Z
   const now = new Date(2023, 11, 5, 12, 34, 56)
-  const basicReport = mockReport({ reportReference: '6543', reportDateAndTime: now })
+  const report = mockReport({ reportReference: '6543', reportDateAndTime: now, withDetails: true })
 
   let fakeApi: nock.Scope
 
@@ -22,27 +23,43 @@ describe('report-loading middleware', () => {
     nock.cleanAll()
   })
 
-  it('should call next request handler if report can be loaded', async () => {
-    fakeApi.get(`/incident-reports/${basicReport.id}`).reply(200, basicReport)
+  it('calls next request handler if report can be loaded', async () => {
+    fakeApi.get(`/incident-reports/${report.id}/with-details`).reply(200, report)
 
-    const req = { params: { id: basicReport.id } } as unknown as Request
+    const req = { params: { id: report.id } } as unknown as Request
     const res = { locals: { apis: { incidentReportingApi: new IncidentReportingApi('token') } } } as Response
     const next: NextFunction = jest.fn()
     await populateReport()(req, res, next)
 
     expect(next).toHaveBeenCalledWith()
-    expect(res.locals.incident.reportReference).toEqual(basicReport.reportReference)
+    expect(res.locals.report.reportReference).toEqual(report.reportReference)
+    expect(res.locals.reportConfig.incidentType).toEqual(report.type)
   })
 
-  it('should forward error if report cannot be loaded', async () => {
-    fakeApi.get(`/incident-reports/${basicReport.id}`).reply(404)
+  it('forwards error if report cannot be loaded', async () => {
+    fakeApi.get(`/incident-reports/${report.id}/with-details`).reply(404)
 
-    const req = { params: { id: basicReport.id } } as unknown as Request
+    const req = { params: { id: report.id } } as unknown as Request
     const res = { locals: { apis: { incidentReportingApi: new IncidentReportingApi('token') } } } as Response
     const next: NextFunction = jest.fn()
     await populateReport()(req, res, next)
 
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'Not Found', status: 404 }))
-    expect(res.locals.incident).toBeUndefined()
+    expect(res.locals.report).toBeUndefined()
+    expect(res.locals.reportConfig).toBeUndefined()
+  })
+
+  it('forwards error if report config cannot be loaded', async () => {
+    report.type = 'UNKNOWN' as Type
+    fakeApi.get(`/incident-reports/${report.id}/with-details`).reply(200, report)
+
+    const req = { params: { id: report.id } } as unknown as Request
+    const res = { locals: { apis: { incidentReportingApi: new IncidentReportingApi('token') } } } as Response
+    const next: NextFunction = jest.fn()
+    await populateReport()(req, res, next)
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ code: 'MODULE_NOT_FOUND' }))
+    expect(res.locals.report.reportReference).toEqual(report.reportReference)
+    expect(res.locals.reportConfig).toBeUndefined()
   })
 })

--- a/server/middleware/populateReport.ts
+++ b/server/middleware/populateReport.ts
@@ -1,15 +1,26 @@
 import type { NextFunction, Request, Response } from 'express'
 
 import logger from '../../logger'
+import { getIncidentTypeConfiguration } from '../reportConfiguration/types'
 
 // eslint-disable-next-line import/prefer-default-export
 export function populateReport() {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const { incidentReportingApi } = res.locals.apis
+    const reportId = req.params.id
+
     try {
-      const { incidentReportingApi } = res.locals.apis
-      res.locals.incident = await incidentReportingApi.getReportById(req.params.id)
+      res.locals.report = await incidentReportingApi.getReportWithDetailsById(reportId)
     } catch (error) {
-      logger.error(error, 'Failed to populate report')
+      logger.error(error, `Failed to populate report ${reportId}`)
+      next(error)
+      return
+    }
+
+    try {
+      res.locals.reportConfig = await getIncidentTypeConfiguration(res.locals.report.type)
+    } catch (error) {
+      logger.error(error, `Failed to populate config for report ${reportId} (${res.locals.report.type})`)
       next(error)
       return
     }

--- a/server/reportConfiguration/types/index.ts
+++ b/server/reportConfiguration/types/index.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import type { IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 import { types } from '../constants'
-import logger from '../../../logger'
 
 export function getAllIncidentTypeConfigurations(): Promise<IncidentTypeConfiguration[]> {
   return Promise.all(types.map(type => import(`./${type.code}`).then(module => module.default)))
@@ -12,13 +11,11 @@ export function getIncidentTypeConfiguration(type: string): Promise<IncidentType
   const ext = __filename.endsWith('.js') ? 'js' : 'ts'
   const configPath = path.resolve(__dirname, `./${type}.${ext}`)
 
-  return import(configPath)
-    .then(module => {
-      if (ext === 'js') {
-        return module.default.default
-      }
+  return import(configPath).then(module => {
+    if (ext === 'js') {
+      return module.default.default
+    }
 
-      return module.default
-    })
-    .catch(error => logger.error(`Failed to import '${type}' configuration:`, error))
+    return module.default
+  })
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -38,7 +38,7 @@ export default function routes(services: Services): Router {
   router.use('/reports/:id/update-details', updateDetailsRouter)
 
   // TODO: WIP, proof-of-concept forms auto-generated from config
-  router.use('/:reportType/questions', questionsRouter)
+  router.use('/reports/:id/questions', questionsRouter)
 
   // proof-of-concept form wizard
   router.use('/reports/:id/prisoner-search', prisonerSearchRoutes())

--- a/server/routes/questions/router.ts
+++ b/server/routes/questions/router.ts
@@ -11,14 +11,17 @@ const router = express.Router({ mergeParams: true })
 
 router.use(
   asyncMiddleware(async (req, res, next) => {
-    const { reportType } = req.params
+    const { incidentReportingApi } = res.locals.apis
+    const reportId = req.params.id
 
-    const found = getTypeDetails(reportType)
-    if (found === undefined) {
-      throw new BadRequest('Invalid report type')
+    const report = await incidentReportingApi.getReportById(reportId)
+
+    const reportTypeFound = getTypeDetails(report.type)
+    if (!reportTypeFound) {
+      throw new BadRequest(`Invalid report type '${report.type}' for report ${reportId}`)
     }
 
-    const config = await getIncidentTypeConfiguration(reportType)
+    const config = await getIncidentTypeConfiguration(report.type)
 
     const steps = generateSteps(config)
     const fields = generateFields(config)

--- a/server/routes/questions/router.ts
+++ b/server/routes/questions/router.ts
@@ -26,14 +26,20 @@ router.use(
     const steps = generateSteps(config)
     const fields = generateFields(config)
 
-    return wizard(steps, fields, {
-      name: `${reportType}-questions`,
+    const wizardRouter = wizard(steps, fields, {
+      name: `${reportId}-questions`,
       templatePath: 'pages/wip/questions',
       // Needs to be false, session already handled by application
       checkSession: false,
       // Needs to be false, CSRF already handled by application
       csrf: false,
-    })(req, res, next)
+    })
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore because express types do not mention this property
+    // and form wizard does not allow you to pass in config for it's
+    // root router
+    wizardRouter.mergeParams = true
+    wizardRouter(req, res, next)
   }),
 )
 

--- a/server/routes/questionsRoute.test.ts
+++ b/server/routes/questionsRoute.test.ts
@@ -1,0 +1,216 @@
+import type { Express } from 'express'
+import request, { type Agent } from 'supertest'
+
+import { appWithAllRoutes } from './testutils/appSetup'
+import { IncidentReportingApi, ReportBasic, ReportWithDetails } from '../data/incidentReportingApi'
+import { convertReportWithDetailsDates } from '../data/incidentReportingApiUtils'
+import { mockReport } from '../data/testData/incidentReporting'
+
+jest.mock('../data/incidentReportingApi')
+
+let app: Express
+let incidentReportingApi: jest.Mocked<IncidentReportingApi>
+
+beforeEach(() => {
+  app = appWithAllRoutes({})
+  incidentReportingApi = IncidentReportingApi.prototype as jest.Mocked<IncidentReportingApi>
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Displaying responses', () => {
+  const incidentDateAndTime = new Date('2024-10-21T16:32:00+01:00')
+  const reportWithDetails: ReportWithDetails = convertReportWithDetailsDates(
+    mockReport({
+      type: 'FINDS',
+      reportReference: '6544',
+      reportDateAndTime: incidentDateAndTime,
+      withDetails: true,
+    }),
+  )
+
+  const reportQuestionsUrl = `/reports/${reportWithDetails.id}/questions`
+
+  let agent: Agent
+
+  beforeEach(() => {
+    agent = request.agent(app)
+    incidentReportingApi.getReportById.mockResolvedValue(reportWithDetails as ReportBasic)
+    incidentReportingApi.getReportWithDetailsById.mockResolvedValue(reportWithDetails)
+  })
+
+  it('form is prefilled with report answers, including date', () => {
+    reportWithDetails.type = 'DEATH_OTHER'
+    reportWithDetails.questions = [
+      {
+        code: 'QID-000000045054',
+        question: 'WERE THE POLICE INFORMED OF THE INCIDENT',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'YES',
+            responseDate: incidentDateAndTime,
+            additionalInformation: null,
+            recordedBy: 'USER1',
+            recordedAt: new Date(),
+          },
+        ],
+      },
+    ]
+
+    return agent
+      .get(reportQuestionsUrl)
+      .redirects(1)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).not.toContain('There is a problem')
+        // 'YES' response to '45054' requires a date, this is displayed
+        expect(res.text).toContain('name="45054-182204-date" type="text" value="21/10/2024"')
+        expect(res.text).toContain('name="45054" type="radio" value="YES" checked')
+      })
+  })
+
+  it('form is prefilled with report answers, multiple choices are selected', () => {
+    reportWithDetails.type = 'FINDS'
+
+    reportWithDetails.questions = [
+      {
+        code: 'QID-000000067179',
+        question: 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'BOSS CHAIR',
+            responseDate: null,
+            additionalInformation: null,
+            recordedBy: 'USER1',
+            recordedAt: incidentDateAndTime,
+          },
+          {
+            response: 'DOG SEARCH',
+            responseDate: null,
+            additionalInformation: null,
+            recordedBy: 'USER1',
+            recordedAt: incidentDateAndTime,
+          },
+        ],
+      },
+      {
+        code: 'QID-000000067180',
+        question: 'IS THE LOCATION OF THE INCIDENT KNOWN?',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'NO',
+            responseDate: null,
+            additionalInformation: null,
+            recordedBy: 'USER1',
+            recordedAt: incidentDateAndTime,
+          },
+        ],
+      },
+    ]
+
+    return agent
+      .get(reportQuestionsUrl)
+      .redirects(1)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).not.toContain('There is a problem')
+        expect(res.text).toContain('value="BOSS CHAIR" checked')
+        expect(res.text).toContain('value="DOG SEARCH" checked')
+      })
+  })
+
+  it('form is prefilled with report answers, multiple questions answered', () => {
+    reportWithDetails.type = 'ASSAULT'
+
+    reportWithDetails.questions = [
+      {
+        code: 'QID-000000061279',
+        question: 'WHAT WAS THE MAIN MANAGEMENT OUTCOME OF THE INCIDENT',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'POLICE REFERRAL',
+            responseDate: null,
+            additionalInformation: null,
+            recordedBy: 'USER1',
+            recordedAt: incidentDateAndTime,
+          },
+        ],
+      },
+      {
+        code: 'QID-000000061280',
+        question: 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'NO',
+            responseDate: null,
+            additionalInformation: null,
+            recordedBy: 'USER1',
+            recordedAt: incidentDateAndTime,
+          },
+        ],
+      },
+      {
+        code: 'QID-000000061281',
+        question: 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'NO',
+            responseDate: null,
+            additionalInformation: null,
+            recordedBy: 'USER1',
+            recordedAt: incidentDateAndTime,
+          },
+        ],
+      },
+      {
+        code: 'QID-000000061282',
+        question: 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'NO',
+            responseDate: null,
+            additionalInformation: null,
+            recordedBy: 'USER1',
+            recordedAt: incidentDateAndTime,
+          },
+        ],
+      },
+      {
+        code: 'QID-000000061283',
+        question: 'IS THE LOCATION OF THE INCDENT KNOWN',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'YES',
+            responseDate: null,
+            additionalInformation: null,
+            recordedBy: 'USER1',
+            recordedAt: incidentDateAndTime,
+          },
+        ],
+      },
+    ]
+
+    return agent
+      .get(reportQuestionsUrl)
+      .redirects(1)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).not.toContain('There is a problem')
+        expect(res.text).toContain('name="61279" type="radio" value="POLICE REFERRAL" checked')
+        expect(res.text).toContain('name="61280" type="radio" value="NO" checked')
+        expect(res.text).toContain('name="61281" type="radio" value="NO" checked')
+        expect(res.text).toContain('name="61282" type="radio" value="NO" checked')
+        expect(res.text).toContain('name="61283" type="radio" value="YES" checked')
+      })
+  })
+})

--- a/server/routes/questionsRoute.test.ts
+++ b/server/routes/questionsRoute.test.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express'
 import request, { type Agent } from 'supertest'
 
 import { appWithAllRoutes } from './testutils/appSetup'
-import { IncidentReportingApi, ReportBasic, ReportWithDetails } from '../data/incidentReportingApi'
+import { IncidentReportingApi, ReportWithDetails } from '../data/incidentReportingApi'
 import { convertReportWithDetailsDates } from '../data/incidentReportingApiUtils'
 import { mockReport } from '../data/testData/incidentReporting'
 
@@ -37,7 +37,6 @@ describe('Displaying responses', () => {
 
   beforeEach(() => {
     agent = request.agent(app)
-    incidentReportingApi.getReportById.mockResolvedValue(reportWithDetails as ReportBasic)
     incidentReportingApi.getReportWithDetailsById.mockResolvedValue(reportWithDetails)
   })
 

--- a/server/routes/questionsRoute.test.ts
+++ b/server/routes/questionsRoute.test.ts
@@ -22,6 +22,7 @@ afterEach(() => {
 
 describe('Displaying responses', () => {
   const incidentDateAndTime = new Date('2024-10-21T16:32:00+01:00')
+  // Report type/answers updated in each test
   const reportWithDetails: ReportWithDetails = convertReportWithDetailsDates(
     mockReport({
       type: 'FINDS',

--- a/server/views/pages/wip/questions/questionPage.njk
+++ b/server/views/pages/wip/questions/questionPage.njk
@@ -18,6 +18,8 @@
 
 
     options.fields {{ options.fields | dump(2) }}
+
+    report {{ report | dump(2) }}
   </pre>
 
 {% endblock %}


### PR DESCRIPTION
Report questions page now display a report's responses to questions.

- moved questions page from `/:reportType/questions` to `/reports/:id/questions` as it now loads a report and shows the questions based on a given report's type
- the form's values are set from each of the questions' responses, unless a value is already set on the form (e.g. because user submitted a different value)
- matching between responses and fields values is done by answers' code: the `response` field of the answer's response is the "code" of the answer (e.g. `'YES'`, not an answer ID, nor the answer's label, e.g. `'Yes'`)
- values have to be set differently depending on whether the question allows multiple choices (`string[]` for checkboxes)  or a single response (`string` for radio buttons).
- each response can additionally require a date and/or a comment, this is based off the report type config. The report config is also used to determine these fields names (as their name is in the form `${question.id}-${answer.id}-(date|comment)`
- the API also currently prefixes question IDs with `QID-0...`, this may be problematic for updating questions' answers but for reading we can easily strip this prefix, which is what this does.
- finally, because of the dynamic way we import modules with the report types configuration and because of the difference between how the tests are run (TS) vs. how the application runs (transpiled JS)