### PR TITLE
IR-68: Get Azure Application Insights settings from kubernetes secret directly

### DIFF
--- a/helm_deploy/hmpps-incident-reporting/values.yaml
+++ b/helm_deploy/hmpps-incident-reporting/values.yaml
@@ -30,7 +30,6 @@ generic-service:
     REDIS_ENABLED: "true"
     REDIS_TLS_ENABLED: "true"
     TOKEN_VERIFICATION_ENABLED: "true"
-    APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
     AUDIT_ENABLED: "false"
     AUDIT_SQS_REGION: "eu-west-2"
     AUDIT_SERVICE_NAME: "UNASSIGNED"
@@ -38,6 +37,8 @@ generic-service:
   envFrom:
     - secretRef:
         name: hmpps-incident-reporting
+    - secretRef:
+        name: application-insights
 
   namespace_secrets:
     elasticache-redis:


### PR DESCRIPTION
…the k8s secret itself is created by terraform from a shared DPS secret in a AWS systems manager parameter

Ref: [hmpps-template-typescript#485](https://github.com/ministryofjustice/hmpps-template-typescript/pull/485)