### PR TITLE
Add more “allowed to do X in NOMIS only” permissions checks

### DIFF
--- a/server/middleware/permissions.test.ts
+++ b/server/middleware/permissions.test.ts
@@ -431,6 +431,32 @@ describe('Permissions', () => {
           const permissions = new Permissions(user)
           expect(mockReports.every(report => permissions.canApproveOrRejectReport(report))).toBe(action === granted)
         })
+
+        it.each([
+          { userType: notLoggedIn, action: denied },
+          { userType: unauthorisedNotInLeeds, action: denied },
+          { userType: unauthorisedInLeeds, action: denied },
+          { userType: reportingNotInLeeds, action: denied },
+          { userType: reportingInLeeds, action: denied },
+          { userType: reportingInLeedsWithPecs, action: denied },
+          { userType: approverNotInLeeds, action: denied },
+          { userType: approverInLeeds, action: granted },
+          { userType: approverInLeedsWithoutPecs, action: granted },
+          { userType: viewOnlyNotInLeeds, action: denied },
+          { userType: viewOnlyInLeeds, action: denied },
+          { userType: viewOnlyInLeedsWithPecs, action: denied },
+        ])(
+          'should be $action to $userType.description only in NOMIS when Leeds is inactive in DPS',
+          ({ userType: { user }, action }) => {
+            config.activePrisons = ['MDI']
+
+            const permissions = new Permissions(user)
+            expect(mockReports.every(report => permissions.canApproveOrRejectReport(report))).toBe(false)
+            expect(mockReports.every(report => permissions.canApproveOrRejectReportInNomisOnly(report))).toBe(
+              action === granted,
+            )
+          },
+        )
       })
 
       describe('in a PECS region', () => {
@@ -451,6 +477,32 @@ describe('Permissions', () => {
           const permissions = new Permissions(user)
           expect(mockPecsReports.every(report => permissions.canApproveOrRejectReport(report))).toBe(action === granted)
         })
+
+        it.each([
+          { userType: notLoggedIn, action: denied },
+          { userType: unauthorisedNotInLeeds, action: denied },
+          { userType: unauthorisedInLeeds, action: denied },
+          { userType: reportingNotInLeeds, action: denied },
+          { userType: reportingInLeeds, action: denied },
+          { userType: reportingInLeedsWithPecs, action: denied },
+          { userType: approverNotInLeeds, action: granted },
+          { userType: approverInLeeds, action: granted },
+          { userType: approverInLeedsWithoutPecs, action: denied },
+          { userType: viewOnlyNotInLeeds, action: denied },
+          { userType: viewOnlyInLeeds, action: denied },
+          { userType: viewOnlyInLeedsWithPecs, action: denied },
+        ])(
+          'should be $action to $userType.description only in NOMIS when active casload is inactive in DPS',
+          ({ userType: { user }, action }) => {
+            config.activeForPecsRegions = false
+
+            const permissions = new Permissions(user)
+            expect(mockPecsReports.every(report => permissions.canApproveOrRejectReport(report))).toBe(false)
+            expect(mockPecsReports.every(report => permissions.canApproveOrRejectReportInNomisOnly(report))).toBe(
+              action === granted,
+            )
+          },
+        )
       })
     })
   })

--- a/server/middleware/permissions.test.ts
+++ b/server/middleware/permissions.test.ts
@@ -193,6 +193,30 @@ describe('Permissions', () => {
           const permissions = new Permissions(user)
           expect(permissions.canCreateReportInLocation('LEI')).toBe(action === granted)
         })
