### PR TITLE
IR-68: Fix cancel link on form wizard pages – the font size was wrong

### DIFF
--- a/server/views/partials/formWizardLayout.njk
+++ b/server/views/partials/formWizardLayout.njk
@@ -50,7 +50,7 @@
           {% endif %}
 
           {% if cancelUrl %}
-            <a href="{{ cancelUrl }}" class="govuk-link--no-visited-state">Cancel</a>
+            <a href="{{ cancelUrl }}" class="govuk-link govuk-link--no-visited-state">Cancel</a>
           {% endif %}
         </div>
       </form>


### PR DESCRIPTION
i buggered up the size when i changed all the links to not indicate visited state