### PR TITLE
IR-68: SCSS tweak

### DIFF
--- a/assets/scss/components/_header-bar.scss
+++ b/assets/scss/components/_header-bar.scss
@@ -4,10 +4,10 @@
   background-color: govuk-colour('black');
 
   &__container {
-    @include govuk-width-container;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    @include govuk-width-container;
   }
 
   &__logo {
@@ -18,20 +18,20 @@
   }
 
   &__title {
-    @include govuk-responsive-padding(3, 'right');
     display: flex;
     align-items: center;
+    @include govuk-responsive-padding(3, 'right');
 
     &__organisation-name {
-      @include govuk-responsive-margin(2, 'right');
-      @include govuk-font($size: 24, $weight: 'bold');
       display: flex;
       align-items: center;
+      @include govuk-responsive-margin(2, 'right');
+      @include govuk-font($size: 24, $weight: 'bold');
     }
 
     &__service-name {
-      @include govuk-responsive-margin(2, 'right');
       display: none;
+      @include govuk-responsive-margin(2, 'right');
       @include govuk-font(24);
 
       @include govuk-media-query($from: desktop) {
@@ -64,8 +64,8 @@
     }
 
     &__sub-text {
-      @include govuk-font(16);
       display: none;
+      @include govuk-font(16);
 
       @include govuk-media-query($from: tablet) {
         display: block;
@@ -87,9 +87,9 @@
     }
 
     &__item {
-      @include govuk-font(19);
       margin-bottom: govuk-spacing(1);
       text-align: right;
+      @include govuk-font(19);
 
       @include govuk-media-query($from: tablet) {
         @include govuk-responsive-margin(4, 'right');
@@ -116,6 +116,6 @@
 }
 
 .govuk-phase-banner {
-  @include govuk-width-container;
   border: none;
+  @include govuk-width-container;
 }


### PR DESCRIPTION
The sass compiler issues a deprecation warnings about ordering of nested declarations but only in the fallback header component. Reordering plain properties first appeases it, but doesn’t change the actual effect on layout. (Users never see this fallback header anyway)