+
+        it.each([
+          { userType: notLoggedIn, action: denied },
+          { userType: unauthorisedNotInLeeds, action: denied },
+          { userType: unauthorisedInLeeds, action: denied },
+          { userType: reportingNotInLeeds, action: denied },
+          { userType: reportingInLeeds, action: granted },
+          { userType: reportingInLeedsWithPecs, action: granted },
+          { userType: approverNotInLeeds, action: denied },
+          { userType: approverInLeeds, action: denied },
+          { userType: approverInLeedsWithoutPecs, action: denied },
+          { userType: viewOnlyNotInLeeds, action: denied },
+          { userType: viewOnlyInLeeds, action: denied },
+          { userType: viewOnlyInLeedsWithPecs, action: denied },
+        ])(
+          'should be $action to $userType.description only in NOMIS when Leeds is inactive in DPS',
+          ({ userType: { user }, action }) => {
+            config.activePrisons = ['MDI']
+
+            const permissions = new Permissions(user)
+            expect(permissions.canCreateReportInLocation('LEI')).toBe(false)
+            expect(permissions.canCreateReportInLocationInNomisOnly('LEI')).toBe(action === granted)
+          },
+        )
       })
 
       describe('in active caseload', () => {
@@ -232,6 +256,23 @@ describe('Permissions', () => {
           const permissions = new Permissions(user)
           expect(permissions.canCreateReportInActiveCaseload).toBe(action === granted)
         })
+
+        it.each([
+          { userType: notLoggedIn, action: denied },
+          { userType: unauthorisedNotInLeeds, action: denied },
+          { userType: reportingNotInLeeds, action: granted },
+          { userType: approverNotInLeeds, action: denied },
+          { userType: viewOnlyNotInLeeds, action: denied },
+        ])(
+          'should be $action to $userType.descriptionIgnoringCaseload only in NOMIS when active casload is inactive in DPS',
+          ({ userType: { user }, action }) => {
+            config.activePrisons = []
+
+            const permissions = new Permissions(user)
+            expect(permissions.canCreateReportInActiveCaseload).toBe(false)
+            expect(permissions.canCreateReportInActiveCaseloadInNomisOnly).toBe(action === granted)
+          },
+        )
       })
 
       describe('in a PECS region', () => {
@@ -252,6 +293,30 @@ describe('Permissions', () => {
           const permissions = new Permissions(user)
           expect(permissions.canCreateReportInLocation('NORTH')).toBe(action === granted)
         })
+
+        it.each([
+          { userType: notLoggedIn, action: denied },
+          { userType: unauthorisedNotInLeeds, action: denied },
+          { userType: unauthorisedInLeeds, action: denied },
+          { userType: reportingNotInLeeds, action: denied },
+          { userType: reportingInLeeds, action: denied },
+          { userType: reportingInLeedsWithPecs, action: denied },
+          { userType: approverNotInLeeds, action: granted },
+          { userType: approverInLeeds, action: granted },
+          { userType: approverInLeedsWithoutPecs, action: denied },
+          { userType: viewOnlyNotInLeeds, action: denied },
+          { userType: viewOnlyInLeeds, action: denied },
+          { userType: viewOnlyInLeedsWithPecs, action: denied },
+        ])(
+          'should be $action to $userType.description only in NOMIS when PECS reports are inactive in DPS',
+          ({ userType: { user }, action }) => {
+            config.activeForPecsRegions = false
+
+            const permissions = new Permissions(user)
+            expect(permissions.canCreateReportInLocation('NORTH')).toBe(false)
+            expect(permissions.canCreateReportInLocationInNomisOnly('NORTH')).toBe(action === granted)
+          },
+        )
       })
     })
 

--- a/server/middleware/permissions.ts
+++ b/server/middleware/permissions.ts
@@ -76,9 +76,9 @@ export class Permissions {
     return (
       // user could have created report at this location were it enabled
       this.couldCreateReportInLocationIfActiveInService(code) &&
-      // if PECS region, are they enabled?
+      // if PECS region, are they disabled?
       ((isPecsRegionCode(code) && !config.activeForPecsRegions) ||
-        // otherwise is the prison enabled?
+        // otherwise is the prison disabled?
         !isPrisonActiveInService(code))
     )
   }
@@ -121,9 +121,9 @@ export class Permissions {
     return (
       // user could have edited report at this location were it enabled
       this.couldEditReportIfLocationActiveInService(report) &&
-      // if PECS region, are they enabled?
+      // if PECS region, are they disabled?
       ((isPecsRegionCode(report.location) && !config.activeForPecsRegions) ||
-        // otherwise is the prison enabled?
+        // otherwise is the prison disabled?
         !isPrisonActiveInService(report.location))
     )
   }
@@ -156,9 +156,9 @@ export class Permissions {
     return (
       // user could have approved/rejected report at this location were it enabled
       this.couldApproveOrRejectReportIfLocationActiveInService(report) &&
-      // if PECS region, are they enabled?
+      // if PECS region, are they disabled?
       ((isPecsRegionCode(report.location) && !config.activeForPecsRegions) ||
-        // otherwise is the prison enabled?
+        // otherwise is the prison disabled?
         !isPrisonActiveInService(report.location))
     )
   }

