### PR TITLE
IR-954: Allow changing a report’s type

### DIFF
--- a/integration_tests/e2e/changeType.cy.ts
+++ b/integration_tests/e2e/changeType.cy.ts
@@ -1,0 +1,175 @@
+import { mockReport } from '../../server/data/testData/incidentReporting'
+import Page from '../pages/page'
+import { ChangeTypeConfirmationPage, TypePage } from '../pages/reports/type'
+
+context('Change incident type', () => {
+  const now = new Date()
+  const reportWithDetails = mockReport({
+    type: 'DISORDER',
+    reportReference: '6544',
+    reportDateAndTime: now,
+    withDetails: true, // needed when redirecting back to view page
+  })
+  reportWithDetails.prisonersInvolved = []
+  reportWithDetails.prisonerInvolvementDone = false
+  reportWithDetails.staffInvolved = []
+  reportWithDetails.staffInvolvementDone = false
+  reportWithDetails.questions = []
+  reportWithDetails.correctionRequests = []
+
+  beforeEach(() => {
+    cy.resetBasicStubs()
+
+    cy.signIn()
+    cy.task('stubIncidentReportingApiGetReportById', { report: reportWithDetails })
+    cy.visit(`/reports/${reportWithDetails.id}/change-type`)
+  })
+
+  it('should list available types', () => {
+    const changeTypeConfirmationPage = Page.verifyOnPage(ChangeTypeConfirmationPage)
+    changeTypeConfirmationPage.submit()
+
+    const typePage = Page.verifyOnPage(TypePage)
+    typePage.typeChoices.then(choices => {
+      expect(choices).to.deep.equal([
+        {
+          label: 'Absconder',
+          value: 'ABSCONDER',
+          checked: false,
+        },
+        {
+          label: 'Assault',
+          value: 'ASSAULT',
+          checked: false,
+        },
+        {
+          label: 'Attempted escape from custody',
+          value: 'ATTEMPTED_ESCAPE_FROM_CUSTODY',
+          checked: false,
+        },
+        {
+          label: 'Attempted escape from escort',
+          value: 'ATTEMPTED_ESCAPE_FROM_ESCORT',
+          checked: false,
+        },
+        {
+          label: 'Bomb threat',
+          value: 'BOMB_THREAT',
+          checked: false,
+        },
+        {
+          label: 'Breach of security',
+          value: 'BREACH_OF_SECURITY',
+          checked: false,
+        },
+        {
+          label: 'Death in custody',
+          value: 'DEATH_IN_CUSTODY',
+          checked: false,
+        },
+        {
+          label: 'Death (other)',
+          value: 'DEATH_OTHER',
+          checked: false,
+        },
+        {
+          label: 'Drone sighting',
+          value: 'DRONE_SIGHTING',
+          checked: false,
+        },
+        {
+          label: 'Escape from custody',
+          value: 'ESCAPE_FROM_CUSTODY',
+          checked: false,
+        },
+        {
+          label: 'Escape from escort',
+          value: 'ESCAPE_FROM_ESCORT',
+          checked: false,
+        },
+        {
+          label: 'Finds',
+          value: 'FINDS',
+          checked: false,
+        },
+        {
+          label: 'Fire',
+          value: 'FIRE',
+          checked: false,
+        },
+        {
+          label: 'Food refusal',
+          value: 'FOOD_REFUSAL',
+          checked: false,
+        },
+        {
+          label: 'Full close down search',
+          value: 'FULL_CLOSE_DOWN_SEARCH',
+          checked: false,
+        },
+        {
+          label: 'Key lock incident',
+          value: 'KEY_LOCK_INCIDENT',
+          checked: false,
+        },
+        {
+          label: 'Radio compromise',
+          value: 'RADIO_COMPROMISE',
+          checked: false,
+        },
+        {
+          label: 'Released in error',
+          value: 'RELEASED_IN_ERROR',
+          checked: false,
+        },
+        {
+          label: 'Self harm',
+          value: 'SELF_HARM',
+          checked: false,
+        },
+        {
+          label: 'Temporary release failure',
+          value: 'TEMPORARY_RELEASE_FAILURE',
+          checked: false,
+        },
+        {
+          label: 'Tool loss',
+          value: 'TOOL_LOSS',
+          checked: false,
+        },
+        {
+          label: 'Miscellaneous',
+          value: 'MISCELLANEOUS',
+          checked: false,
+        },
+      ])
+    })
+  })
+
+  it('should show an error if not type is chosen', () => {
+    const changeTypeConfirmationPage = Page.verifyOnPage(ChangeTypeConfirmationPage)
+    changeTypeConfirmationPage.submit()
+
+    const typePage = Page.verifyOnPage(TypePage)
+    typePage.submit()
+    typePage.errorSummary.contains('There is a problem')
+  })
+
+  it('should allow changing type', () => {
+    const changeTypeConfirmationPage = Page.verifyOnPage(ChangeTypeConfirmationPage)
+    changeTypeConfirmationPage.submit()
+
+    const typePage = Page.verifyOnPage(TypePage)
+    typePage.selectType('MISCELLANEOUS')
+
+    cy.task('stubIncidentReportingApiChangeReportType', {
+      request: { newType: 'MISCELLANEOUS' },
+      report: reportWithDetails,
+    })
+    cy.task('stubIncidentReportingApiGetReportWithDetailsById', { report: reportWithDetails })
+    cy.task('stubPrisonApiMockPrisons')
+    cy.task('stubManageKnownUsers')
+
+    typePage.submit()
+  })
+})

