### PR TITLE
Establishment column sort bug fix

### DIFF
--- a/server/routes/dashboard/tableColumns.ts
+++ b/server/routes/dashboard/tableColumns.ts
@@ -5,7 +5,7 @@ type ColumnNames =
   | 'description'
   | 'reportedBy'
   | 'status'
-  | 'establishment'
+  | 'location'
 
 export type ColumnEntry = {
   column: ColumnNames
@@ -51,7 +51,7 @@ const statusColumn: ColumnEntry = {
 }
 
 const establishmentColumn: ColumnEntry = {
-  column: 'establishment',
+  column: 'location',
   escapedHtml: 'Establishment',
   classes: 'govuk-table__cell--establishment',
 }


### PR DESCRIPTION
Changed background column name to match filters and query. Mismatch was causing error when sorting