### PR TITLE
IR-950: Clear prisoner & staff search session if successfully rendered

### DIFF
--- a/server/routes/reports/prisoners/search/controller.ts
+++ b/server/routes/reports/prisoners/search/controller.ts
@@ -58,6 +58,15 @@ export class PrisonerSearchController extends GetBaseController<Values> {
     return `${res.locals.reportSubUrlPrefix}/prisoners`
   }
 
+  render(req: FormWizard.Request<Values, keyof Values>, res: express.Response, next: express.NextFunction) {
+    super.render(req, res, next)
+
+    if (res.locals.searchResults) {
+      // clear session after rendering page since search was successfully performed and session would leak otherwise
+      req.journeyModel.reset()
+    }
+  }
+
   async successHandler(
     req: FormWizard.Request<Values>,
     res: express.Response,

--- a/server/routes/reports/staff/search/controller.ts
+++ b/server/routes/reports/staff/search/controller.ts
@@ -43,6 +43,15 @@ export class StaffSearchController extends GetBaseController<Values> {
     return `${res.locals.reportSubUrlPrefix}/staff`
   }
 
+  render(req: FormWizard.Request<Values, keyof Values>, res: express.Response, next: express.NextFunction) {
+    super.render(req, res, next)
+
+    if (res.locals.searchResults) {
+      // clear session after rendering page since search was successfully performed and session would leak otherwise
+      req.journeyModel.reset()
+    }
+  }
+
   async successHandler(
     req: FormWizard.Request<Values>,
     res: express.Response,


### PR DESCRIPTION
While it wasn’t preventing any normal user interactions, the search pages remembered the last thing you searched for