### PR TITLE
IR-958: Bundle DPR stylesheets into one file

### DIFF
--- a/assets/scss/dpr.scss
+++ b/assets/scss/dpr.scss
@@ -1,0 +1,5 @@
+$govuk-suppressed-warnings: 'ie8', 'govuk-typography-scale-14', 'legacy-organisation-colours';
+
+@import 'govuk-frontend/dist/govuk';
+@import '@ministryofjustice/frontend/moj/all';
+@import '@ministryofjustice/hmpps-digital-prison-reporting-frontend/dpr/all';

--- a/esbuild/assets.config.js
+++ b/esbuild/assets.config.js
@@ -50,7 +50,13 @@ const buildAssets = buildConfig => {
       }),
       sassPlugin({
         quietDeps: true,
-        loadPaths: [path.join(process.cwd(), 'node_modules'), process.cwd()],
+        loadPaths: [
+          process.cwd(),
+          path.join(process.cwd(), 'node_modules'),
+          path.join(process.cwd(), 'node_modules/govuk-frontend/dist'),
+          path.join(process.cwd(), 'node_modules/@ministryofjustice/frontend'),
+          path.join(process.cwd(), 'node_modules/@ministryofjustice/hmpps-digital-prison-reporting-frontend'),
+        ],
       }),
       typecheckPlugin(),
     ],

--- a/server/views/partials/dprLayout.njk
+++ b/server/views/partials/dprLayout.njk
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block pageStylesheets %}
-  <link href="/assets/dpr/css/all.css" rel="stylesheet" />
+  <link href="{{ "/assets/css/dpr.css" | assetMap }}" rel="stylesheet" />
 {% endblock %}
 
 {% block pageJavascript %}


### PR DESCRIPTION
Continues on from #398:
• it appears that DPR SCSS bundle can be built if additional undocumented load paths are provided to the sass plugin