### PR TITLE
IR-970: Run incident type config validations as part of the test suite

### DIFF
--- a/scripts/validateConfig.ts
+++ b/scripts/validateConfig.ts
@@ -5,22 +5,20 @@ import { validateConfig } from '../server/data/incidentTypeConfiguration/validat
 import { getAllIncidentTypeConfigurations } from '../server/reportConfiguration/types'
 
 function main(): void {
-  getAllIncidentTypeConfigurations().then(incidentTypeConfigurations => {
-    incidentTypeConfigurations.forEach(incidentTypeConfiguration => {
-      printText(
-        `Checking ${incidentTypeConfiguration.active ? 'active' : 'inactive'} type configuration for: ${incidentTypeConfiguration.incidentType}`,
-      )
-      const errors = validateConfig(incidentTypeConfiguration)
-      if (errors.length > 0) {
-        printText(`${red('WARNING')}: Errors found:`)
-        for (const error of errors) {
-          printText(` - ${error.message}`)
-        }
-      } else {
-        printText(green('No errors found'))
+  for (const incidentTypeConfiguration of getAllIncidentTypeConfigurations()) {
+    printText(
+      `Checking ${incidentTypeConfiguration.active ? 'active' : 'inactive'} type configuration for: ${incidentTypeConfiguration.incidentType}`,
+    )
+    const errors = validateConfig(incidentTypeConfiguration)
+    if (errors.length > 0) {
+      printText(`${red('WARNING')}: Errors found:`)
+      for (const error of errors) {
+        printText(` - ${error.message}`)
       }
-    })
-  })
+    } else {
+      printText(green('No errors found'))
+    }
+  }
 }
 
 main()

--- a/server/data/incidentTypeConfiguration/validation.test.ts
+++ b/server/data/incidentTypeConfiguration/validation.test.ts
@@ -3,23 +3,23 @@ import { ESCAPE_FROM_PRISON_1 } from '../../reportConfiguration/types/ESCAPE_FRO
 import { type QuestionConfiguration, type AnswerConfiguration, type IncidentTypeConfiguration } from './types'
 import { validateConfig } from './validation'
 
-describe('DPS config validation', () => {
-  describe('active configs', () => {
-    it('are valid', async () => {
-      const allConfigs = getAllIncidentTypeConfigurations()
-      const activeConfigs = allConfigs.filter(config => config.active)
-
-      for (const config of activeConfigs) {
-        const errors = validateConfig(config).map(err => err.message)
-        if (errors.length > 0) {
-          throw new Error(
-            `Config for '${config.incidentType}' incident type has validation errors: ${errors.join('; ')}`,
-          )
-        }
-      }
-    })
+describe('Active incident type configurations', () => {
+  const activeConfigs = getAllIncidentTypeConfigurations().filter(config => config.active)
+  const scenarios = activeConfigs.map(config => {
+    return { incidentType: config.incidentType, config }
   })
 
+  it.each(scenarios)('Config for $incidentType is valid', ({ incidentType, config }) => {
+    const errors = validateConfig(config).map(err => err.message)
+    if (errors.length > 0) {
+      throw new Error(
+        `Config for '${incidentType}' incident type is invalid: ${errors.join('; ')}`,
+      )
+    }
+  })
+})
+
+describe('DPS config validation', () => {
   describe('when config has no known issues', () => {
     it('returns no errors', () => {
       // '1' (START)

--- a/server/data/incidentTypeConfiguration/validation.test.ts
+++ b/server/data/incidentTypeConfiguration/validation.test.ts
@@ -6,7 +6,7 @@ import { validateConfig } from './validation'
 describe('DPS config validation', () => {
   describe('active configs', () => {
     it('are valid', async () => {
-      const allConfigs = await getAllIncidentTypeConfigurations()
+      const allConfigs = getAllIncidentTypeConfigurations()
       const activeConfigs = allConfigs.filter(config => config.active)
 
       for (const config of activeConfigs) {

--- a/server/data/incidentTypeConfiguration/validation.test.ts
+++ b/server/data/incidentTypeConfiguration/validation.test.ts
@@ -43,6 +43,18 @@ describe('DPS config validation', () => {
     })
   })
 
+  describe('when some of the questions/answers IDs contains an hyphen', () => {
+    it('returns an error', () => {
+      const config: IncidentTypeConfiguration = buildValidConfig()
+      config.questions['2'].id += '-BROKEN'
+      config.questions['1'].answers[0].id += '-BROKEN'
+
+      const errors = validateConfig(config).map(err => err.message)
+      expect(errors).toContain(`active question '2-BROKEN' has hiphen in its ID`)
+      expect(errors).toContain(`active answer 'yes-BROKEN' has hiphen in its ID`)
+    })
+  })
+
   describe('when config starting question is unknown', () => {
     it('returns an error', () => {
       const config: IncidentTypeConfiguration = buildValidConfig()

--- a/server/data/incidentTypeConfiguration/validation.test.ts
+++ b/server/data/incidentTypeConfiguration/validation.test.ts
@@ -12,9 +12,7 @@ describe('Active incident type configurations', () => {
   it.each(scenarios)('Config for $incidentType is valid', ({ incidentType, config }) => {
     const errors = validateConfig(config).map(err => err.message)
     if (errors.length > 0) {
-      throw new Error(
-        `Config for '${incidentType}' incident type is invalid: ${errors.join('; ')}`,
-      )
+      throw new Error(`Config for '${incidentType}' incident type is invalid: ${errors.join('; ')}`)
     }
   })
 })

--- a/server/data/incidentTypeConfiguration/validation.test.ts
+++ b/server/data/incidentTypeConfiguration/validation.test.ts
@@ -1,8 +1,25 @@
+import { getAllIncidentTypeConfigurations } from '../../reportConfiguration/types'
 import { ESCAPE_FROM_PRISON_1 } from '../../reportConfiguration/types/ESCAPE_FROM_PRISON_1'
 import { type QuestionConfiguration, type AnswerConfiguration, type IncidentTypeConfiguration } from './types'
 import { validateConfig } from './validation'
 
 describe('DPS config validation', () => {
+  describe('active configs', () => {
+    it('are valid', async () => {
+      const allConfigs = await getAllIncidentTypeConfigurations()
+      const activeConfigs = allConfigs.filter(config => config.active)
+
+      for (const config of activeConfigs) {
+        const errors = validateConfig(config).map(err => err.message)
+        if (errors.length > 0) {
+          throw new Error(
+            `Config for '${config.incidentType}' incident type has validation errors: ${errors.join('; ')}`,
+          )
+        }
+      }
+    })
+  })
+
   describe('when config has no known issues', () => {
     it('returns no errors', () => {
       // '1' (START)

--- a/server/data/incidentTypeConfiguration/validation.ts
+++ b/server/data/incidentTypeConfiguration/validation.ts
@@ -8,6 +8,7 @@ export function validateConfig(config: IncidentTypeConfiguration): Error[] {
   const configGraph = buildConfigGraph(config)
 
   checkStartingQuestion(config, errors)
+  checkIdsDontIncludeHyphens(config, errors)
   checkQuestionsWithoutAnswers(config, errors)
   checkMultipleChoicesNextQuestions(config, errors)
   checkUnknownQuestions(configGraph, errors)
@@ -36,6 +37,24 @@ function checkStartingQuestion(config: IncidentTypeConfiguration, errors: Error[
   } else if (startingQuestion?.active !== true) {
     errors.push(new Error('starting question is inactive'))
   }
+}
+
+function checkIdsDontIncludeHyphens(config: IncidentTypeConfiguration, errors: Error[]): void {
+  Object.values(config.questions)
+    .filter(question => question.active)
+    .forEach(question => {
+      if (question.id.includes('-')) {
+        errors.push(new Error(`active question '${question.id}' has hiphen in its ID`))
+      }
+
+      question.answers
+        .filter(answer => answer.active)
+        .forEach(answer => {
+          if (answer.id.includes('-')) {
+            errors.push(new Error(`active answer '${answer.id}' has hiphen in its ID`))
+          }
+        })
+    })
 }
 
 function checkQuestionsWithoutAnswers(config: IncidentTypeConfiguration, errors: Error[]): void {

--- a/server/reportConfiguration/types/index.ts
+++ b/server/reportConfiguration/types/index.ts
@@ -4,6 +4,7 @@ import type { IncidentTypeConfiguration } from '../../data/incidentTypeConfigura
 import { types } from '../constants'
 
 export function getAllIncidentTypeConfigurations(): IncidentTypeConfiguration[] {
+  // eslint-disable-next-line import/no-dynamic-require, global-require, @typescript-eslint/no-require-imports
   return types.map(type => require(`./${type.code}`).default)
 }
 

--- a/server/reportConfiguration/types/index.ts
+++ b/server/reportConfiguration/types/index.ts
@@ -3,8 +3,8 @@ import path from 'node:path'
 import type { IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
 import { types } from '../constants'
 
-export function getAllIncidentTypeConfigurations(): Promise<IncidentTypeConfiguration[]> {
-  return Promise.all(types.map(type => import(`./${type.code}`).then(module => module.default)))
+export function getAllIncidentTypeConfigurations(): IncidentTypeConfiguration[] {
+  return types.map(type => require(`./${type.code}`).default)
 }
 
 export function getIncidentTypeConfiguration(type: string): Promise<IncidentTypeConfiguration> {


### PR DESCRIPTION
While we run validations on import from NOMIS, there was still the potential that a change to these could lead to invalid configurations.

This is to run these validation with the rest of the tests.

Notable changes:
- I've made `getAllIncidentTypeConfigurations()` synchronous (see commit message for reasoning)
- I've added a validation for the questions/answers IDs to check that they don't include hyphens as this could lead to issues, see [prior discussion](https://github.com/ministryofjustice/hmpps-incident-reporting/pull/403#discussion_r2028814884).