--- a/server/middleware/permissions.ts
+++ b/server/middleware/permissions.ts
@@ -71,9 +71,26 @@ export class Permissions {
     )
   }
 
+  /** Could have created new report in DPS if given prison was active or PECS regions are enabled */
+  canCreateReportInLocationInNomisOnly(code: string): boolean {
+    return (
+      // user could have created report at this location were it enabled
+      this.couldCreateReportInLocationIfActiveInService(code) &&
+      // if PECS region, are they enabled?
+      ((isPecsRegionCode(code) && !config.activeForPecsRegions) ||
+        // otherwise is the prison enabled?
+        !isPrisonActiveInService(code))
+    )
+  }
+
   /** Can create new report in active caseload prison */
   get canCreateReportInActiveCaseload(): boolean {
     return this.canCreateReportInLocation(this.activeCaseloadId)
+  }
+
+  /** Could have created new report in active caseload prison were it enabled */
+  get canCreateReportInActiveCaseloadInNomisOnly(): boolean {
+    return this.canCreateReportInLocationInNomisOnly(this.activeCaseloadId)
   }
 
   private couldEditReportIfLocationActiveInService(report: ReportBasic): boolean {
@@ -131,6 +148,18 @@ export class Permissions {
       ((isPecsRegionCode(report.location) && config.activeForPecsRegions) ||
         // otherwise is the prison enabled?
         isPrisonActiveInService(report.location))
+    )
+  }
+
+  /** Could have approved or rejected this report in DPS if prison was active or PECS regions are enabled */
+  canApproveOrRejectReportInNomisOnly(report: ReportBasic): boolean {
+    return (
+      // user could have approved/rejected report at this location were it enabled
+      this.couldApproveOrRejectReportIfLocationActiveInService(report) &&
+      // if PECS region, are they enabled?
+      ((isPecsRegionCode(report.location) && !config.activeForPecsRegions) ||
+        // otherwise is the prison enabled?
+        !isPrisonActiveInService(report.location))
     )
   }
 }


### PR DESCRIPTION
This would allow presenting a helpful message to use NOMIS in place of a missing action button

