### PR TITLE
IR-687: Permissions checks for creating reports

### DIFF
--- a/server/data/testData/prisonApi.ts
+++ b/server/data/testData/prisonApi.ts
@@ -1,5 +1,12 @@
 import type { Prison, Staff } from '../prisonApi'
 
+export const brixton: Prison = {
+  agencyId: 'BXI',
+  description: 'Brixton (HMP)',
+  agencyType: 'INST',
+  active: true,
+}
+
 export const leeds: Prison = {
   agencyId: 'LEI',
   description: 'Leeds (HMP)',

--- a/server/routes/reports/createReport.ts
+++ b/server/routes/reports/createReport.ts
@@ -6,7 +6,7 @@ import logger from '../../../logger'
 import type { ReportWithDetails } from '../../data/incidentReportingApi'
 import { getTypeDetails } from '../../reportConfiguration/constants'
 import { logoutIf } from '../../middleware/permissions'
-import { cannotCreateReport } from './permissions'
+import { cannotCreateReportInActiveCaseload } from './permissions'
 import { BaseTypeController } from './typeController'
 import { type TypeValues, typeFields, typeFieldNames } from './typeFields'
 import { BaseDetailsController } from './detailsController'
@@ -108,4 +108,4 @@ const createReportWizardRouter = FormWizard(createReportSteps, createReportField
 createReportWizardRouter.mergeParams = true
 // eslint-disable-next-line import/prefer-default-export
 export const createReportRouter = express.Router({ mergeParams: true })
-createReportRouter.use(logoutIf(cannotCreateReport), createReportWizardRouter)
+createReportRouter.use(logoutIf(cannotCreateReportInActiveCaseload), createReportWizardRouter)

--- a/server/routes/reports/permissions.ts
+++ b/server/routes/reports/permissions.ts
@@ -1,6 +1,6 @@
 import type { Response } from 'express'
 
-import { isPrisonActiveInService, Permissions } from '../../middleware/permissions'
+import { Permissions } from '../../middleware/permissions'
 
 /**
  * Used in `logoutIf()` middleware to check that current user can view report in locals.
@@ -14,10 +14,8 @@ export function cannotViewReport(permissions: Permissions, res: Response) {
 /**
  * Used in `logoutIf()` middleware to check that current user can create a report in their active caseload.
  */
-export function cannotCreateReport(permissions: Permissions, res: Response): boolean {
-  const { user } = res.locals
-  const prisonId = user.activeCaseLoad.caseLoadId
-  return !permissions.canCreateReport || !isPrisonActiveInService(prisonId)
+export function cannotCreateReportInActiveCaseload(permissions: Permissions): boolean {
+  return !permissions.canCreateReportInActiveCaseload
 }
 
 /**

--- a/server/views/pages/dashboard.njk
+++ b/server/views/pages/dashboard.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
 {% from "moj/components/pagination/macro.njk" import mojPagination %}
 
@@ -12,12 +13,19 @@
 
 {% block content %}
   {% if permissions.canCreateReport %}
-    {{ govukButton({
-      text: "Report an incident",
-      preventDoubleClick: true,
-      href: "/create-report",
-      isStartButton: true
-    }) }}
+    {% if permissions.canCreateReportInActiveCaseload %}
+      {{ govukButton({
+        text: "Report an incident",
+        preventDoubleClick: true,
+        href: "/create-report",
+        isStartButton: true
+      }) }}
+    {% else %}
+      {{ govukWarningText({
+        text: "You must use NOMIS to create reports in this establishment",
+        iconFallbackText: "Warning"
+      }) }}
+    {% endif %}
   {% endif %}
 
   <div class="horizontal-form__wrapper govuk-!-padding-3 govuk-!-margin-bottom-5">

--- a/server/views/pages/dashboard.njk
+++ b/server/views/pages/dashboard.njk
@@ -1,5 +1,6 @@
 {% extends "../partials/layout.njk" %}
 
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
@@ -10,6 +11,19 @@
 {% from "moj/components/pagination/macro.njk" import mojPagination %}
 
 {% set pageTitle = applicationName + " - Home" %}
+
+{% block beforeContent %}
+  {{ super() }}
+
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Digital Prison Services",
+        href: dpsUrl
+      }
+    ]
+  }) }}
+{% endblock %}
 
 {% block content %}
   {% if permissions.canCreateReport %}

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -34,7 +34,7 @@
   <h1 class="govuk-heading-l">Incident reporting</h1>
 
   {% call renderDpsCards() %}
-    {% if permissions.canCreateReport %}
+    {% if permissions.canCreateReportInActiveCaseload %}
       {{ renderDpsCard({
         heading: "Report an incident",
         description: "TODO",


### PR DESCRIPTION
Improves on #304 to take user’ active caseloads into account when creating reports. This is necessary since there is no way to choose a prison when creating a report and active caseload must be assumed.