### PR TITLE
IR-722: Require report involvements to have names

### DIFF
--- a/server/controllers/addPrisoner/addPrisoner.ts
+++ b/server/controllers/addPrisoner/addPrisoner.ts
@@ -64,6 +64,8 @@ export default class AddPrisoner extends FormInitialStep {
 
       const newPrisonerData: PrisonerInvolvement = {
         prisonerNumber: res.locals.prisoner.prisonerNumber as string,
+        firstName: 'Not',
+        lastName: 'Known',
         prisonerRole: prisonerRole as PrisonerInvolvementRole,
         outcome,
         comment,

--- a/server/data/incidentReportingApi.test.ts
+++ b/server/data/incidentReportingApi.test.ts
@@ -135,8 +135,10 @@ describe('Incident reporting API client', () => {
         urlMethod: 'post',
         testCase: () =>
           apiClient.staffInvolved.addToReport(reportWithDetails.id, {
-            staffRole: 'ACTIVELY_INVOLVED',
             staffUsername: 'abc12a',
+            firstName: 'MARY',
+            lastName: 'JOHNSON',
+            staffRole: 'ACTIVELY_INVOLVED',
           }),
       },
       {
@@ -145,8 +147,8 @@ describe('Incident reporting API client', () => {
         urlMethod: 'patch',
         testCase: () =>
           apiClient.staffInvolved.updateForReport(reportWithDetails.id, 1, {
-            staffRole: 'ACTIVELY_INVOLVED',
             staffUsername: 'abc12a',
+            staffRole: 'ACTIVELY_INVOLVED',
           }),
       },
       {
@@ -167,6 +169,8 @@ describe('Incident reporting API client', () => {
         testCase: () =>
           apiClient.prisonersInvolved.addToReport(reportWithDetails.id, {
             prisonerNumber: 'A1111AA',
+            firstName: 'ANDREW',
+            lastName: 'ARNOLD',
             prisonerRole: 'ACTIVE_INVOLVEMENT',
           }),
       },

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -163,12 +163,16 @@ export type HistoricStatus = {
 
 export type StaffInvolvement = {
   staffUsername: string
+  firstName: string
+  lastName: string
   staffRole: StaffInvolvementRole
   comment: string | null
 }
 
 export type PrisonerInvolvement = {
   prisonerNumber: string
+  firstName: string
+  lastName: string
   prisonerRole: PrisonerInvolvementRole
   outcome: PrisonerInvolvementOutcome | null
   comment: string | null
@@ -486,18 +490,24 @@ export class IncidentReportingApi extends RestClient {
 
 type AddStaffInvolvementRequest = {
   staffUsername: string
+  firstName: string
+  lastName: string
   staffRole: StaffInvolvementRole
   comment?: string
 }
 
 type UpdateStaffInvolvementRequest = {
   staffUsername?: string
+  firstName?: string
+  lastName?: string
   staffRole?: string
   comment?: string | null
 }
 
 type AddPrisonerInvolvementRequest = {
   prisonerNumber: string
+  firstName: string
+  lastName: string
   prisonerRole: PrisonerInvolvementRole
   outcome?: PrisonerInvolvementOutcome
   comment?: string
@@ -505,6 +515,8 @@ type AddPrisonerInvolvementRequest = {
 
 type UpdatePrisonerInvolvementRequest = {
   prisonerNumber?: string
+  firstName?: string
+  lastName?: string
   prisonerRole?: PrisonerInvolvementRole
   outcome?: PrisonerInvolvementOutcome | null
   comment?: string | null

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -14,6 +14,7 @@ import type {
   CorrectionRequest,
   Question,
 } from '../incidentReportingApi'
+import { andrew, barry } from './offenderSearch'
 import { staffBarry, staffMary } from './prisonApi'
 
 interface MockEventConfig {
@@ -150,12 +151,16 @@ export function mockStaffInvolvement(index: number): DatesAsStrings<StaffInvolve
     case 0:
       return {
         staffUsername: staffMary.username,
+        firstName: staffMary.firstName,
+        lastName: staffMary.lastName,
         staffRole: 'ACTIVELY_INVOLVED',
         comment: 'Comment about Mary',
       }
     case 1:
       return {
         staffUsername: staffBarry.username,
+        firstName: staffBarry.firstName,
+        lastName: staffBarry.lastName,
         staffRole: 'PRESENT_AT_SCENE',
         comment: null,
       }
@@ -168,14 +173,18 @@ export function mockPrisonerInvolvement(index: number): DatesAsStrings<PrisonerI
   switch (index) {
     case 0:
       return {
-        prisonerNumber: 'A1111AA',
+        prisonerNumber: andrew.prisonerNumber,
+        firstName: andrew.firstName,
+        lastName: andrew.lastName,
         prisonerRole: 'ACTIVE_INVOLVEMENT',
         outcome: 'LOCAL_INVESTIGATION',
-        comment: 'Comment about A1111AA',
+        comment: `Comment about ${andrew.prisonerNumber}`,
       }
     case 1:
       return {
-        prisonerNumber: 'A2222BB',
+        prisonerNumber: barry.prisonerNumber,
+        firstName: barry.firstName,
+        lastName: barry.lastName,
         prisonerRole: 'SUSPECTED_INVOLVED',
         outcome: null,
         comment: null,


### PR DESCRIPTION
Adapting to changes in [api#237](https://github.com/ministryofjustice/hmpps-incident-reporting-api/pull/237)