Current rules:
```
Access to the service
  should be denied to missing user
  should be denied to user without roles
  should be granted to reporting officer
  should be granted to data warden
  should be granted to HQ view-only user
Viewing a report
  in Leeds
    should be denied to missing user
    should be denied to user without roles or Leeds caseload
    should be denied to user without roles but with Leeds caseload
    should be denied to reporting officer without Leeds caseload
    should be granted to reporting officer with Leeds caseload
    should be granted to reporting officer with Leeds caseload and PECS role
    should be denied to data warden without Leeds caseload
    should be granted to data warden with Leeds caseload
    should be granted to data warden with Leeds caseload missing PECS role
    should be denied to HQ view-only user without Leeds caseload
    should be granted to HQ view-only user with Leeds caseload
    should be granted to HQ view-only user with Leeds caseload and PECS role
  in a PECS region
    should be denied to missing user
    should be denied to user without roles or Leeds caseload
    should be denied to user without roles but with Leeds caseload
    should be denied to reporting officer without Leeds caseload
    should be denied to reporting officer with Leeds caseload
    should be granted to reporting officer with Leeds caseload and PECS role
    should be granted to data warden without Leeds caseload
    should be granted to data warden with Leeds caseload
    should be denied to data warden with Leeds caseload missing PECS role
    should be denied to HQ view-only user without Leeds caseload
    should be denied to HQ view-only user with Leeds caseload
    should be granted to HQ view-only user with Leeds caseload and PECS role
Creating a new report
  ignoring caseloads
    should by denied to missing user
    should by denied to user without roles
    should by granted to reporting officer
    should by granted to data warden
    should by denied to HQ view-only user
  in Leeds
    should be denied to missing user
    should be denied to user without roles or Leeds caseload
    should be denied to user without roles but with Leeds caseload
    should be denied to reporting officer without Leeds caseload
    should be granted to reporting officer with Leeds caseload
    should be granted to reporting officer with Leeds caseload and PECS role
    should be denied to data warden without Leeds caseload
    should be denied to data warden with Leeds caseload
    should be denied to data warden with Leeds caseload missing PECS role
    should be denied to HQ view-only user without Leeds caseload
    should be denied to HQ view-only user with Leeds caseload
    should be denied to HQ view-only user with Leeds caseload and PECS role
    should be denied to missing user only in NOMIS when Leeds is inactive in DPS
    should be denied to user without roles or Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to user without roles but with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to reporting officer without Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be granted to reporting officer with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be granted to reporting officer with Leeds caseload and PECS role only in NOMIS when Leeds is inactive in DPS
    should be denied to data warden without Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to data warden with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to data warden with Leeds caseload missing PECS role only in NOMIS when Leeds is inactive in DPS
    should be denied to HQ view-only user without Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to HQ view-only user with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to HQ view-only user with Leeds caseload and PECS role only in NOMIS when Leeds is inactive in DPS
  in active caseload
    should be denied to missing user
    should be denied to user without roles
    should be granted to reporting officer whose active caseload is active in the service
    should be denied to reporting officer whose active caseload is inactive in the service
    should be denied to data warden whose active caseload is active in the service
    should be denied to data warden whose active caseload is inactive in the service
    should be denied to HQ view-only user
    should be denied to missing user only in NOMIS when active casload is inactive in DPS
    should be denied to user without roles only in NOMIS when active casload is inactive in DPS
    should be granted to reporting officer only in NOMIS when active casload is inactive in DPS
    should be denied to data warden only in NOMIS when active casload is inactive in DPS
    should be denied to HQ view-only user only in NOMIS when active casload is inactive in DPS
  in a PECS region
    should be denied to missing user
    should be denied to user without roles or Leeds caseload
    should be denied to user without roles but with Leeds caseload
    should be denied to reporting officer without Leeds caseload
    should be denied to reporting officer with Leeds caseload
    should be denied to reporting officer with Leeds caseload and PECS role
    should be granted to data warden without Leeds caseload
    should be granted to data warden with Leeds caseload
    should be denied to data warden with Leeds caseload missing PECS role
    should be denied to HQ view-only user without Leeds caseload
    should be denied to HQ view-only user with Leeds caseload
    should be denied to HQ view-only user with Leeds caseload and PECS role
    should be denied to missing user only in NOMIS when PECS reports are inactive in DPS
    should be denied to user without roles or Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to user without roles but with Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to reporting officer without Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to reporting officer with Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to reporting officer with Leeds caseload and PECS role only in NOMIS when PECS reports are inactive in DPS
    should be granted to data warden without Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be granted to data warden with Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to data warden with Leeds caseload missing PECS role only in NOMIS when PECS reports are inactive in DPS
    should be denied to HQ view-only user without Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to HQ view-only user with Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to HQ view-only user with Leeds caseload and PECS role only in NOMIS when PECS reports are inactive in DPS
Editing a report
  in Leeds
    should be denied to missing user
    should be denied to user without roles or Leeds caseload
    should be denied to user without roles but with Leeds caseload
    should be denied to reporting officer without Leeds caseload
    should be granted to reporting officer with Leeds caseload
    should be granted to reporting officer with Leeds caseload and PECS role
    should be denied to data warden without Leeds caseload
    should be denied to data warden with Leeds caseload
    should be denied to data warden with Leeds caseload missing PECS role
    should be denied to HQ view-only user without Leeds caseload
    should be denied to HQ view-only user with Leeds caseload
    should be denied to HQ view-only user with Leeds caseload and PECS role
    should be denied to missing user only in NOMIS when Leeds is inactive in DPS
    should be denied to user without roles or Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to user without roles but with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to reporting officer without Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be granted to reporting officer with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be granted to reporting officer with Leeds caseload and PECS role only in NOMIS when Leeds is inactive in DPS
    should be denied to data warden without Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to data warden with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to data warden with Leeds caseload missing PECS role only in NOMIS when Leeds is inactive in DPS
    should be denied to HQ view-only user without Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to HQ view-only user with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to HQ view-only user with Leeds caseload and PECS role only in NOMIS when Leeds is inactive in DPS
  in a PECS region
    should be denied to missing user
    should be denied to user without roles or Leeds caseload
    should be denied to user without roles but with Leeds caseload
    should be denied to reporting officer without Leeds caseload
    should be denied to reporting officer with Leeds caseload
    should be denied to reporting officer with Leeds caseload and PECS role
    should be granted to data warden without Leeds caseload
    should be granted to data warden with Leeds caseload
    should be denied to data warden with Leeds caseload missing PECS role
    should be denied to HQ view-only user without Leeds caseload
    should be denied to HQ view-only user with Leeds caseload
    should be denied to HQ view-only user with Leeds caseload and PECS role
    should be denied to missing user only in NOMIS when PECS reports are inactive in DPS
    should be denied to user without roles or Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to user without roles but with Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to reporting officer without Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to reporting officer with Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to reporting officer with Leeds caseload and PECS role only in NOMIS when PECS reports are inactive in DPS
    should be granted to data warden without Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be granted to data warden with Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to data warden with Leeds caseload missing PECS role only in NOMIS when PECS reports are inactive in DPS
    should be denied to HQ view-only user without Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to HQ view-only user with Leeds caseload only in NOMIS when PECS reports are inactive in DPS
    should be denied to HQ view-only user with Leeds caseload and PECS role only in NOMIS when PECS reports are inactive in DPS
Approving or rejecting a report
  in Leeds
    should be denied to missing user
    should be denied to user without roles or Leeds caseload
    should be denied to user without roles but with Leeds caseload
    should be denied to reporting officer without Leeds caseload
    should be denied to reporting officer with Leeds caseload
    should be denied to reporting officer with Leeds caseload and PECS role
    should be denied to data warden without Leeds caseload
    should be granted to data warden with Leeds caseload
    should be granted to data warden with Leeds caseload missing PECS role
    should be denied to HQ view-only user without Leeds caseload
    should be denied to HQ view-only user with Leeds caseload
    should be denied to HQ view-only user with Leeds caseload and PECS role
    should be denied to missing user only in NOMIS when Leeds is inactive in DPS
    should be denied to user without roles or Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to user without roles but with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to reporting officer without Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to reporting officer with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to reporting officer with Leeds caseload and PECS role only in NOMIS when Leeds is inactive in DPS
    should be denied to data warden without Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be granted to data warden with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be granted to data warden with Leeds caseload missing PECS role only in NOMIS when Leeds is inactive in DPS
    should be denied to HQ view-only user without Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to HQ view-only user with Leeds caseload only in NOMIS when Leeds is inactive in DPS
    should be denied to HQ view-only user with Leeds caseload and PECS role only in NOMIS when Leeds is inactive in DPS
  in a PECS region
    should be denied to missing user
    should be denied to user without roles or Leeds caseload
    should be denied to user without roles but with Leeds caseload
    should be denied to reporting officer without Leeds caseload
    should be denied to reporting officer with Leeds caseload
    should be denied to reporting officer with Leeds caseload and PECS role
    should be granted to data warden without Leeds caseload
    should be granted to data warden with Leeds caseload
    should be denied to data warden with Leeds caseload missing PECS role
    should be denied to HQ view-only user without Leeds caseload
    should be denied to HQ view-only user with Leeds caseload
    should be denied to HQ view-only user with Leeds caseload and PECS role
    should be denied to missing user only in NOMIS when active casload is inactive in DPS
    should be denied to user without roles or Leeds caseload only in NOMIS when active casload is inactive in DPS
    should be denied to user without roles but with Leeds caseload only in NOMIS when active casload is inactive in DPS
    should be denied to reporting officer without Leeds caseload only in NOMIS when active casload is inactive in DPS
    should be denied to reporting officer with Leeds caseload only in NOMIS when active casload is inactive in DPS
    should be denied to reporting officer with Leeds caseload and PECS role only in NOMIS when active casload is inactive in DPS
    should be granted to data warden without Leeds caseload only in NOMIS when active casload is inactive in DPS
    should be granted to data warden with Leeds caseload only in NOMIS when active casload is inactive in DPS
    should be denied to data warden with Leeds caseload missing PECS role only in NOMIS when active casload is inactive in DPS
    should be denied to HQ view-only user without Leeds caseload only in NOMIS when active casload is inactive in DPS
    should be denied to HQ view-only user with Leeds caseload only in NOMIS when active casload is inactive in DPS
    should be denied to HQ view-only user with Leeds caseload and PECS role only in NOMIS when active casload is inactive in DPS
```