### PR TITLE
IR-621: Ability to save answers to questions

### DIFF
--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -150,16 +150,12 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
 
             if (answerConfig.commentRequired) {
               const commentFieldName = `${questionConfig.id}-${answerConfig.id}-comment`
-              if (submittedValues[commentFieldName] !== '') {
-                response.additionalInformation = submittedValues[commentFieldName] as string
-              }
+              response.additionalInformation = submittedValues[commentFieldName] as string
             }
 
             if (answerConfig.dateRequired) {
               const dateFieldName = `${questionConfig.id}-${answerConfig.id}-date`
-              if (submittedValues[dateFieldName] !== '') {
-                response.responseDate = parseDateInput(submittedValues[dateFieldName] as string)
-              }
+              response.responseDate = parseDateInput(submittedValues[dateFieldName] as string)
             }
             questionResponses.responses.push(response)
           }

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -119,6 +119,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
       const questionResponses: AddOrUpdateQuestionWithResponsesRequest = {
         code: fieldName,
         question: questionConfig.code,
+        additionalInformation: null,
         responses: [],
       }
 

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -46,9 +46,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
         const questionConfig: QuestionConfiguration = reportConfig.questions[fieldName]
         if (questionConfig === undefined) {
           logger.error(
-            new Error(
-              `Report '${report.id}': Question with code '${fieldName}' not found in ${report.type}'s configuration.`,
-            ),
+            `Report '${report.id}': Question with code '${fieldName}' not found in ${report.type}'s configuration.`,
           )
           // eslint-disable-next-line no-continue
           continue
@@ -67,9 +65,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
           const answerConfig = this.findAnswerConfigByCode(answerCode, questionConfig)
           if (answerConfig === undefined) {
             logger.error(
-              new Error(
-                `Report '${report.id}': Answer with code '${answerCode}' not found in ${report.type}'s question '${questionConfig.id}' configuration.`,
-              ),
+              `Report '${report.id}': Answer with code '${answerCode}' not found in ${report.type}'s question '${questionConfig.id}' configuration.`,
             )
             // eslint-disable-next-line no-continue
             continue
@@ -114,9 +110,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
       const questionConfig = reportConfig.questions[fieldName]
       if (questionConfig === undefined) {
         logger.error(
-          new Error(
-            `Report '${report.id}': Submitted Field '${fieldName}' not found in ${report.type}'s configuration.`,
-          ),
+          `Report '${report.id}': Submitted Field '${fieldName}' not found in ${report.type}'s configuration.`,
         )
 
         // eslint-disable-next-line no-continue
@@ -138,9 +132,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
         const answerConfig = this.findAnswerConfigByCode(responseCode, questionConfig)
         if (answerConfig === undefined) {
           logger.error(
-            new Error(
-              `Report '${report.id}': Submitted Answer with code '${responseCode}' not found in ${report.type}'s question '${questionConfig.id}' configuration.`,
-            ),
+            `Report '${report.id}': Submitted Answer with code '${responseCode}' not found in ${report.type}'s question '${questionConfig.id}' configuration.`,
           )
           // eslint-disable-next-line no-continue
           continue

--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -2,8 +2,8 @@ import { FormWizard } from 'hmpo-form-wizard'
 import type express from 'express'
 import { BaseController } from '../index'
 import {
-  type AddQuestionResponseRequest,
-  type AddQuestionWithResponsesRequest,
+  type AddOrUpdateQuestionResponseRequest,
+  type AddOrUpdateQuestionWithResponsesRequest,
   type ReportWithDetails,
 } from '../../data/incidentReportingApi'
 import format from '../../utils/format'
@@ -116,7 +116,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
         // eslint-disable-next-line no-continue
         continue
       }
-      const questionResponses: AddQuestionWithResponsesRequest = {
+      const questionResponses: AddOrUpdateQuestionWithResponsesRequest = {
         code: fieldName,
         question: questionConfig.code,
         responses: [],
@@ -127,7 +127,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
         .filter(responseCode => responseCode !== '')
         .forEach(responseCode => {
           const answerConfig = this.findAnswerConfigByCode(responseCode, questionConfig)
-          const response: AddQuestionResponseRequest = {
+          const response: AddOrUpdateQuestionResponseRequest = {
             response: responseCode,
             responseDate: null,
             additionalInformation: null,
@@ -151,11 +151,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
       questionsResponses.push(questionResponses)
     }
 
-    // TODO: API could allow multiple answer per HTTP request
-    for (const questionResponses of questionsResponses) {
-      // eslint-disable-next-line no-await-in-loop
-      await incidentReportingApi.addQuestionWithResponses(report.id, questionResponses)
-    }
+    await incidentReportingApi.addOrUpdateQuestionsWithResponses(report.id, questionsResponses)
 
     super.saveValues(req, res, next)
   }

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -209,7 +209,7 @@ export type AddOrUpdateQuestionWithResponsesRequest = {
   additionalInformation?: string
 }
 
-type AddOrUpdateQuestionResponseRequest = {
+export type AddOrUpdateQuestionResponseRequest = {
   response: string
   responseDate?: Date
   additionalInformation?: string

--- a/server/routes/questions/router.test.ts
+++ b/server/routes/questions/router.test.ts
@@ -383,7 +383,7 @@ describe(`Submitting questions' responses`, () => {
       })
   })
 
-  it('form is prefilled with report answers, multiple questions answered', async () => {
+  it('submitting responses to multiple questions', async () => {
     reportWithDetails.type = 'ASSAULT'
     const firstQuestionStep = ASSAULT.startingQuestionId
     const followingStep = '61285'

--- a/server/routes/questions/router.test.ts
+++ b/server/routes/questions/router.test.ts
@@ -1,20 +1,20 @@
 import type { Express } from 'express'
 import request, { type Agent } from 'supertest'
 
-import { appWithAllRoutes } from './testutils/appSetup'
+import { appWithAllRoutes } from '../testutils/appSetup'
 import {
   type AddOrUpdateQuestionWithResponsesRequest,
   IncidentReportingApi,
   type ReportWithDetails,
-} from '../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../data/incidentReportingApiUtils'
-import { mockReport } from '../data/testData/incidentReporting'
-import DEATH_OTHER from '../reportConfiguration/types/DEATH_OTHER'
-import { parseDateInput } from '../utils/utils'
-import FINDS from '../reportConfiguration/types/FINDS'
-import ASSAULT from '../reportConfiguration/types/ASSAULT'
+} from '../../data/incidentReportingApi'
+import { convertReportWithDetailsDates } from '../../data/incidentReportingApiUtils'
+import { mockReport } from '../../data/testData/incidentReporting'
+import DEATH_OTHER from '../../reportConfiguration/types/DEATH_OTHER'
+import { parseDateInput } from '../../utils/utils'
+import FINDS from '../../reportConfiguration/types/FINDS'
+import ASSAULT from '../../reportConfiguration/types/ASSAULT'
 
-jest.mock('../data/incidentReportingApi')
+jest.mock('../../data/incidentReportingApi')
 
 let app: Express
 let incidentReportingApi: jest.Mocked<IncidentReportingApi>

--- a/server/routes/questionsRoute.test.ts
+++ b/server/routes/questionsRoute.test.ts
@@ -2,9 +2,17 @@ import type { Express } from 'express'
 import request, { type Agent } from 'supertest'
 
 import { appWithAllRoutes } from './testutils/appSetup'
-import { IncidentReportingApi, ReportWithDetails } from '../data/incidentReportingApi'
+import {
+  type AddOrUpdateQuestionWithResponsesRequest,
+  IncidentReportingApi,
+  type ReportWithDetails,
+} from '../data/incidentReportingApi'
 import { convertReportWithDetailsDates } from '../data/incidentReportingApiUtils'
 import { mockReport } from '../data/testData/incidentReporting'
+import DEATH_OTHER from '../reportConfiguration/types/DEATH_OTHER'
+import { parseDateInput } from '../utils/utils'
+import FINDS from '../reportConfiguration/types/FINDS'
+import ASSAULT from '../reportConfiguration/types/ASSAULT'
 
 jest.mock('../data/incidentReportingApi')
 
@@ -211,6 +219,262 @@ describe('Displaying responses', () => {
         expect(res.text).toContain('name="61281" type="radio" value="NO" checked')
         expect(res.text).toContain('name="61282" type="radio" value="NO" checked')
         expect(res.text).toContain('name="61283" type="radio" value="YES" checked')
+      })
+  })
+})
+
+describe(`Submitting questions' responses`, () => {
+  const incidentDateAndTime = new Date('2024-10-21T16:32:00+01:00')
+  // Report type/answers updated in each test
+  const reportWithDetails: ReportWithDetails = convertReportWithDetailsDates(
+    mockReport({
+      type: 'FINDS',
+      reportReference: '6544',
+      reportDateAndTime: incidentDateAndTime,
+      withDetails: true,
+    }),
+  )
+  reportWithDetails.questions = []
+
+  const reportQuestionsUrl = `/reports/${reportWithDetails.id}/questions`
+
+  let agent: Agent
+
+  beforeEach(() => {
+    agent = request.agent(app)
+    incidentReportingApi.getReportWithDetailsById.mockResolvedValue(reportWithDetails)
+  })
+
+  it('submitting when answers not provided shows errors', async () => {
+    reportWithDetails.type = 'DEATH_OTHER'
+    const firstQuestionStep = DEATH_OTHER.startingQuestionId
+    const followingStep = '44434'
+    const submittedAnswers = {
+      // 'WERE THE POLICE INFORMED OF THE INCIDENT',
+      '45054': '',
+    }
+
+    await agent.get(reportQuestionsUrl).redirects(1).expect(200)
+    const postUrl = `${reportQuestionsUrl}/${firstQuestionStep}/`
+    return agent
+      .post(postUrl)
+      .send(submittedAnswers)
+      .redirects(1)
+      .expect(200)
+      .expect(res => {
+        expect(incidentReportingApi.addOrUpdateQuestionsWithResponses).toHaveBeenCalledTimes(0)
+        expect(res.text).toContain('There is a problem')
+        expect(res.text).toContain('<a href="#45054">This field is required</a>')
+        expect(res.redirects[0]).toMatch(postUrl)
+        expect(res.redirects[0]).not.toMatch(`/${followingStep}`)
+      })
+  })
+
+  it('submitting when answers invalid shows errors', async () => {
+    reportWithDetails.type = 'DEATH_OTHER'
+    const firstQuestionStep = DEATH_OTHER.startingQuestionId
+    const followingStep = '44434'
+    const submittedAnswers = {
+      // 'WERE THE POLICE INFORMED OF THE INCIDENT',
+      '45054': 'YES',
+      // invalid date
+      '45054-182204-date': 'Thu 27th Nov, yesterday',
+    }
+
+    await agent.get(reportQuestionsUrl).redirects(1).expect(200)
+    const postUrl = `${reportQuestionsUrl}/${firstQuestionStep}/`
+    return agent
+      .post(postUrl)
+      .send(submittedAnswers)
+      .redirects(1)
+      .expect(200)
+      .expect(res => {
+        expect(incidentReportingApi.addOrUpdateQuestionsWithResponses).toHaveBeenCalledTimes(0)
+        expect(res.text).toContain('There is a problem')
+        expect(res.text).toContain('<a href="#45054-182204-date">Enter a date</a>')
+        expect(res.redirects[0]).toMatch(postUrl)
+        expect(res.redirects[0]).not.toMatch(`/${followingStep}`)
+      })
+  })
+
+  it('submitting answers requiring dates', async () => {
+    reportWithDetails.type = 'DEATH_OTHER'
+    const firstQuestionStep = DEATH_OTHER.startingQuestionId
+    const followingStep = '44434'
+    const responseDate = '30/07/2024'
+    const submittedAnswers = {
+      // 'WERE THE POLICE INFORMED OF THE INCIDENT',
+      '45054': 'YES',
+      '45054-182204-comment': 'ignored',
+      '45054-182204-date': responseDate,
+    }
+    const expectedRequest: AddOrUpdateQuestionWithResponsesRequest[] = [
+      {
+        code: '45054',
+        question: 'WERE THE POLICE INFORMED OF THE INCIDENT',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'YES',
+            responseDate: parseDateInput(responseDate),
+            additionalInformation: null,
+          },
+        ],
+      },
+    ]
+
+    await agent.get(reportQuestionsUrl).redirects(1).expect(200)
+    return agent
+      .post(`${reportQuestionsUrl}/${firstQuestionStep}/`)
+      .send(submittedAnswers)
+      .redirects(1)
+      .expect(200)
+      .expect(res => {
+        expect(incidentReportingApi.addOrUpdateQuestionsWithResponses).toHaveBeenCalledWith(
+          reportWithDetails.id,
+          expectedRequest,
+        )
+        expect(res.text).not.toContain('There is a problem')
+        expect(res.redirects[0]).toMatch(`/${followingStep}`)
+      })
+  })
+
+  it('submitting multiple answers to a question', async () => {
+    reportWithDetails.type = 'FINDS'
+    const firstQuestionStep = FINDS.startingQuestionId
+    const followingStep = '67180'
+    const submittedAnswers = {
+      // 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)'
+      '67179': ['BOSS CHAIR', 'DOG SEARCH'],
+    }
+    const expectedRequest: AddOrUpdateQuestionWithResponsesRequest[] = [
+      {
+        code: '67179',
+        question: 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'BOSS CHAIR',
+            responseDate: null,
+            additionalInformation: null,
+          },
+          {
+            response: 'DOG SEARCH',
+            responseDate: null,
+            additionalInformation: null,
+          },
+        ],
+      },
+    ]
+
+    await agent.get(reportQuestionsUrl).redirects(1).expect(200)
+    return agent
+      .post(`${reportQuestionsUrl}/${firstQuestionStep}/`)
+      .send(submittedAnswers)
+      .redirects(1)
+      .expect(200)
+      .expect(res => {
+        expect(incidentReportingApi.addOrUpdateQuestionsWithResponses).toHaveBeenCalledWith(
+          reportWithDetails.id,
+          expectedRequest,
+        )
+        expect(res.text).not.toContain('There is a problem')
+        expect(res.redirects[0]).toMatch(`/${followingStep}`)
+      })
+  })
+
+  it('form is prefilled with report answers, multiple questions answered', async () => {
+    reportWithDetails.type = 'ASSAULT'
+    const firstQuestionStep = ASSAULT.startingQuestionId
+    const followingStep = '61285'
+    const submittedAnswers = {
+      // 'WHAT WAS THE MAIN MANAGEMENT OUTCOME OF THE INCIDENT'
+      '61279': 'POLICE REFERRAL',
+      // 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES'
+      '61280': 'YES',
+      // 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT'
+      '61281': 'NO',
+      // 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED'
+      '61282': 'YES',
+      // 'IS THE LOCATION OF THE INCDENT KNOWN'
+      '61283': 'NO',
+    }
+    const expectedRequest: AddOrUpdateQuestionWithResponsesRequest[] = [
+      {
+        code: '61279',
+        question: 'WHAT WAS THE MAIN MANAGEMENT OUTCOME OF THE INCIDENT',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'POLICE REFERRAL',
+            responseDate: null,
+            additionalInformation: null,
+          },
+        ],
+      },
+      {
+        code: '61280',
+        question: 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'YES',
+            responseDate: null,
+            additionalInformation: null,
+          },
+        ],
+      },
+      {
+        code: '61281',
+        question: 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'NO',
+            responseDate: null,
+            additionalInformation: null,
+          },
+        ],
+      },
+      {
+        code: '61282',
+        question: 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'YES',
+            responseDate: null,
+            additionalInformation: null,
+          },
+        ],
+      },
+      {
+        code: '61283',
+        question: 'IS THE LOCATION OF THE INCDENT KNOWN',
+        additionalInformation: null,
+        responses: [
+          {
+            response: 'NO',
+            responseDate: null,
+            additionalInformation: null,
+          },
+        ],
+      },
+    ]
+
+    await agent.get(reportQuestionsUrl).redirects(1).expect(200)
+    return agent
+      .post(`${reportQuestionsUrl}/${firstQuestionStep}/`)
+      .send(submittedAnswers)
+      .redirects(1)
+      .expect(200)
+      .expect(res => {
+        expect(incidentReportingApi.addOrUpdateQuestionsWithResponses).toHaveBeenCalledWith(
+          reportWithDetails.id,
+          expectedRequest,
+        )
+        expect(res.text).not.toContain('There is a problem')
+        expect(res.redirects[0]).toMatch(`/${followingStep}`)
       })
   })
 })


### PR DESCRIPTION
Ability to save answers to a report's questions.

This is using the recently added [`PUT /incident-reports/{reportId}/questions`](https://incident-reporting-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html#/Questions%20and%20responses%20forming%20an%20incident%20report/addOrUpdateQuestionsWithResponses) endpoint so it would either save the answer if this is the first time it was submitted or it would update the answer if a previous answer record was present.