### PR TITLE
IR-790: DPR assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "jwt-decode": "^4.0.0",
         "nocache": "^4.0.0",
         "nunjucks": "^3.2.4",
-        "nunjucks-date": "^1.5.0",
         "passport": "^0.7.0",
         "passport-oauth2": "^1.8.0",
         "redis": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "jwt-decode": "^4.0.0",
     "nocache": "^4.0.0",
     "nunjucks": "^3.2.4",
-    "nunjucks-date": "^1.5.0",
     "passport": "^0.7.0",
     "passport-oauth2": "^1.8.0",
     "redis": "^4.7.0",

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -32,9 +32,9 @@ export default function setUpStaticResources(): Router {
     '/node_modules/@ministryofjustice/hmpps-digital-prison-reporting-frontend/dpr/assets',
     '/node_modules/accessible-autocomplete/dist',
   ).forEach(dir => staticRoute('/assets', dir))
-  staticRoute('/assets/js/jquery.min.js', '/node_modules/jquery/dist/jquery.min.js')
 
   // Digital Prison Reporting & related third-party plugins
+  staticRoute('/assets/govuk', '/node_modules/govuk-frontend/dist/govuk/assets') // DPR forces GOVUK assets to load from /assets/govuk
   staticRoute('/moj/assets', '/node_modules/@ministryofjustice/frontend/moj/assets') // DPR forces MoJ assets to load from /moj/assets
   staticRoute('/assets/dpr', '/node_modules/@ministryofjustice/hmpps-digital-prison-reporting-frontend/dpr/assets')
   staticRoute('/assets/ext/chart.js', '/node_modules/chart.js/dist/chart.umd.js')


### PR DESCRIPTION
Continues on from #342 to add missing route to GOV.UK assets for DPR pages and remove seemingly-unnecessary dependency and jQuery route