### PR TITLE
Report view: Questions case: Account for `QID-` prefix

### DIFF
--- a/server/controllers/wip/questionsController.ts
+++ b/server/controllers/wip/questionsController.ts
@@ -11,6 +11,7 @@ import {
   findAnswerConfigByCode,
   IncidentTypeConfiguration,
   QuestionConfiguration,
+  stripQidPrefix,
 } from '../../data/incidentTypeConfiguration/types'
 import logger from '../../../logger'
 import { parseDateInput } from '../../utils/utils'
@@ -42,7 +43,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
 
       for (const question of report.questions) {
         // TODO: Remove QID-stripping logic once removed from API
-        const fieldName = this.questionIdFromCode(question.code)
+        const fieldName = stripQidPrefix(question.code)
         const questionConfig: QuestionConfiguration = reportConfig.questions[fieldName]
         if (questionConfig === undefined) {
           logger.error(
@@ -181,15 +182,5 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
         next()
       }
     })
-  }
-
-  /** Strips `QID-0...` prefix and returns the question ID
-   *
-   * TODO: Remove QID-stripping logic once removed from API
-   */
-  private questionIdFromCode(code: string): string {
-    const re = /^QID-0*/
-
-    return code.replace(re, '')
   }
 }

--- a/server/data/incidentTypeConfiguration/types.ts
+++ b/server/data/incidentTypeConfiguration/types.ts
@@ -57,3 +57,13 @@ interface PrisonerRoleConfiguration {
 export function findAnswerConfigByCode(answerCode: string, questionConfig: QuestionConfiguration): AnswerConfiguration {
   return questionConfig.answers.find(answerConfig => answerConfig.code.trim() === answerCode.trim())
 }
+
+/** Strips `QID-0...` prefix and returns the question ID
+ *
+ * TODO: Remove QID-stripping logic once removed from API
+ */
+export function stripQidPrefix(code: string): string {
+  const re = /^QID-0*/
+
+  return code.replace(re, '')
+}

--- a/server/routes/viewReport.ts
+++ b/server/routes/viewReport.ts
@@ -13,7 +13,11 @@ import {
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import { populateReport } from '../middleware/populateReport'
 import { type ReportWithDetails } from '../data/incidentReportingApi'
-import { findAnswerConfigByCode, type IncidentTypeConfiguration } from '../data/incidentTypeConfiguration/types'
+import {
+  findAnswerConfigByCode,
+  stripQidPrefix,
+  type IncidentTypeConfiguration,
+} from '../data/incidentTypeConfiguration/types'
 
 export default function viewReport(service: Services): Router {
   const router = Router({ mergeParams: true })
@@ -71,7 +75,8 @@ export default function viewReport(service: Services): Router {
  */
 function useReportConfigLabels(report: ReportWithDetails, reportConfig: IncidentTypeConfiguration): ReportWithDetails {
   for (const question of report.questions) {
-    const questionConfig = reportConfig.questions[question.code]
+    const questionCode = stripQidPrefix(question.code)
+    const questionConfig = reportConfig.questions[questionCode]
     if (!questionConfig) {
       // eslint-disable-next-line no-continue
       continue


### PR DESCRIPTION
When displaying questions/answers in the report view strip any possible `QID-` prefix that may still be present in the data returned by the API.

Long term, once all the data will no longer have
these prefixes (e.g. all environment have been re-migrated) we can remove this simple logic. Although for codes without this prefix this is a no-op.