--- a/integration_tests/e2e/createCompletedReport.cy.ts
+++ b/integration_tests/e2e/createCompletedReport.cy.ts
@@ -8,7 +8,7 @@ import { andrew } from '../../server/data/testData/offenderSearch'
 import { moorland, staffMary } from '../../server/data/testData/prisonApi'
 import HomePage from '../pages/home'
 import Page from '../pages/page'
-import TypePage from '../pages/reports/type'
+import { TypePage } from '../pages/reports/type'
 import DetailsPage from '../pages/reports/details'
 import {
   AddPrisonerInvolvementsPage,

--- a/integration_tests/e2e/createMinimalDraftReport.cy.ts
+++ b/integration_tests/e2e/createMinimalDraftReport.cy.ts
@@ -1,7 +1,7 @@
 import { mockReport } from '../../server/data/testData/incidentReporting'
 import HomePage from '../pages/home'
 import Page from '../pages/page'
-import TypePage from '../pages/reports/type'
+import { TypePage } from '../pages/reports/type'
 import DetailsPage from '../pages/reports/details'
 import { PrisonerInvolvementsPage } from '../pages/reports/involvements/prisoners'
 

--- a/integration_tests/e2e/dashboard.cy.ts
+++ b/integration_tests/e2e/dashboard.cy.ts
@@ -4,7 +4,7 @@ import { DashboardPage } from '../pages/dashboard'
 import HomePage from '../pages/home'
 import Page from '../pages/page'
 import ReportPage from '../pages/reports/report'
-import TypePage from '../pages/reports/type'
+import { TypePage } from '../pages/reports/type'
 import { mockReport } from '../../server/data/testData/incidentReporting'
 
 context('Searching for a report', () => {

--- a/integration_tests/e2e/viewReport.cy.ts
+++ b/integration_tests/e2e/viewReport.cy.ts
@@ -163,9 +163,6 @@ context('View report', () => {
 
         expect(typeRow.value).to.contain('Disorder')
         expect(typeRow.actionLinks).to.have.lengthOf(0)
-        // TODO: on a different branch
-        // expect(typeRow.actionLink).to.contain('Change')
-        // expect(typeRow.actionLink).attr('href').contains(`/reports/${reportWithDetails.id}/change-type`)
 
         expect(dateRow.value).to.contain(now.getFullYear())
         expect(dateRow.actionLinks).to.have.lengthOf(1)

--- a/integration_tests/e2e/viewReport.cy.ts
+++ b/integration_tests/e2e/viewReport.cy.ts
@@ -49,11 +49,9 @@ context('View report', () => {
         const [typeRow, dateRow, descriptionRow] = rows
 
         expect(typeRow.value).to.contain('Disorder')
-        expect(typeRow.actionLinks).to.have.lengthOf(0)
-        // TODO: on a different branch
-        // expect(typeRow.actionLinks).to.have.lengthOf(1)
-        // expect(typeRow.actionLinks[0]).to.contain('Change')
-        // expect(typeRow.actionLinks[0]).attr('href').contains(`/reports/${reportWithDetails.id}/change-type`)
+        expect(typeRow.actionLinks).to.have.lengthOf(1)
+        expect(typeRow.actionLinks[0]).to.contain('Change')
+        expect(typeRow.actionLinks[0]).attr('href').contains(`/reports/${reportWithDetails.id}/change-type`)
 
         expect(dateRow.value).to.contain(now.getFullYear())
         expect(dateRow.actionLinks).to.have.lengthOf(1)

--- a/integration_tests/pages/reports/type.ts
+++ b/integration_tests/pages/reports/type.ts
@@ -1,10 +1,21 @@
+// eslint-disable-next-line max-classes-per-file
 import { type Type, getTypeDetails } from '../../../server/reportConfiguration/constants'
 import FormWizardPage from '../formWizard'
 import type { PageElement } from '../page'
 
-export default class TypePage extends FormWizardPage {
+export class ChangeTypeConfirmationPage extends FormWizardPage {
+  constructor() {
+    super('Some of your answers will be deleted')
+  }
+}
+
+export class TypePage extends FormWizardPage {
   constructor() {
     super('Select the incident type')
+  }
+
+  get typeChoices() {
+    return this.radioOrCheckboxOptions('type')
   }
 
   selectType(type: Type): PageElement<HTMLLabelElement> {

--- a/server/middleware/populateReportConfiguration.test.ts
+++ b/server/middleware/populateReportConfiguration.test.ts
@@ -84,7 +84,7 @@ describe('Middleware to load report configuration and progress', () => {
     expect(res.locals.questionSteps).toBeUndefined()
     expect(res.locals.questionProgress).toBeUndefined()
     expect(next).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'populateReportConfiguration() requires req.locals.report', status: 501 }),
+      expect.objectContaining({ message: 'populateReportConfiguration() requires res.locals.report', status: 501 }),
     )
   })
 })

--- a/server/middleware/populateReportConfiguration.ts
+++ b/server/middleware/populateReportConfiguration.ts
@@ -17,7 +17,7 @@ export function populateReportConfiguration(generateQuestionSteps = true) {
     const { report } = res.locals
     if (!report) {
       // expect to always be used after populateReport() middleware
-      next(new NotImplemented('populateReportConfiguration() requires req.locals.report'))
+      next(new NotImplemented('populateReportConfiguration() requires res.locals.report'))
       return
     }
 

--- a/server/middleware/redirectOnReportStatus.test.ts
+++ b/server/middleware/redirectOnReportStatus.test.ts
@@ -1,0 +1,50 @@
+import type { NextFunction, Request, Response } from 'express'
+
+import { convertReportDates } from '../data/incidentReportingApiUtils'
+import { mockReport } from '../data/testData/incidentReporting'
+import { now } from '../testutils/fakeClock'
+import { redirectIfStatusNot } from './redirectOnReportStatus'
+
+describe('Middleware to redirect to report view depending on status', () => {
+  const mockedReport = convertReportDates(
+    mockReport({ reportReference: '6543', reportDateAndTime: now, withDetails: false }),
+  )
+  const reportUrl = `/reports/${mockedReport.id}`
+
+  it('should redirect to report view page when the status is not listed', async () => {
+    mockedReport.status = 'AWAITING_ANALYSIS'
+    const req = {} as unknown as Request
+    const res = { locals: { report: mockedReport, reportUrl }, redirect: jest.fn() } as unknown as Response
+    const next: NextFunction = jest.fn()
+
+    await redirectIfStatusNot('DRAFT', 'INFORMATION_REQUIRED')(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.redirect).toHaveBeenCalledWith(reportUrl)
+  })
+
+  it('should call next handler when the status is listed', async () => {
+    mockedReport.status = 'DRAFT'
+    const req = {} as unknown as Request
+    const res = { locals: { report: mockedReport, reportUrl }, redirect: jest.fn() } as unknown as Response
+    const next: NextFunction = jest.fn()
+
+    await redirectIfStatusNot('DRAFT', 'INFORMATION_REQUIRED')(req, res, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+
+  it('should fail if report local is not supplied', async () => {
+    const req = {} as unknown as Request
+    const res = { locals: {}, redirect: jest.fn() } as unknown as Response
+    const next: NextFunction = jest.fn()
+
+    await redirectIfStatusNot('DRAFT', 'INFORMATION_REQUIRED')(req, res, next)
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'redirectIfStatusNot() requires res.locals.report', status: 501 }),
+    )
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+})

--- a/server/middleware/redirectOnReportStatus.ts
+++ b/server/middleware/redirectOnReportStatus.ts
@@ -1,0 +1,28 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express'
+import { NotImplemented } from 'http-errors'
+
+import logger from '../../logger'
+import type { Status } from '../reportConfiguration/constants'
+
+// eslint-disable-next-line import/prefer-default-export
+export function redirectIfStatusNot(...statuses: Status[]): RequestHandler {
+  if (!statuses.length) {
+    throw new NotImplemented('redirectIfStatusNot() requires at least one status')
+  }
+
+  return (_req: Request, res: Response, next: NextFunction): void => {
+    const { report } = res.locals
+    if (!report) {
+      // expect to always be used after populateReport() middleware
+      next(new NotImplemented('redirectIfStatusNot() requires res.locals.report'))
+      return
+    }
+
+    if (statuses.includes(report.status)) {
+      logger.info('Report %s status is %s but route requires %j', report.id, report.status, statuses)
+      next()
+    } else {
+      res.redirect(res.locals.reportUrl)
+    }
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,6 +7,7 @@ import { PrisonApi } from '../data/prisonApi'
 import makeDebugRoutes from './debug'
 import makeDownloadConfigRouter from './downloadReportConfig'
 import { createReportRouter } from './reports/createReportRouter'
+import { changeTypeRouter } from './reports/details/changeType'
 import { updateDetailsRouter } from './reports/details/updateReportDetails'
 import { historyRouter } from './reports/history'
 import { viewReportRouter } from './reports/viewReport'
@@ -35,6 +36,7 @@ export default function routes(services: Services): Router {
   router.use('/create-report', createReportRouter)
   router.use('/reports/:reportId', viewReportRouter(services))
   router.use('/reports/:reportId/history', historyRouter(services))
+  router.use('/reports/:reportId/change-type', changeTypeRouter)
   router.use('/reports/:reportId/update-details', updateDetailsRouter)
   router.use('/reports/:reportId', editReportRouter)
 

--- a/server/routes/reports/details/changeType.test.ts
+++ b/server/routes/reports/details/changeType.test.ts
@@ -1,0 +1,183 @@
+import request, { type Agent } from 'supertest'
+
+import { appWithAllRoutes } from '../../testutils/appSetup'
+import { IncidentReportingApi, type ReportBasic, ReportWithDetails } from '../../../data/incidentReportingApi'
+import { convertBasicReportDates } from '../../../data/incidentReportingApiUtils'
+import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
+import { mockThrownError } from '../../../data/testData/thrownErrors'
+import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../data/testData/users'
+import { types } from '../../../reportConfiguration/constants'
+import { now } from '../../../testutils/fakeClock'
+
+jest.mock('../../../data/incidentReportingApi')
+
+let agent: Agent
+let incidentReportingApi: jest.Mocked<IncidentReportingApi>
+
+beforeEach(() => {
+  agent = request.agent(appWithAllRoutes())
+  incidentReportingApi = IncidentReportingApi.prototype as jest.Mocked<IncidentReportingApi>
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Changing incident type', () => {
+  let mockedReport: ReportBasic
+
+  let confirmationUrl: string
+  let selectUrl: string
+
+  beforeEach(() => {
+    mockedReport = convertBasicReportDates(
+      mockReport({
+        type: 'DISORDER',
+        reportReference: '6544',
+        reportDateAndTime: now,
+      }),
+    )
+    confirmationUrl = `/reports/${mockedReport.id}/change-type`
+    selectUrl = `/reports/${mockedReport.id}/change-type/select`
+
+    incidentReportingApi.getReportById.mockResolvedValueOnce(mockedReport)
+    incidentReportingApi.changeReportType.mockRejectedValue(new Error('should not be called'))
+  })
+
+  it('should 404 if report is not found', () => {
+    const error = mockThrownError(mockErrorResponse({ status: 404, message: 'Report not found' }), 404)
+    incidentReportingApi.getReportById.mockReset()
+    incidentReportingApi.getReportById.mockRejectedValueOnce(error)
+
+    return agent
+      .get(confirmationUrl)
+      .expect(404)
+      .expect(res => {
+        expect(res.text).toContain('Page not found')
+      })
+  })
+
+  it('should show a confirmation page first', () => {
+    return agent
+      .get(confirmationUrl)
+      .expect(200)
+      .expect(res => {
+        expect(res.request.url.endsWith('/change-type')).toBe(true)
+        expect(res.text).toContain('app-confirm-change-type')
+        expect(res.text).toContain('Some of your answers will be deleted')
+      })
+  })
+
+  describe('After confirmation page', () => {
+    beforeEach(async () => {
+      await agent.post(confirmationUrl).send({})
+      incidentReportingApi.getReportById.mockResolvedValueOnce(mockedReport)
+    })
+
+    it('should list active incident types apart from current one', () => {
+      return agent
+        .get(selectUrl)
+        .expect(200)
+        .expect(res => {
+          expect(res.request.url.endsWith('/change-type/select')).toBe(true)
+
+          expect(res.text).toContain('app-type')
+
+          expect(res.text).toContain('Select the incident type')
+          types.forEach(type => {
+            if (type.code === mockedReport.type || !type.active) {
+              expect(res.text).not.toContain(type.code)
+              // TODO: there is overlap with active types
+              // expect(res.text).not.toContain(type.description)
+            } else {
+              expect(res.text).toContain(type.code)
+              expect(res.text).toContain(type.description)
+            }
+          })
+
+          expect(res.text).not.toContain('There is a problem')
+          expect(res.text).not.toContain('Choose one of the options')
+        })
+    })
+
+    it.each([
+      { scenario: 'no option is selected', invalidPayload: {} },
+      { scenario: 'an inactive type is submitted', invalidPayload: { type: 'OLD_DISORDER' } },
+      { scenario: 'current type is submitted', invalidPayload: { type: 'DISORDER' } },
+    ])('should show an error if $scenario', ({ invalidPayload }) => {
+      incidentReportingApi.getReportById.mockResolvedValueOnce(mockedReport) // due to redirect
+
+      return agent
+        .post(selectUrl)
+        .send(invalidPayload)
+        .expect(200)
+        .redirects(1)
+        .expect(res => {
+          expect(res.request.url.endsWith('/change-type/select')).toBe(true)
+          expect(res.text).toContain('app-type')
+          expect(res.text).toContain('There is a problem')
+          expect(res.text).toContain('Choose one of the options')
+        })
+    })
+
+    it('should send request to API if form is valid and proceed to next step', () => {
+      incidentReportingApi.changeReportType.mockReset()
+      incidentReportingApi.changeReportType.mockResolvedValueOnce(mockedReport as ReportWithDetails) // mock is basic but value is unused anyway
+
+      return agent
+        .post(selectUrl)
+        .send({ type: 'MISCELLANEOUS' })
+        .expect(302)
+        .expect(res => {
+          expect(res.redirect).toBe(true)
+          expect(res.header.location).toEqual(`/reports/${mockedReport.id}`)
+          expect(incidentReportingApi.changeReportType).toHaveBeenCalledWith(mockedReport.id, {
+            newType: 'MISCELLANEOUS',
+          })
+        })
+    })
+
+    it('should show an error if API rejects request', () => {
+      const error = mockThrownError(mockErrorResponse({ message: 'Type is inactive' }))
+      incidentReportingApi.changeReportType.mockReset()
+      incidentReportingApi.changeReportType.mockRejectedValueOnce(error)
+      incidentReportingApi.getReportById.mockResolvedValueOnce(mockedReport) // due to redirect
+
+      return agent
+        .post(selectUrl)
+        .send({ type: 'MISCELLANEOUS' })
+        .redirects(1)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('There is a problem')
+          expect(res.text).toContain('Sorry, there was a problem with your request')
+          expect(res.text).not.toContain('Bad Request')
+          expect(res.text).not.toContain('Type is inactive')
+        })
+    })
+  })
+
+  describe('Permissions', () => {
+    // NB: these test cases are simplified because the permissions class methods are thoroughly tested elsewhere
+
+    const granted = 'granted' as const
+    const denied = 'denied' as const
+    it.each([
+      { userType: 'reporting officer', user: reportingUser, action: granted },
+      { userType: 'data warden', user: approverUser, action: denied },
+      { userType: 'HQ view-only user', user: hqUser, action: denied },
+      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+    ])('should be $action to $userType', ({ user, action }) => {
+      const testRequest = request
+        .agent(appWithAllRoutes({ userSupplier: () => user }))
+        .get(confirmationUrl)
+        .redirects(1)
+      if (action === 'granted') {
+        return testRequest.expect(200)
+      }
+      return testRequest.expect(res => {
+        expect(res.redirects[0]).toContain('/sign-out')
+      })
+    })
+  })
+})

--- a/server/routes/reports/details/changeType.test.ts
+++ b/server/routes/reports/details/changeType.test.ts
@@ -57,6 +57,17 @@ describe('Changing incident type', () => {
       })
   })
 
+  it('should redirect if report is not a draft', () => {
+    mockedReport.status = 'AWAITING_ANALYSIS'
+    return agent
+      .get(confirmationUrl)
+      .expect(302)
+      .expect(res => {
+        expect(res.redirect).toBe(true)
+        expect(res.header.location).toEqual(`/reports/${mockedReport.id}`)
+      })
+  })
+
   it('should show a confirmation page first', () => {
     return agent
       .get(confirmationUrl)

--- a/server/routes/reports/details/changeType.ts
+++ b/server/routes/reports/details/changeType.ts
@@ -7,6 +7,7 @@ import { BaseController } from '../../../controllers'
 import type { ReportBasic } from '../../../data/incidentReportingApi'
 import { logoutIf } from '../../../middleware/permissions'
 import { populateReport } from '../../../middleware/populateReport'
+import { redirectIfStatusNot } from '../../../middleware/redirectOnReportStatus'
 import { cannotEditReport } from '../permissions'
 import { BaseTypeController } from './typeController'
 import { type TypeValues, typeFields, typeFieldNames } from './typeFields'
@@ -107,4 +108,9 @@ const changeTypeWizardRouter = FormWizard(changeTypeSteps, changeTypeFields, cha
 changeTypeWizardRouter.mergeParams = true
 // eslint-disable-next-line import/prefer-default-export
 export const changeTypeRouter = express.Router({ mergeParams: true })
-changeTypeRouter.use(populateReport(false), logoutIf(cannotEditReport), changeTypeWizardRouter)
+changeTypeRouter.use(
+  populateReport(false),
+  logoutIf(cannotEditReport),
+  redirectIfStatusNot('DRAFT'),
+  changeTypeWizardRouter,
+)

--- a/server/routes/reports/details/changeType.ts
+++ b/server/routes/reports/details/changeType.ts
@@ -1,0 +1,110 @@
+// eslint-disable-next-line max-classes-per-file
+import express from 'express'
+import FormWizard from 'hmpo-form-wizard'
+
+import logger from '../../../../logger'
+import { BaseController } from '../../../controllers'
+import type { ReportBasic } from '../../../data/incidentReportingApi'
+import { logoutIf } from '../../../middleware/permissions'
+import { populateReport } from '../../../middleware/populateReport'
+import { cannotEditReport } from '../permissions'
+import { BaseTypeController } from './typeController'
+import { type TypeValues, typeFields, typeFieldNames } from './typeFields'
+
+class ConfirmTypeChangeController extends BaseController<TypeValues> {
+  getBackLink(_req: FormWizard.Request<TypeValues>, res: express.Response): string {
+    return res.locals.reportUrl
+  }
+}
+
+class TypeController extends BaseTypeController<TypeValues> {
+  // TODO: wizard namespace identifier is shared. consider generating it per request somehow?
+  //       otherwise cannot edit 2 pages at once in different windows
+
+  middlewareLocals(): void {
+    this.use(this.customiseFields)
+    super.middlewareLocals()
+  }
+
+  private customiseFields(
+    req: FormWizard.Request<TypeValues>,
+    res: express.Response,
+    next: express.NextFunction,
+  ): void {
+    const { fields } = req.form.options
+    const report = res.locals.report as ReportBasic
+
+    const customisedFields = { ...fields }
+
+    customisedFields.type = {
+      ...customisedFields.type,
+      items: customisedFields.type.items.filter(type => type.value !== report.type),
+    }
+
+    req.form.options.fields = customisedFields
+
+    next()
+  }
+
+  async successHandler(
+    req: FormWizard.Request<TypeValues>,
+    res: express.Response,
+    next: express.NextFunction,
+  ): Promise<void> {
+    const report = res.locals.report as ReportBasic
+    const { type } = req.form.values
+
+    try {
+      await res.locals.apis.incidentReportingApi.changeReportType(report.id, { newType: type })
+      logger.info(`Report ${report.reportReference} type changed to ${type}`)
+
+      // clear session since report has been saved
+      req.journeyModel.reset()
+
+      super.successHandler(req, res, next)
+    } catch (e) {
+      logger.error(e, `Report ${report.reportReference} type could not be changed: %j`, e)
+      const err = this.convertIntoValidationError(e)
+      this.errorHandler({ type: err }, req, res, next)
+    }
+  }
+
+  getBackLink(_req: FormWizard.Request<TypeValues>, res: express.Response): string {
+    return res.locals.reportUrl
+  }
+
+  getNextStep(_req: FormWizard.Request<TypeValues>, res: express.Response): string {
+    return res.locals.reportUrl
+  }
+}
+
+const changeTypeSteps: FormWizard.Steps<TypeValues> = {
+  '/': {
+    entryPoint: true,
+    controller: ConfirmTypeChangeController,
+    template: 'confirm-type-change',
+    next: 'select',
+  },
+  '/select': {
+    fields: typeFieldNames,
+    controller: TypeController,
+    template: 'type',
+  },
+}
+
+const changeTypeFields: FormWizard.Fields<TypeValues> = { ...typeFields }
+
+const changeTypeConfig: FormWizard.Config<TypeValues> = {
+  name: 'changeType',
+  checkSession: false,
+  csrf: false,
+  templatePath: 'pages/reports',
+}
+
+const changeTypeWizardRouter = FormWizard(changeTypeSteps, changeTypeFields, changeTypeConfig)
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore because express types do not mention this property and form wizard does not allow you to pass in config for it's root router
+changeTypeWizardRouter.mergeParams = true
+// eslint-disable-next-line import/prefer-default-export
+export const changeTypeRouter = express.Router({ mergeParams: true })
+changeTypeRouter.use(populateReport(false), logoutIf(cannotEditReport), changeTypeWizardRouter)

--- a/server/routes/reports/details/updateReportDetails.test.ts
+++ b/server/routes/reports/details/updateReportDetails.test.ts
@@ -184,7 +184,7 @@ describe('Updating report details', () => {
       })
   })
 
-  it('should send request to API if form is valid and proceed to next step', async () => {
+  it('should send request to API if form is valid and proceed to next step', () => {
     incidentReportingApi.updateReport.mockResolvedValueOnce(reportBasic)
 
     return agent

--- a/server/routes/reports/viewReport.test.ts
+++ b/server/routes/reports/viewReport.test.ts
@@ -45,6 +45,8 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
+// TODO: links need checking. especially when they appear and when they hide
+
 describe('View report page', () => {
   let mockedReport: ReportWithDetails
   let viewReportUrl: string

--- a/server/routes/reports/viewReport.test.ts
+++ b/server/routes/reports/viewReport.test.ts
@@ -113,6 +113,9 @@ describe('View report page', () => {
           expect(res.text).toContain('5 December 2023, 11:34')
           expect(res.text).toContain('Description')
           expect(res.text).toContain('A new incident created in the new service of type FINDS')
+
+          expect(res.text).toContain(`${viewReportUrl}/change-type`)
+          expect(res.text).toContain(`${viewReportUrl}/update-details`)
         })
     })
 
@@ -141,6 +144,8 @@ describe('View report page', () => {
             expect(res.text).toContain('Outcome: No outcome')
           }
           expect(res.text).toContain('Details: No comment')
+
+          expect(res.text).toContain(`${viewReportUrl}/prisoners`)
         })
     })
 
@@ -155,6 +160,8 @@ describe('View report page', () => {
           expect(res.text).toContain('Present at scene')
           expect(res.text).toContain('Mary Johnson')
           expect(res.text).toContain('Actively involved')
+
+          expect(res.text).toContain(`${viewReportUrl}/staff`)
         })
     })
 
@@ -167,6 +174,8 @@ describe('View report page', () => {
 
           expect(res.text).toContain('About the incident')
           // TODO: will need to become type-specific once content is ready
+
+          expect(res.text).not.toContain(`${viewReportUrl}/questions"`)
 
           expect(res.text).toContain('1. Describe how the item was found')
           expect(res.text).toContain('Cell search')
@@ -246,6 +255,9 @@ describe('View report page', () => {
           expect(res.text).toContain('5 December 2023, 11:34')
           expect(res.text).toContain('Description')
           expect(res.text).toContain('An old drone sighting')
+
+          expect(res.text).not.toContain(`${viewReportUrl}/change-type`)
+          expect(res.text).toContain(`${viewReportUrl}/update-details`)
         })
     })
 
@@ -274,6 +286,8 @@ describe('View report page', () => {
             expect(res.text).toContain('Outcome: No outcome')
           }
           expect(res.text).toContain('Details: No comment')
+
+          expect(res.text).toContain(`${viewReportUrl}/prisoners`)
         })
     })
 
@@ -286,6 +300,8 @@ describe('View report page', () => {
           expect(res.text).toContain('Present at scene')
           expect(res.text).toContain('Mary Johnson')
           expect(res.text).toContain('Actively involved')
+
+          expect(res.text).toContain(`${viewReportUrl}/staff`)
         })
     })
 
@@ -370,6 +386,9 @@ describe('View report page', () => {
           expect(res.text).toContain('5 December 2023, 11:34')
           expect(res.text).toContain('Description')
           expect(res.text).toContain('A new incident created in the new service of type FINDS')
+
+          expect(res.text).toContain(`${viewReportUrl}/change-type`)
+          expect(res.text).toContain(`${viewReportUrl}/update-details`)
         })
     })
 
