### PR TITLE
IR-740: Fix question/response configuration traversal

### DIFF
--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -49,12 +49,6 @@ export default {
 
   /** Search users */
   stubSearchUsers: (query: string, results: UsersSearchResult[], page = 0): SuperAgentRequest => {
-    const queryRegex = [
-      `nameFilter=${encodeURIComponent(query)}`,
-      'status=ACTIVE',
-      `size=${ManageUsersApiClient.PAGE_SIZE}`,
-      `page=${page}`,
-    ].join('&')
     const response: UsersSearchResponse = {
       content: results,
       number: page,
@@ -66,7 +60,13 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/manage-users-api/prisonusers/search/\\?.*${queryRegex}.*`,
+        urlPath: '/manage-users-api/prisonusers/search',
+        queryParameters: {
+          nameFilter: query,
+          status: 'ACTIVE',
+          size: ManageUsersApiClient.PAGE_SIZE,
+          page,
+        },
       },
       response: {
         status: 200,

--- a/server/controllers/involvements/summary.ts
+++ b/server/controllers/involvements/summary.ts
@@ -108,8 +108,8 @@ export abstract class InvolvementSummary extends BaseController<Values> {
     const report = res.locals.report as ReportWithDetails
     const { confirmAdd } = req.form.values
 
+    // clear session since choice made
     req.journeyModel.reset()
-    req.sessionModel.reset()
 
     if (confirmAdd === 'yes') {
       res.redirect(`${res.locals.reportSubUrlPrefix}/${this.type}/search`)

--- a/server/data/incidentTypeConfiguration/questionProgress.test.ts
+++ b/server/data/incidentTypeConfiguration/questionProgress.test.ts
@@ -159,9 +159,9 @@ describe('Question progress', () => {
     )
     // no responses
     report.questions = []
-    const questionProgress = new QuestionProgress(config, steps, report)
 
     it('should track progress through report questions', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       const progress = Array.from(questionProgress)
       expect(progress).toEqual([
         // on first question, which is incomplete
@@ -177,10 +177,12 @@ describe('Question progress', () => {
     })
 
     it('should return first incomplete question', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       expect(questionProgress.firstIncompleteStep()).toHaveProperty('questionConfig.id', '1')
     })
 
     it('should state that the report is incomplete', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       expect(questionProgress.isComplete).toBe(false)
     })
   })
@@ -206,9 +208,9 @@ describe('Question progress', () => {
         additionalInformation: null,
       },
     ]
-    const questionProgress = new QuestionProgress(config, steps, report)
 
     it('should track progress through report questions', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       const progress = Array.from(questionProgress)
       expect(progress).toEqual([
         expect.objectContaining({
@@ -238,10 +240,12 @@ describe('Question progress', () => {
     })
 
     it('should return first incomplete question', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       expect(questionProgress.firstIncompleteStep()).toHaveProperty('questionConfig.id', '2')
     })
 
     it('should state that the report is incomplete', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       expect(questionProgress.isComplete).toBe(false)
     })
   })
@@ -267,9 +271,9 @@ describe('Question progress', () => {
         additionalInformation: null,
       },
     ]
-    const questionProgress = new QuestionProgress(config, steps, report)
 
     it('should track progress through report questions', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       const progress = Array.from(questionProgress)
       expect(progress).toEqual([
         expect.objectContaining({
@@ -299,10 +303,12 @@ describe('Question progress', () => {
     })
 
     it('should return first incomplete question', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       expect(questionProgress.firstIncompleteStep()).toHaveProperty('questionConfig.id', '4')
     })
 
     it('should state that the report is incomplete', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       expect(questionProgress.isComplete).toBe(false)
     })
   })
@@ -373,9 +379,9 @@ describe('Question progress', () => {
         additionalInformation: null,
       },
     ]
-    const questionProgress = new QuestionProgress(config, steps, report)
 
     it('should track progress through report questions', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       const progress = Array.from(questionProgress)
       expect(progress).toEqual([
         expect.objectContaining({
@@ -439,10 +445,12 @@ describe('Question progress', () => {
     })
 
     it('should return no first incomplete question', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       expect(questionProgress.firstIncompleteStep()).toBeNull()
     })
 
     it('should state that the report is complete', () => {
+      const questionProgress = new QuestionProgress(config, steps, report)
       expect(questionProgress.isComplete).toBe(true)
     })
   })
@@ -790,6 +798,80 @@ describe('Question progress', () => {
           ],
           false,
         )
+      })
+    })
+
+    describe('for questions with inactive responses', () => {
+      const configWithInactiveResponses: IncidentTypeConfiguration = {
+        startingQuestionId: '1',
+        active: true,
+        incidentType: 'MISCELLANEOUS',
+        prisonerRoles: [],
+        questions: {
+          '1': {
+            id: '1',
+            active: true,
+            code: 'Q1',
+            label: 'Question 1',
+            multipleAnswers: false,
+            answers: [
+              {
+                id: '1',
+                code: 'A1',
+                active: false,
+                label: 'Answer 1 (old, inactive)',
+                dateRequired: false,
+                commentRequired: false,
+                nextQuestionId: null,
+              },
+              {
+                id: '2',
+                code: 'A1',
+                active: true,
+                label: 'Answer 1 (new, active)',
+                dateRequired: false,
+                commentRequired: false,
+                nextQuestionId: '2',
+              },
+            ],
+          },
+          '2': {
+            id: '2',
+            active: true,
+            code: 'Q2',
+            label: 'Question 2',
+            multipleAnswers: false,
+            answers: [...config.questions['4'].answers],
+          },
+        },
+      }
+      const stepsWithInactiveResponses = generateSteps(configWithInactiveResponses)
+      const report = convertReportWithDetailsDates(
+        mockReport({ type: 'MISCELLANEOUS', reportReference: '6543', reportDateAndTime: now, withDetails: true }),
+      )
+      report.questions = [
+        {
+          code: '1',
+          question: 'Q1',
+          responses: [
+            {
+              response: 'A1',
+              responseDate: null,
+              additionalInformation: null,
+              recordedAt: new Date(),
+              recordedBy: 'some-user',
+            },
+          ],
+          additionalInformation: null,
+        },
+      ]
+
+      it('should prefer active responses over inactive ones', () => {
+        const questionProgress = new QuestionProgress(configWithInactiveResponses, stepsWithInactiveResponses, report)
+        const progress = Array.from(questionProgress)
+        expect(progress).toHaveLength(2)
+        expect(progress[0].isComplete).toBe(true)
+        expect(progress[1].isComplete).toBe(false)
       })
     })
   })

--- a/server/data/incidentTypeConfiguration/utils.ts
+++ b/server/data/incidentTypeConfiguration/utils.ts
@@ -17,6 +17,12 @@ export function conditionalFieldName(
 }
 
 /** Finds the Answer config for a given answer code */
-export function findAnswerConfigByCode(answerCode: string, questionConfig: QuestionConfiguration): AnswerConfiguration {
-  return questionConfig.answers.find(answerConfig => answerConfig.code.trim() === answerCode.trim())
+export function findAnswerConfigByCode(
+  answerCode: string,
+  questionConfig: QuestionConfiguration,
+  mustBeActive = true,
+): AnswerConfiguration {
+  return questionConfig.answers.find(
+    answerConfig => (answerConfig.active || !mustBeActive) && answerConfig.code === answerCode.trim(),
+  )
 }

--- a/server/data/incidentTypeConfiguration/utils.ts
+++ b/server/data/incidentTypeConfiguration/utils.ts
@@ -1,5 +1,5 @@
 import type { AnswerConfiguration, QuestionConfiguration } from './types'
-import type { Question } from '../incidentReportingApi'
+import type { Question, Response } from '../incidentReportingApi'
 
 export function questionFieldName(question: QuestionConfiguration | Question): string {
   if ('answers' in question) {
@@ -25,4 +25,13 @@ export function findAnswerConfigByCode(
   return questionConfig.answers.find(
     answerConfig => (answerConfig.active || !mustBeActive) && answerConfig.code === answerCode.trim(),
   )
+}
+
+/** Finds the Answer config for a given Response inside a report */
+export function findAnswerConfigForResponse(
+  response: Response,
+  questionConfig: QuestionConfiguration,
+  mustBeActive = true,
+): AnswerConfiguration {
+  return findAnswerConfigByCode(response.response, questionConfig, mustBeActive)
 }

--- a/server/services/questionsToDelete.ts
+++ b/server/services/questionsToDelete.ts
@@ -96,7 +96,7 @@ export default class QuestionsToDelete {
     answeredQuestions: AnsweredQuestion[],
   ): string | symbol | null {
     const answeredQuestion = answeredQuestions.find(question => question.code === start)
-    let questionConfig: QuestionConfiguration | null = null
+    let questionConfig: QuestionConfiguration | null
     let answerConfig: AnswerConfiguration | null = null
 
     if (answeredQuestion) {
@@ -106,15 +106,16 @@ export default class QuestionsToDelete {
         answerConfig = findAnswerConfigByCode(response.response, questionConfig)
       }
     } else {
-      // Current question not answered, but peraphs there is no branching...
+      // Current question not answered, but perhaps there is no branching...
       // and we can still determine the next question
       questionConfig = config.questions[start]
       if (questionConfig) {
-        const nextQuestionIds = new Set(questionConfig.answers.map(ansConf => ansConf.nextQuestionId))
+        const activeAnswers = questionConfig.answers.filter(ansConf => ansConf.active)
+        const nextQuestionIds = new Set(activeAnswers.map(ansConf => ansConf.nextQuestionId))
         const noBranching = nextQuestionIds.size === 1
         if (noBranching) {
           // eslint-disable-next-line prefer-destructuring
-          answerConfig = questionConfig.answers[0]
+          answerConfig = activeAnswers[0]
         }
       }
     }


### PR DESCRIPTION
Key lock incident highlighted a few problems related to inactive question & response configuration. This was not always filtered out meaning that
- some valid responses were accidentally being deleted
- the incorrect next question/page was being chosen

Also, clearing form wizard session when questions are saved successfully in the hope of preventing form wizards interfering with each other.