### PR TITLE
IR-801: Remove unnecessary querystring.stringify() call

### DIFF
--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -1,5 +1,3 @@
-import querystring from 'querystring'
-
 import logger from '../../logger'
 import config from '../config'
 import RestClient from './restClient'
@@ -71,12 +69,12 @@ export default class ManageUsersApiClient {
 
     return ManageUsersApiClient.restClient(token).get({
       path: `/prisonusers/search`,
-      query: querystring.stringify({
+      query: {
         nameFilter: query?.trim(),
         status,
         size: ManageUsersApiClient.PAGE_SIZE,
         page,
-      }),
+      },
     })
   }
 }


### PR DESCRIPTION
Superagent takes care of that so we don't need to stringify the query parameters (we don't do it in the other clients)