@@ -381,6 +400,8 @@ describe('View report page', () => {
           expect(res.text).toContain('Prisoners involved')
           expect(res.text).toContain('No prisoners added')
           expect(res.text).toContain('Add a prisoner')
+
+          expect(res.text).toContain(`${viewReportUrl}/prisoners`)
         })
     })
 
@@ -392,6 +413,8 @@ describe('View report page', () => {
           expect(res.text).toContain('Staff involved')
           expect(res.text).toContain('No staff added')
           expect(res.text).toContain('Add a member of staff')
+
+          expect(res.text).toContain(`${viewReportUrl}/staff`)
         })
     })
 
@@ -402,6 +425,8 @@ describe('View report page', () => {
         .expect(res => {
           expect(res.text).toContain('About the incident')
           // TODO: will need to become type-specific once content is ready
+
+          expect(res.text).not.toContain(`${viewReportUrl}/questions"`)
 
           expect(res.text).toContain('1. Describe how the item was found')
           expect(res.text).toContain(`${viewReportUrl}/questions/67179`)
@@ -432,15 +457,13 @@ describe('View report page', () => {
       previousActivePrisons = config.activePrisons
     })
 
-    let reportId: string
-
     beforeEach(() => {
       config.activePrisons = previousActivePrisons
 
-      const report = convertReportWithDetailsDates(
+      mockedReport = convertReportWithDetailsDates(
         mockReport({ reportReference: '6543', reportDateAndTime: now, withDetails: true }),
       )
-      report.questions = [
+      mockedReport.questions = [
         makeSimpleQuestion(
           '67179',
           'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)',
@@ -449,8 +472,9 @@ describe('View report page', () => {
         ),
         makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', 'YES'),
       ]
-      reportId = report.id
-      incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(report)
+      incidentReportingApi.getReportWithDetailsById.mockReset()
+      incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(mockedReport)
+      viewReportUrl = `/reports/${mockedReport.id}`
     })
 
     const granted = 'granted' as const
@@ -462,17 +486,31 @@ describe('View report page', () => {
       { userType: 'unauthorised user', user: unauthorisedUser, action: denied, canEdit: false },
     ])('should be $action to $userType', ({ user, action, canEdit }) => {
       const testRequest = request(appWithAllRoutes({ services: { userService }, userSupplier: () => user }))
-        .get(`/reports/${reportId}`)
+        .get(viewReportUrl)
         .redirects(1)
       if (action === 'granted') {
         return testRequest.expect(200).expect(res => {
+          let textContentMatcher: (text: string) => void
           if (canEdit) {
-            expect(res.text).toContain('Check your answers')
-            expect(res.text).toContain('question responses')
+            textContentMatcher = expect(res.text).toContain
           } else {
-            expect(res.text).not.toContain('Check your answers')
-            expect(res.text).not.toContain('question responses')
+            textContentMatcher = expect(res.text).not.toContain
           }
+          ;[
+            // heading prefix
+            'Check your answers',
+            // question page links
+            'question responses',
+            // change links
+            'Change',
+            `${viewReportUrl}/change-type`,
+            `${viewReportUrl}/update-details`,
+            `${viewReportUrl}/prisoners`,
+            `${viewReportUrl}/staff`,
+            `${viewReportUrl}/questions`,
+          ].forEach(text => {
+            textContentMatcher(text)
+          })
         })
       }
       return testRequest.expect(res => {
@@ -489,7 +527,7 @@ describe('View report page', () => {
       config.activePrisons = ['LEI']
 
       return request(appWithAllRoutes({ services: { userService }, userSupplier: () => user }))
-        .get(`/reports/${reportId}`)
+        .get(viewReportUrl)
         .expect(res => {
           const warningShows = res.text.includes('This report can only be amended in NOMIS')
           expect(warningShows).toBe(warn)

--- a/server/views/pages/reports/confirm-type-change.njk
+++ b/server/views/pages/reports/confirm-type-change.njk
@@ -1,0 +1,12 @@
+{% extends "partials/formWizardLayout.njk" %}
+
+{% set pageTitle = "Some of your answers will be deleted" %}
+{% set bodyClasses = "app-confirm-change-type" %}
+
+{% block formFields %}
+  <p>
+    Changing the type of incident will remove some of your answers.
+    {# TODO: it's not the summary that needs re-entering #}
+    You’ll need to re-enter the incident summary and any prisoners that were involved.
+  </p>
+{% endblock %}

--- a/server/views/pages/reports/view/_details.njk
+++ b/server/views/pages/reports/view/_details.njk
@@ -9,7 +9,16 @@
       key: { text: "Type" },
       value: {
         text: typesLookup[report.type] or report.type
-      }
+      },
+      actions: {
+        items: [
+          {
+            href: reportUrl + "/change-type",
+            text: "Change",
+            visuallyHiddenText: "incident type"
+          }
+        ]
+      } if canEditReport else {}
     },
     {
       key: { text: "Date and time of incident" },

--- a/server/views/pages/reports/view/_details.njk
+++ b/server/views/pages/reports/view/_details.njk
@@ -18,7 +18,7 @@
             visuallyHiddenText: "incident type"
           }
         ]
-      } if canEditReport else {}
+      } if canEditReport and report.status === "DRAFT" else {}
     },
     {
       key: { text: "Date and time of incident" },


### PR DESCRIPTION
Depends on [api#196](https://github.com/ministryofjustice/hmpps-incident-reporting-api/pull/196): API handles archiving questions and clearing prisoner involvements.