### PR TITLE
Changes made to view report page as per IR-733 with corresponding changes made to some unit tests

### DIFF
--- a/server/routes/viewReport.test.ts
+++ b/server/routes/viewReport.test.ts
@@ -106,9 +106,13 @@ describe('GET view report page with details', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Andrew Arnold')
-        expect(res.text).toContain('Active involvement - Investigation (local)')
+        expect(res.text).toContain('Role: Active involvement')
+        expect(res.text).toContain('Outcome: Investigation (local)')
+        expect(res.text).toContain('Comment: Comment about A1111AA')
         expect(res.text).toContain('A2222BB')
-        expect(res.text).toContain('Suspected involved - No outcome')
+        expect(res.text).toContain('Role: Suspected involved')
+        expect(res.text).toContain('Outcome: No outcome')
+        expect(res.text).toContain('Comment: No comment')
       })
   })
   it('should render staff involved with roles', () => {
@@ -137,8 +141,9 @@ describe('GET view report page with details', () => {
       .get('/reports/6543')
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('NOT_SPECIFIED')
-        expect(res.text).toContain('Please amend question 2')
+        expect(res.text).toContain('USER2')
+        expect(res.text).toContain('Description: Please amend question 2')
+        expect(res.text).toContain('Submitted at: 5 December 2023, 12:34')
       })
   })
 })
@@ -219,7 +224,6 @@ describe('GET view report page without details', () => {
       .expect(res => {
         expect(res.text).toContain('Question responses')
         expect(res.text).toContain('No responses found')
-        expect(res.text).toContain('Add responses')
       })
   })
   it('should render correction requests', () => {

--- a/server/routes/viewReport.ts
+++ b/server/routes/viewReport.ts
@@ -33,7 +33,13 @@ export default function viewReport(service: Services): Router {
 
     let usernames = [report.reportedBy]
     if (report.staffInvolved) {
-      usernames = [...report.staffInvolved.map(staff => staff.staffUsername), report.reportedBy]
+      usernames = [...report.staffInvolved.map(staff => staff.staffUsername), ...usernames]
+    }
+    if (report.correctionRequests) {
+      usernames = [
+        ...report.correctionRequests.map(correctionRequest => correctionRequest.correctionRequestedBy),
+        ...usernames,
+      ]
     }
     const usersLookup = await userService.getUsers(res.locals.systemToken, usernames)
 

--- a/server/views/pages/debug/reportDetails.njk
+++ b/server/views/pages/debug/reportDetails.njk
@@ -17,14 +17,15 @@
 
 {%- set location =  prisonsLookup[report.location].description or report.location -%}
 {%- set reportingOfficer =  usersLookup[report.reportedBy].name or report.reportedBy -%}
+{%- set reportedDate =  report.reportedAt | date -%}
 
 {% block content %}
   <h1 class="govuk-heading-m">Report {{ report.reportReference }}
     {{ govukTag({
-    text: report.status
+    text: statusLookup[report.status] or report.status
     }) }}
   </h1>
-  <h2 class="govuk-heading-s">Incident reported in {{ location }} by {{ reportingOfficer }}</h2>
+  <h2 class="govuk-heading-s">Incident reported in {{ location }} by {{ reportingOfficer }} on {{ reportedDate }}</h2>
 
 <!-- Incident details table -->
 {{ govukSummaryList({
@@ -106,18 +107,29 @@
         {% else %}
           {%- set outcome = 'No outcome' -%}
         {% endif %}
+        {% if prisonerInvolved.comment %}
+          {%- set comment = prisonerInvolved.comment -%}
+        {% else %}
+          {%- set comment = 'No comment' -%}
+        {% endif %}
+        {% set prisonerValues %}
+          Role: {{ prisonerRole }}
+          <br />
+          Outcome: {{ outcome }}
+          <br />
+          Comment: {{ comment }}
+        {% endset %}
 
         {%- set prisonerURL = dpsUrl + '/prisoner/' + prisonerInvolved.prisonerNumber -%}
         {% set prisonerURLKey %}
           <a href="{{ prisonerURL }}" class="govuk-link">{{ prisonerName }}</a>
         {% endset %}
+
         {%- set prisonerRows = (prisonerRows.push({
           key: {
             html: prisonerURLKey
           },
-          value: {
-            text: prisonerRole + ' - ' + outcome
-          },
+          value: { html: prisonerValues },
           actions: {
             items: [
               {
@@ -177,12 +189,23 @@
       {%- set staffName = usersLookup[staffInvolved.staffUsername].name or staffInvolved.staffUsername -%}
       {%- set staffRole = staffInvolvementLookup[staffInvolved.staffRole] or staffInvolved.staffRole -%}
 
+      {% if staffInvolved.comment %}
+        {%- set comment = staffInvolved.comment -%}
+      {% else %}
+        {%- set comment = 'No comment' -%}
+      {% endif %}
+      {% set staffValues %}
+        Role: {{ staffRole }}
+        <br />
+        Comment: {{ comment }}
+      {% endset %}
+
       {%- set staffRows = (staffRows.push({
         key: {
           text: staffName
         },
         value: {
-          text: staffRole
+          html: staffValues
         },
         actions: {
           items: [
@@ -237,13 +260,7 @@
   }) }}
 
 <!-- Question responses table -->
-  {%- set questionsActionItems = [
-    {
-      href: "#",
-      text: "Add responses",
-      visuallyHiddenText: "add question responses"
-    }
-  ] -%}
+  {%- set questionsActionItems = [ ] -%}
 
   {%- if report.questions.length > 0 -%}
     {%- set questionsRows = [] -%}
@@ -254,7 +271,7 @@
             {{ response.response }}
             {% if response.responseDate %}
               <br />
-              Date: {{ response.responseDate }}
+              Date: {{ response.responseDate | date }}
             {% endif %}
             {% if response.additionalInformation %}
               <br />
@@ -277,7 +294,7 @@
     {%- endfor -%}
 
     {%- set questionsActionItems = (questionsActionItems.push({
-      href: "#",
+      href: "/reports/" + report.id + "/questions",
       text: "Change",
       visuallyHiddenText: "change question responses"
     }), questionsActionItems) -%}
@@ -306,15 +323,22 @@
   {%- if report.correctionRequests.length > 0 -%}
   {%- set correctionRows = [] -%}
     {%- for correctionRequest in report.correctionRequests -%}
-      {%- set reason = correctionRequest.reason  -%}
+      {%- set requestedBy = usersLookup[correctionRequest.correctionRequestedBy].name or correctionRequest.correctionRequestedBy -%}
       {%- set description = correctionRequest.descriptionOfChange -%}
+      {%- set requestedAt = correctionRequest.correctionRequestedAt | dateAndTime -%}
+
+      {% set correctionValues %}
+        Description: {{ description }}
+        <br />
+        Submitted at: {{ requestedAt }}
+      {% endset %}
 
       {%- set correctionRows = (correctionRows.push({
         key: {
-          text: reason
+          text: requestedBy
         },
         value: {
-          text: description
+          html: correctionValues
         }
       }), correctionRows) -%}
 


### PR DESCRIPTION
Summary of changes made in this PR:

- Text within status tag now the "user friendly" version
- Added missing date to summary title 
- Reformatted detailed within prisoners involved to include comments
- Same done for staff involved
- Add responses button removed. 
- "Change" link in question responses now takes you to start of questions with answers filled.
- Any dates showing in question responses are now formatted
- The following changes to correction requests section:

- 1. First column shows who made the request
- 2. Details now show Description of change in first line, followed by Date and time of when it was submitted on the second.