### PR TITLE
IR-743 dashboard search

### DIFF
--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -106,12 +106,14 @@ export type ReportWithDetails = ReportBasic & {
 }
 
 export type GetEventsParams = {
+  reference: string
   location: string
   eventDateFrom: Date // Inclusive
   eventDateUntil: Date // Inclusive
 } & PaginationSortingParams
 
 export type GetReportsParams = {
+  reference: string
   location: string | string[]
   source: InformationSource
   status: Status
@@ -227,7 +229,8 @@ export class IncidentReportingApi extends RestClient {
   }
 
   async getEvents(
-    { location, eventDateFrom, eventDateUntil, page, size, sort }: Partial<GetEventsParams> = {
+    { reference, location, eventDateFrom, eventDateUntil, page, size, sort }: Partial<GetEventsParams> = {
+      reference: null,
       location: null,
       eventDateFrom: null,
       eventDateUntil: null,
@@ -240,6 +243,9 @@ export class IncidentReportingApi extends RestClient {
       page,
       size,
       sort,
+    }
+    if (reference) {
+      query.reference = reference
     }
     if (location) {
       query.location = location
@@ -277,6 +283,7 @@ export class IncidentReportingApi extends RestClient {
 
   async getReports(
     {
+      reference,
       location,
       source,
       status,
@@ -292,6 +299,7 @@ export class IncidentReportingApi extends RestClient {
       size,
       sort,
     }: Partial<GetReportsParams> = {
+      reference: null,
       location: null,
       source: null,
       status: null,
@@ -312,6 +320,9 @@ export class IncidentReportingApi extends RestClient {
       page,
       size,
       sort,
+    }
+    if (reference) {
+      query.reference = reference
     }
     if (location) {
       query.location = location

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -81,7 +81,7 @@ export type ReportBasic = {
   reportReference: string
   type: Type
   incidentDateAndTime: Date
-  location: string
+  location: string | string[]
   title: string
   description: string
   reportedBy: string
@@ -112,7 +112,7 @@ export type GetEventsParams = {
 } & PaginationSortingParams
 
 export type GetReportsParams = {
-  location: string
+  location: string | string[]
   source: InformationSource
   status: Status
   type: Type

--- a/server/routes/dashboard.test.ts
+++ b/server/routes/dashboard.test.ts
@@ -1,30 +1,25 @@
 import type { Express } from 'express'
 import request from 'supertest'
 
-import { PrisonApi } from '../data/prisonApi'
 import { appWithAllRoutes } from './testutils/appSetup'
-import { IncidentReportingApi } from '../data/incidentReportingApi'
+import { type GetReportsParams, IncidentReportingApi } from '../data/incidentReportingApi'
 import { mockReport } from '../data/testData/incidentReporting'
 import { unsortedPageOf } from '../data/testData/paginatedResponses'
 import { convertBasicReportDates } from '../data/incidentReportingApiUtils'
 import UserService from '../services/userService'
 import type { User } from '../data/manageUsersApiClient'
-import { leeds, moorland } from '../data/testData/prisonApi'
 
-jest.mock('../data/prisonApi')
 jest.mock('../data/incidentReportingApi')
 jest.mock('../services/userService')
 
 let app: Express
 let incidentReportingApi: jest.Mocked<IncidentReportingApi>
 let userService: jest.Mocked<UserService>
-let prisonApi: jest.Mocked<PrisonApi>
 
 beforeEach(() => {
   userService = UserService.prototype as jest.Mocked<UserService>
   app = appWithAllRoutes({ services: { userService } })
   incidentReportingApi = IncidentReportingApi.prototype as jest.Mocked<IncidentReportingApi>
-  prisonApi = PrisonApi.prototype as jest.Mocked<PrisonApi>
 })
 
 afterEach(() => {
@@ -32,7 +27,7 @@ afterEach(() => {
 })
 
 describe('GET dashboard', () => {
-  it('should render dashboard with button and table', () => {
+  it('should render dashboard with button and table, results filtered on caseload', () => {
     const now = new Date(2023, 11, 5, 12, 34, 56)
     const mockedReports = [
       convertBasicReportDates(mockReport({ reportReference: '6543', reportDateAndTime: now })),
@@ -44,12 +39,17 @@ describe('GET dashboard', () => {
     const users: Record<string, User> = { JOHN_SMITH: { username: 'JOHN_SMITH', name: 'John Smith' } }
     userService.getUsers.mockResolvedValueOnce(users)
 
-    const prisons = {
-      LEI: leeds,
-      MDI: moorland,
+    const expectedParams: Partial<GetReportsParams> = {
+      location: ['MDI'],
+      incidentDateFrom: undefined,
+      incidentDateUntil: undefined,
+      involvingPrisonerNumber: null,
+      page: 0,
+      reference: null,
+      sort: ['incidentDateAndTime,DESC'],
+      status: undefined,
+      type: undefined,
     }
-    prisonApi.getPrisons.mockResolvedValue(prisons)
-
     return request(app)
       .get('/reports')
       .expect('Content-Type', /html/)
@@ -59,7 +59,7 @@ describe('GET dashboard', () => {
         expect(res.text).toContain('6543')
         expect(res.text).toContain('6544')
         expect(res.text).toContain('5 December 2023, 11:34')
-        expect(incidentReportingApi.getReports).toHaveBeenCalledTimes(1)
+        expect(incidentReportingApi.getReports).toHaveBeenCalledWith(expectedParams)
       })
   })
   it('should show actual name when username found, username if not', () => {
@@ -78,12 +78,6 @@ describe('GET dashboard', () => {
     const users: Record<string, User> = { JOHN_SMITH: { username: 'JOHN_SMITH', name: 'John Smith' } }
     userService.getUsers.mockResolvedValueOnce(users)
 
-    const prisons = {
-      LEI: leeds,
-      MDI: moorland,
-    }
-    prisonApi.getPrisons.mockResolvedValue(prisons)
-
     return request(app)
       .get('/reports')
       .expect('Content-Type', /html/)
@@ -91,6 +85,164 @@ describe('GET dashboard', () => {
         expect(res.text).toContain('John Smith')
         expect(res.text).not.toContain('>JOHN_SMITH<')
         expect(res.text).toContain('JOHN_WICK')
+      })
+  })
+  it('should render all filters except establishment if user caseload is only 1 establishment', () => {
+    const now = new Date(2023, 11, 5, 12, 34, 56)
+    const mockedReports = [
+      convertBasicReportDates(mockReport({ reportReference: '6543', reportDateAndTime: now })),
+      convertBasicReportDates(mockReport({ reportReference: '6544', reportDateAndTime: now })),
+    ]
+    const pageOfReports = unsortedPageOf(mockedReports)
+    incidentReportingApi.getReports.mockResolvedValueOnce(pageOfReports)
+
+    const users: Record<string, User> = { JOHN_SMITH: { username: 'JOHN_SMITH', name: 'John Smith' } }
+    userService.getUsers.mockResolvedValueOnce(users)
+
+    const expectedParams: Partial<GetReportsParams> = {
+      location: ['MDI'],
+      incidentDateFrom: undefined,
+      incidentDateUntil: undefined,
+      involvingPrisonerNumber: null,
+      page: 0,
+      reference: null,
+      sort: ['incidentDateAndTime,DESC'],
+      status: undefined,
+      type: undefined,
+    }
+    return request(app)
+      .get('/reports')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('searchID')
+        expect(res.text).toContain('Search an incident number or offender ID')
+        expect(res.text).toContain('fromDate')
+        expect(res.text).toContain('Incident date from')
+        expect(res.text).toContain('toDate')
+        expect(res.text).toContain('Incident date to')
+        expect(res.text).not.toContain('Establishment')
+        expect(res.text).not.toContain('location')
+        expect(res.text).toContain('incidentType')
+        expect(res.text).toContain('Incident type')
+        expect(res.text).toContain('Filter')
+        expect(res.text).not.toContain('Clear')
+        expect(res.text).toContain('incidentStatuses')
+        expect(incidentReportingApi.getReports).toHaveBeenCalledWith(expectedParams)
+      })
+  })
+})
+
+describe('search validations', () => {
+  it.each([
+    { scenario: 'search contains only letters', searchValue: 'abcd' },
+    { scenario: 'search contains wrong pattern', searchValue: 'AB11ABC' },
+    { scenario: 'search contains multiple values', searchValue: '12345678 A0011BC' },
+  ])('should present errors when $scenario', ({ searchValue }) => {
+    const now = new Date(2023, 11, 5, 12, 34, 56)
+    const mockedReports = [
+      convertBasicReportDates(mockReport({ reportReference: '6543', reportDateAndTime: now })),
+      convertBasicReportDates(mockReport({ reportReference: '6544', reportDateAndTime: now })),
+    ]
+    const pageOfReports = unsortedPageOf(mockedReports)
+    incidentReportingApi.getReports.mockResolvedValueOnce(pageOfReports)
+
+    const users: Record<string, User> = { JOHN_SMITH: { username: 'JOHN_SMITH', name: 'John Smith' } }
+    userService.getUsers.mockResolvedValueOnce(users)
+
+    const expectedParams: Partial<GetReportsParams> = {
+      location: ['MDI'],
+      incidentDateFrom: undefined,
+      incidentDateUntil: undefined,
+      involvingPrisonerNumber: null,
+      page: 0,
+      reference: null,
+      sort: ['incidentDateAndTime,DESC'],
+      status: undefined,
+      type: undefined,
+    }
+
+    return request(app)
+      .get(`/reports`)
+      .query({ searchID: searchValue })
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain(
+          'Enter a valid incident reference number or offender ID. For example, 12345678 or A0011BB',
+        )
+        expect(res.text).toContain('Clear')
+        expect(incidentReportingApi.getReports).toHaveBeenCalledWith(expectedParams)
+      })
+  })
+  it('should not present errors and search for reference number when only digits', () => {
+    const now = new Date(2023, 11, 5, 12, 34, 56)
+    const mockedReports = [
+      convertBasicReportDates(mockReport({ reportReference: '6543', reportDateAndTime: now })),
+      convertBasicReportDates(mockReport({ reportReference: '6544', reportDateAndTime: now })),
+    ]
+    const pageOfReports = unsortedPageOf(mockedReports)
+    incidentReportingApi.getReports.mockResolvedValueOnce(pageOfReports)
+
+    const users: Record<string, User> = { JOHN_SMITH: { username: 'JOHN_SMITH', name: 'John Smith' } }
+    userService.getUsers.mockResolvedValueOnce(users)
+
+    const expectedParams: Partial<GetReportsParams> = {
+      location: ['MDI'],
+      incidentDateFrom: undefined,
+      incidentDateUntil: undefined,
+      involvingPrisonerNumber: null,
+      page: 0,
+      reference: '12345678',
+      sort: ['incidentDateAndTime,DESC'],
+      status: undefined,
+      type: undefined,
+    }
+
+    return request(app)
+      .get(`/reports`)
+      .query({ searchID: '12345678' })
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).not.toContain(
+          'Enter a valid incident reference number or offender ID. For example, 12345678 or A0011BB',
+        )
+        expect(res.text).toContain('Clear')
+        expect(incidentReportingApi.getReports).toHaveBeenCalledWith(expectedParams)
+      })
+  })
+  it('should not present errors and search for prisoner ID when matching pattern', () => {
+    const now = new Date(2023, 11, 5, 12, 34, 56)
+    const mockedReports = [
+      convertBasicReportDates(mockReport({ reportReference: '6543', reportDateAndTime: now })),
+      convertBasicReportDates(mockReport({ reportReference: '6544', reportDateAndTime: now })),
+    ]
+    const pageOfReports = unsortedPageOf(mockedReports)
+    incidentReportingApi.getReports.mockResolvedValueOnce(pageOfReports)
+
+    const users: Record<string, User> = { JOHN_SMITH: { username: 'JOHN_SMITH', name: 'John Smith' } }
+    userService.getUsers.mockResolvedValueOnce(users)
+
+    const expectedParams: Partial<GetReportsParams> = {
+      location: ['MDI'],
+      incidentDateFrom: undefined,
+      incidentDateUntil: undefined,
+      involvingPrisonerNumber: 'A0011BC',
+      page: 0,
+      reference: null,
+      sort: ['incidentDateAndTime,DESC'],
+      status: undefined,
+      type: undefined,
+    }
+
+    return request(app)
+      .get(`/reports`)
+      .query({ searchID: 'A0011BC' })
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).not.toContain(
+          'Enter a valid incident reference number or offender ID. For example, 12345678 or A0011BB',
+        )
+        expect(res.text).toContain('Clear')
+        expect(incidentReportingApi.getReports).toHaveBeenCalledWith(expectedParams)
       })
   })
 })

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -127,7 +127,7 @@ export default function dashboard(service: Services): Router {
     let referenceNumber: string = null
     if (searchID) {
       // Test if search is for a prisoner ID and use if so
-      if (searchID.match(/[a-zA-Z][0-9]{4}[a-zA-Z]{2}/)) {
+      if (searchID.match(/^[a-zA-Z][0-9]{4}[a-zA-Z]{2}$/)) {
         prisonerId = searchID
       }
       // Test if search is for an incident reference number and use if so

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -13,11 +13,11 @@ import type { Services } from '../services'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 
 interface ListFormData {
+  searchID?: string
   location?: string
   fromDate?: string
   toDate?: string
   incidentType?: Type
-  reportingOfficer?: string
   incidentStatuses?: Status
   sort?: string
   order?: Order
@@ -32,12 +32,13 @@ export default function dashboard(service: Services): Router {
   get('/', async (req, res) => {
     const { incidentReportingApi, prisonApi } = res.locals.apis
 
+    console.log(req.query)
     const {
+      searchID,
       location,
       fromDate: fromDateInput,
       toDate: toDateInput,
       incidentType,
-      reportingOfficer,
       page,
       incidentStatuses,
     }: ListFormData = req.query
@@ -51,11 +52,11 @@ export default function dashboard(service: Services): Router {
     }
 
     const formValues: ListFormData = {
+      searchID,
       location,
       fromDate: fromDateInput,
       toDate: toDateInput,
       incidentType: incidentType as Type,
-      reportingOfficer,
       incidentStatuses: incidentStatuses as Status,
       sort,
       order: order as Order,
@@ -130,12 +131,15 @@ export default function dashboard(service: Services): Router {
       incidentDateUntil: toDate,
       type: incidentType,
       status: incidentStatuses,
-      reportedByUsername: reportingOfficer,
+      involvingPrisonerNumber: searchID,
       page: pageNumber - 1,
       sort: [`${sort},${orderString}`],
     })
 
     const queryString = new URLSearchParams()
+    if (searchID) {
+      queryString.append('searchID', searchID)
+    }
     if (location) {
       queryString.append('location', location)
     }
@@ -151,9 +155,6 @@ export default function dashboard(service: Services): Router {
     if (incidentStatuses) {
       queryString.append('incidentStatuses', incidentStatuses)
     }
-    if (reportingOfficer) {
-      queryString.append('reportingOfficer', reportingOfficer)
-    }
     const tableHeadUrlPrefix = `/reports?${queryString}&`
     if (sort) {
       queryString.append('sort', sort)
@@ -165,7 +166,7 @@ export default function dashboard(service: Services): Router {
     const urlPrefix = `/reports?${queryString}&`
 
     const noFiltersSupplied = Boolean(
-      !location && !fromDate && !toDate && !incidentType && !incidentStatuses && !reportingOfficer,
+      !searchID && !location && !fromDate && !toDate && !incidentType && !incidentStatuses,
     )
 
     const reports = reportsResponse.content

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -123,6 +123,23 @@ export default function dashboard(service: Services): Router {
       toDate = null
       errors.push({ href: '#toDate', text: `Enter a valid to date, for example ${todayAsShortDate}` })
     }
+    let prisonerId: string = null
+    let referenceNumber: string = null
+    if (searchID) {
+      // Test if search is for a prisoner ID and use if so
+      if (searchID.match(/[a-zA-Z][0-9]{4}[a-zA-Z]{2}/)) {
+        prisonerId = searchID
+      }
+      // Test if search is for an incident reference number and use if so
+      else if (searchID.match(/^[0-9]+$/)) {
+        referenceNumber = searchID
+      } else {
+        errors.push({
+          href: '#searchID',
+          text: `Enter a valid incident reference number or offender ID. For example, 12345678 or A0011BB`,
+        })
+      }
+    }
 
     // Parse page number
     let pageNumber = (page && typeof page === 'string' && parseInt(page, 10)) || 1
@@ -137,18 +154,6 @@ export default function dashboard(service: Services): Router {
     // Overwrite locations with chosen filter if it exists
     if (location) {
       searchLocations = location
-    }
-    let prisonerId: string = null
-    let referenceNumber: string = null
-    if (searchID) {
-      // Test if search is for a prisoner ID and use if so
-      if (searchID.match(/[a-zA-Z][0-9]{4}[a-zA-Z]{2}/)) {
-        prisonerId = searchID
-      }
-      // Test if search is for an incident reference number and use if so
-      if (searchID.match(/^[0-9]+$/)) {
-        referenceNumber = searchID
-      }
     }
 
     // Get reports from API

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -30,7 +30,7 @@ export default function dashboard(service: Services): Router {
   const get = (path: PathParams, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   get('/', async (req, res) => {
-    const { incidentReportingApi, prisonApi } = res.locals.apis
+    const { incidentReportingApi } = res.locals.apis
 
     const userCaseloads = res.locals.user.caseLoads
     const userCaseloadIds = userCaseloads.map(caseload => caseload.caseLoadId)
@@ -138,19 +138,33 @@ export default function dashboard(service: Services): Router {
     if (location) {
       searchLocations = location
     }
+    let prisonerId: string = null
+    let referenceNumber: string = null
+    if (searchID) {
+      // Test if search is for a prisoner ID and use if so
+      if (searchID.match(/[a-zA-Z][0-9]{4}[a-zA-Z]{2}/)) {
+        prisonerId = searchID
+      }
+      // Test if search is for an incident reference number and use if so
+      if (searchID.match(/^[0-9]+$/)) {
+        referenceNumber = searchID
+      }
+    }
 
     // Get reports from API
     const reportsResponse = await incidentReportingApi.getReports({
+      reference: referenceNumber,
       location: searchLocations,
       incidentDateFrom: fromDate,
       incidentDateUntil: toDate,
       type: incidentType,
       status: incidentStatuses,
-      involvingPrisonerNumber: searchID,
+      involvingPrisonerNumber: prisonerId,
       page: pageNumber - 1,
       sort: [`${sort},${orderString}`],
     })
 
+    // console.log(reportsResponse)
     const queryString = new URLSearchParams()
     if (searchID) {
       queryString.append('searchID', searchID)

--- a/server/views/pages/dashboard.njk
+++ b/server/views/pages/dashboard.njk
@@ -30,8 +30,9 @@
           text: "Search an incident number or offender ID",
           classes: "govuk-label--s"
         },
-        classes: "govuk-!-width-full",
-        value: formValues.searchID
+        classes: "govuk-!-width-half",
+        value: formValues.searchID,
+        errorMessage: errors | findFieldInGovukErrorSummary("searchID")
       }) }}
 
       {{ mojDatePicker({

--- a/server/views/pages/dashboard.njk
+++ b/server/views/pages/dashboard.njk
@@ -58,15 +58,17 @@
         leadingZeros: "true"
       }) }}
 
-      {{ govukSelect({
-        name: "location",
-        id: "location",
-        label: {
-          text: "Establishment"
-        },
-        items: prisons | govukSelectInsertDefault("All") | govukSelectSetSelected(formValues.location),
-        errorMessage: errors | findFieldInGovukErrorSummary("location")
-      }) }}
+      {% if showEstablishmentsFilter %}
+        {{ govukSelect({
+          name: "location",
+          id: "location",
+          label: {
+            text: "Establishment"
+          },
+          items: establishments | govukSelectInsertDefault("All") | govukSelectSetSelected(formValues.location),
+          errorMessage: errors | findFieldInGovukErrorSummary("location")
+        }) }}
+      {% endif %}
 
       {{ govukSelect({
         name: "incidentType",

--- a/server/views/pages/dashboard.njk
+++ b/server/views/pages/dashboard.njk
@@ -2,6 +2,7 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/pagination/macro.njk" import mojPagination %}
 {% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
@@ -10,7 +11,6 @@
 {% set pageTitle = applicationName + " - Home" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">Incident reports</h1>
   <div class="govuk-button-group">
     {{ govukButton({
     text: "Report an incident",
@@ -20,24 +20,25 @@
     }) }}
   </div>
   <div class="horizontal-form__wrapper govuk-!-padding-3 govuk-!-margin-bottom-5">
-    <h2 class="govuk-heading-m">Filter by</h2>
+    <h2 class="govuk-heading-l">Incident reports</h2>
 
     <form class="horizontal-form {% if errors.length > 0 %}horizontal-form--with-errors{% endif %} govuk-!-margin-bottom-3" method="get" novalidate>
-      {{ govukSelect({
-        name: "location",
-        id: "location",
+      {{ govukInput({
+        id: "searchID",
+        name: "searchID",
         label: {
-          text: "Prison"
+          text: "Search an incident number or offender ID",
+          classes: "govuk-label--s"
         },
-        items: prisons | govukSelectInsertDefault("All") | govukSelectSetSelected(formValues.location),
-        errorMessage: errors | findFieldInGovukErrorSummary("location")
+        classes: "govuk-!-width-full",
+        value: formValues.searchID
       }) }}
 
       {{ mojDatePicker({
         id: "fromDate",
         name: "fromDate",
         label: {
-          text: "Date from"
+          text: "Incident date from"
         },
         value: formValues.fromDate,
         maxDate: todayAsShortDate,
@@ -49,12 +50,22 @@
         id: "toDate",
         name: "toDate",
         label: {
-          text: "Date to"
+          text: "Incident date to"
         },
         value: formValues.toDate,
         maxDate: todayAsShortDate,
         errorMessage: errors | findFieldInGovukErrorSummary("toDate"),
         leadingZeros: "true"
+      }) }}
+
+      {{ govukSelect({
+        name: "location",
+        id: "location",
+        label: {
+          text: "Establishment"
+        },
+        items: prisons | govukSelectInsertDefault("All") | govukSelectSetSelected(formValues.location),
+        errorMessage: errors | findFieldInGovukErrorSummary("location")
       }) }}
 
       {{ govukSelect({
@@ -65,16 +76,6 @@
         },
         items: incidentTypes | govukSelectInsertDefault("Choose type") | govukSelectSetSelected(formValues.incidentType),
         errorMessage: errors | findFieldInGovukErrorSummary("incidentType")
-      }) }}
-
-      {{ govukSelect({
-        name: "reportingOfficer",
-        id: "reportingOfficer",
-        label: {
-        text: "Reporting officer"
-        },
-        items: reportingOfficers | govukSelectInsertDefault("Choose officer") | govukSelectSetSelected(formValues.reportingOfficer),
-        errorMessage: errors | findFieldInGovukErrorSummary("reportingOfficer")
       }) }}
 
       {{ govukCheckboxes({


### PR DESCRIPTION
Dashboard search functionality added as per IR-743.

In this branch:

Search added to dashboard
- Search will look for matches on incident reference number or prisoner number involved fields. Search will do either or depending on regex match on the pattern of the submitted value.
- Search input has validation that if user has submitted a value that is neither only digits or matches the prisoner id pattern, an error message will appear and the search will not be filtered.

Unit tests have been added to check this functionality.  