### PR TITLE
IR-801: Added `searchUsers()` method to Manage Users API client

### DIFF
--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -3,6 +3,10 @@ import type { Response as SuperAgentResponse, SuperAgentRequest } from 'superage
 import { stubFor } from './wiremock'
 import { mockUser, mockSharedUser } from '../../server/data/testData/manageUsers'
 import { staffBarry, staffMary } from '../../server/data/testData/prisonApi'
+import ManageUsersApiClient, {
+  type UsersSearchResponse,
+  type UsersSearchResult,
+} from '../../server/data/manageUsersApiClient'
 
 export default {
   /** Current user */
@@ -42,6 +46,37 @@ export default {
         }),
       ),
     ),
+
+  /** Search users */
+  stubSearchUsers: (query: string, results: UsersSearchResult[], page = 0): SuperAgentRequest => {
+    const queryRegex = [
+      `nameFilter=${encodeURIComponent(query)}`,
+      'status=ACTIVE',
+      `size=${ManageUsersApiClient.PAGE_SIZE}`,
+      `page=${page}`,
+    ].join('&')
+    const response: UsersSearchResponse = {
+      content: results,
+      number: page,
+      totalPages: 1,
+      totalElements: results.length,
+      last: true,
+    }
+
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/manage-users-api/prisonusers/search/\\?.*${queryRegex}.*`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: response,
+      },
+    })
+  },
 
   stubManageUsersPing: (): SuperAgentRequest =>
     stubFor({

--- a/server/data/manageUsersApiClient.test.ts
+++ b/server/data/manageUsersApiClient.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 
 import config from '../config'
-import ManageUsersApiClient from './manageUsersApiClient'
+import ManageUsersApiClient, { type UsersSearchResponse } from './manageUsersApiClient'
 
 jest.mock('./tokenStore/redisTokenStore')
 
@@ -21,8 +21,8 @@ describe('manageUsersApiClient', () => {
     nock.cleanAll()
   })
 
-  describe('getUser', () => {
-    it('should return data from api', async () => {
+  describe('getUser()', () => {
+    it('returns data from api', async () => {
       const response = { data: 'data' }
 
       fakeManageUsersApiClient
@@ -32,6 +32,47 @@ describe('manageUsersApiClient', () => {
 
       const output = await manageUsersApiClient.getUser(token.access_token)
       expect(output).toEqual(response)
+    })
+  })
+
+  describe('searchUsers()', () => {
+    const mockResponse: UsersSearchResponse = {
+      content: [
+        {
+          username: 'BSMITH_GEN',
+          firstName: 'Bob',
+          lastName: 'Smith',
+          email: 'bsmith@example.com',
+          activeCaseload: {
+            id: 'MDI',
+            name: 'Moorland (HMP & YOI)',
+          },
+        },
+      ],
+      number: 0,
+      totalPages: 1,
+      totalElements: 1,
+      last: true,
+    }
+
+    it('returns the search results', async () => {
+      fakeManageUsersApiClient
+        .get('/prisonusers/search?nameFilter=bob%20smith&status=ACTIVE&size=20&page=0')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(200, mockResponse)
+
+      const response = await manageUsersApiClient.searchUsers(token.access_token, 'bob smith')
+      expect(response).toEqual(mockResponse)
+    })
+
+    it('trims the query', async () => {
+      fakeManageUsersApiClient
+        .get('/prisonusers/search?nameFilter=bob%20smith&status=ACTIVE&size=20&page=0')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(200, mockResponse)
+
+      const response = await manageUsersApiClient.searchUsers(token.access_token, 'bob smith  ')
+      expect(response).toEqual(mockResponse)
     })
   })
 })

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -1,3 +1,5 @@
+import querystring from 'querystring'
+
 import logger from '../../logger'
 import config from '../config'
 import RestClient from './restClient'
@@ -13,18 +15,68 @@ export interface User {
   activeCaseLoadId?: string // deprecated, use user roles api
 }
 
+export type UsersSearchResponse = {
+  content: UsersSearchResult[]
+
+  // current page number (zero-based)
+  number: number
+  totalPages: number
+  totalElements: number
+  // is last page?
+  last: boolean
+}
+
+export type UsersSearchResult = {
+  username: string
+  firstName: string
+  lastName: string
+  email: string
+  activeCaseload: null | {
+    id: string
+    name: string
+  }
+}
+
 export default class ManageUsersApiClient {
+  static readonly PAGE_SIZE = 20
+
   private static restClient(token: string): RestClient {
     return new RestClient('Manage Users Api Client', config.apis.manageUsersApi, token)
   }
 
+  /**
+   * Get current user details
+   */
   getUser(token: string): Promise<User> {
     logger.info('Getting user details: calling HMPPS Manage Users Api')
     return ManageUsersApiClient.restClient(token).get<User>({ path: '/users/me' })
   }
 
+  /**
+   * Get a user by username
+   */
   getNamedUser(token: string, username: string): Promise<User> {
     logger.info(`Getting ${username} user details: calling HMPPS Manage Users Api`)
     return ManageUsersApiClient.restClient(token).get<User>({ path: `/users/${username}` })
+  }
+
+  /**
+   * Search for NOMIS users matching on partial first name, surname, username or email
+   *
+   * Requires role ROLE_MAINTAIN_ACCESS_ROLES_ADMIN
+   */
+  searchUsers(token: string, query: string, page: number = 0): Promise<UsersSearchResponse> {
+    type Status = 'ACTIVE' | 'INACTIVE' | 'ALL'
+    const status: Status = 'ACTIVE'
+
+    return ManageUsersApiClient.restClient(token).get({
+      path: `/prisonusers/search`,
+      query: querystring.stringify({
+        nameFilter: query?.trim(),
+        status,
+        size: ManageUsersApiClient.PAGE_SIZE,
+        page,
+      }),
+    })
   }
 }


### PR DESCRIPTION
Uses the [`GET /prisonusers/search` endpoint] to search for NOMIS users.

This endpoint was chosen instead of other (similar) [`GET /users/search` endpoint](https://manage-users-api.hmpps.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/user-search-controller/searchForUsersInMultipleSourceSystems) because response
contains active caseload of users (when present) which is something designs suggest
is needed.

The query string is matched against first/last name, username or email address.

Client needs the `MAINTAIN_ACCESS_ROLES_ADMIN` role (currently anyway) to be able to search all users.

[`GET /prisonusers/search` endpoint]: https://manage-users-api.hmpps.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/user-search-controller/getUsers