### PR TITLE
IR-721: Ensure questions are rendered in order

### DIFF
--- a/server/routes/questions/router.test.ts
+++ b/server/routes/questions/router.test.ts
@@ -73,6 +73,7 @@ describe('Displaying responses', () => {
       .redirects(1)
       .expect(200)
       .expect(res => {
+        expect(fieldNames(res.text)).toEqual(['45054'])
         expect(res.text).not.toContain('There is a problem')
         // 'YES' response to '45054' requires a date, this is displayed
         expect(res.text).toContain('name="45054-182204-date" type="text" value="21/10/2024"')
@@ -126,6 +127,7 @@ describe('Displaying responses', () => {
       .redirects(1)
       .expect(200)
       .expect(res => {
+        expect(fieldNames(res.text)).toEqual(['67179'])
         expect(res.text).not.toContain('There is a problem')
         expect(res.text).toContain('value="BOSS CHAIR" checked')
         expect(res.text).toContain('value="DOG SEARCH" checked')
@@ -214,6 +216,7 @@ describe('Displaying responses', () => {
       .expect(200)
       .expect(res => {
         expect(res.text).not.toContain('There is a problem')
+        expect(fieldNames(res.text)).toEqual(['61279', '61280', '61281', '61282', '61283'])
         expect(res.text).toContain('name="61279" type="radio" value="POLICE REFERRAL" checked')
         expect(res.text).toContain('name="61280" type="radio" value="NO" checked')
         expect(res.text).toContain('name="61281" type="radio" value="NO" checked')
@@ -264,6 +267,7 @@ describe(`Submitting questions' responses`, () => {
       .expect(res => {
         expect(incidentReportingApi.addOrUpdateQuestionsWithResponses).toHaveBeenCalledTimes(0)
         expect(res.text).toContain('There is a problem')
+        expect(fieldNames(res.text)).toEqual(['45054'])
         expect(res.text).toContain('<a href="#45054">This field is required</a>')
         expect(res.redirects[0]).toMatch(postUrl)
         expect(res.redirects[0]).not.toMatch(`/${followingStep}`)
@@ -291,6 +295,7 @@ describe(`Submitting questions' responses`, () => {
       .expect(res => {
         expect(incidentReportingApi.addOrUpdateQuestionsWithResponses).toHaveBeenCalledTimes(0)
         expect(res.text).toContain('There is a problem')
+        expect(fieldNames(res.text)).toEqual(['45054'])
         expect(res.text).toContain('<a href="#45054-182204-date">Enter a date</a>')
         expect(res.redirects[0]).toMatch(postUrl)
         expect(res.redirects[0]).not.toMatch(`/${followingStep}`)
@@ -478,3 +483,10 @@ describe(`Submitting questions' responses`, () => {
       })
   })
 })
+
+function fieldNames(response: string): string[] {
+  const regexp = /<input .* id="([0-9]+)-item"/g
+
+  const matches = [...response.matchAll(regexp)]
+  return matches.map(match => match[1])
+}

--- a/server/views/pages/wip/questions/questionPage.njk
+++ b/server/views/pages/wip/questions/questionPage.njk
@@ -1,5 +1,22 @@
 {% extends "partials/formWizardLayout.njk" %}
 
+{% block formFields %}
+  {% from "macros/renderField.njk" import renderField %}
+
+  {# NB: Fields are rendered in the original order #}
+  {% for fieldName in reportSteps[options.route].fields %}
+    {% set field = options.fields[fieldName] %}
+
+    {# NB:
+      - dependent fields are currently only used in conditionals so are rendered separately
+      - fields starting with _ are internally generated (e.g. hours and minutes subfields for time)
+    #}
+    {% if not field.dependent and not fieldName.startsWith("_") %}
+      {{ renderField(fieldName, field, options, values, errors) }}
+    {% endif %}
+  {% endfor %}
+{% endblock %}
+
 {% block content %}
   {{ super() }}
 


### PR DESCRIPTION
Looping through the fields in `option.fields` sometimes results in the questions in a group being deplayed in an order which is different from the one in the config.

This makes sure the fields are rendered in the same order as they appear in the step/config.