### PR TITLE
IR-973: Clear form wizard session more strategically

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -66,6 +66,8 @@ export declare global {
       reportSubUrlPrefix?: string
       /** Some routes load incident type config */
       reportConfig?: IncidentTypeConfiguration
+      /** Form wizard controllers can reset the journey session on success by setting this to true */
+      clearSessionOnSuccess?: boolean
       /** Some routes load question form wizard steps into locals */
       questionSteps?: FormWizard.Steps<FormWizard.MultiValues>
       /** Some routes load question form wizard fields into locals */

--- a/server/controllers/base.test.ts
+++ b/server/controllers/base.test.ts
@@ -1,7 +1,12 @@
-import type express from 'express'
-import type FormWizard from 'hmpo-form-wizard'
+// eslint-disable-next-line max-classes-per-file
+import cookieParser from 'cookie-parser'
+import cookieSession from 'cookie-session'
+import express from 'express'
+import FormWizard from 'hmpo-form-wizard'
+import request from 'supertest'
 
 import { mockThrownError } from '../data/testData/thrownErrors'
+import nunjucksSetup from '../utils/nunjucksSetup'
 import { BaseController } from './base'
 
 class TestController extends BaseController {
@@ -230,6 +235,127 @@ describe('Base form wizard controller', () => {
 
       const error = controller.validateField('time', req, res)
       expect(error).toBeUndefined()
+    })
+  })
+
+  describe('Sessions', () => {
+    function makeApp(shouldClearSessionOnSuccess: boolean): express.Express {
+      const app = express()
+
+      // cookies needed for form wizard session handling
+      app.use(cookieParser())
+      app.use(cookieSession({ keys: [''] }))
+
+      // accept POSTs
+      app.use(express.json())
+
+      // CSRF middleware needed for base controller to forward secrets properly
+      app.use((_req, res, next) => {
+        res.locals.csrfToken = 'csrf-token'
+        next()
+      })
+
+      // template rendering middleware is expected to exist
+      nunjucksSetup(app)
+
+      class Controller extends BaseController {
+        successHandler(req: FormWizard.Request, res: express.Response, next: express.NextFunction) {
+          if (shouldClearSessionOnSuccess) {
+            res.locals.clearSessionOnSuccess = true
+          }
+
+          super.successHandler(req, res, next)
+        }
+      }
+
+      // debug route to inspect session contents
+      app.get('/dump-session', (req, res) => {
+        const sessionAsJson = JSON.stringify({
+          ...req.session,
+        })
+        res.send(sessionAsJson)
+      })
+
+      const router = FormWizard(
+        { '/': { fields: ['name'], entryPoint: true, next: '/dump-session' } },
+        { name: { name: 'name', label: 'Name', validate: ['required'], component: 'govukInput' } },
+        {
+          name: 'test',
+          journeyName: 'test',
+          controller: Controller,
+          template: 'partials/formWizardLayout',
+          csrf: false,
+        },
+        // TODO: checkSession: false
+      )
+      app.use('/', router)
+
+      return app
+    }
+
+    it('should be cleared on success when locals flag is set', async () => {
+      const app = makeApp(true)
+      const agent = request.agent(app)
+
+      await agent.get('/').expect(200)
+      return agent
+        .post('/')
+        .send({ name: 'John' })
+        .redirects(1)
+        .expect(200)
+        .expect(res => {
+          const session = JSON.parse(res.text)
+
+          // clearing wizard journey retains the keys in the session but the values are empty objects
+          expect(session).toHaveProperty('hmpo-wizard-test', {})
+          expect(session).toHaveProperty('hmpo-journey-test', {})
+        })
+    })
+
+    it('should not be cleared on success when locals flag is absent', async () => {
+      const app = makeApp(false)
+      const agent = request.agent(app)
+
+      await agent.get('/').expect(200)
+      return agent
+        .post('/')
+        .send({ name: 'John' })
+        .redirects(1)
+        .expect(200)
+        .expect(res => {
+          const session = JSON.parse(res.text)
+
+          // session model is not cleared and form value exists
+          expect(session).toHaveProperty('hmpo-wizard-test')
+          expect(session['hmpo-wizard-test']).toHaveProperty('name', 'John')
+
+          // journey model is not cleared and history properties exist
+          expect(session).toHaveProperty('hmpo-journey-test')
+          expect(session['hmpo-journey-test']).toHaveProperty('lastVisited')
+          expect(session['hmpo-journey-test']).toHaveProperty('history')
+          expect(session['hmpo-journey-test']).toHaveProperty('registered-models')
+        })
+    })
+
+    it('should not be cleared on error', async () => {
+      const app = makeApp(true)
+      const agent = request.agent(app)
+
+      await agent.get('/').expect(200)
+      await agent.post('/').send({ name: '' }).redirects(1).expect(200)
+      await agent.get('/dump-session').expect(res => {
+        const session = JSON.parse(res.text)
+
+        // session model is not cleared and error properties exist
+        expect(session).toHaveProperty('hmpo-wizard-test')
+        expect(session['hmpo-wizard-test']).toHaveProperty('errors')
+        expect(session['hmpo-wizard-test']).toHaveProperty('errorValues')
+
+        // journey model is not cleared and history properties exist
+        expect(session).toHaveProperty('hmpo-journey-test')
+        expect(session['hmpo-journey-test']).toHaveProperty('lastVisited')
+        expect(session['hmpo-journey-test']).toHaveProperty('registered-models')
+      })
     })
   })
 })

--- a/server/controllers/base.test.ts
+++ b/server/controllers/base.test.ts
@@ -286,7 +286,6 @@ describe('Base form wizard controller', () => {
           template: 'partials/formWizardLayout',
           csrf: false,
         },
-        // TODO: checkSession: false
       )
       app.use('/', router)
 

--- a/server/controllers/base.ts
+++ b/server/controllers/base.ts
@@ -120,6 +120,22 @@ export abstract class BaseController<
 
     return allValues
   }
+
+  successHandler(req: FormWizard.Request<V, K>, res: express.Response, next: express.NextFunction): void {
+    // optionally, clear the journey from the session as the final action
+    // form wizard’s standard `successHandler` will add a history step to the journey model
+    // so _here_ is too early to clear the session and the `next` function is never called
+    if (res.locals.clearSessionOnSuccess) {
+      const actualRedirect = res.redirect.bind(res)
+      res.redirect = (...args: unknown[]) => {
+        // clear the session just before redirecting
+        req.journeyModel.reset()
+        actualRedirect(...args)
+      }
+    }
+
+    super.successHandler(req, res, next)
+  }
 }
 
 // install application-specific validators

--- a/server/controllers/involvements/remove.ts
+++ b/server/controllers/involvements/remove.ts
@@ -67,7 +67,7 @@ export abstract class RemoveInvolvement<
         await this.deleteInvolvement(req, res)
 
         // clear session since involvement has been saved
-        req.journeyModel.reset()
+        res.locals.clearSessionOnSuccess = true
       }
 
       next()

--- a/server/controllers/involvements/summary.ts
+++ b/server/controllers/involvements/summary.ts
@@ -108,10 +108,10 @@ export abstract class InvolvementSummary extends BaseController<Values> {
     const report = res.locals.report as ReportWithDetails
     const { confirmAdd } = req.form.values
 
-    // clear session since choice made
-    req.journeyModel.reset()
-
     if (confirmAdd === 'yes') {
+      // clear session since choice made
+      req.journeyModel.reset()
+
       res.redirect(`${res.locals.reportSubUrlPrefix}/${this.type}/search`)
     } else {
       if (confirmAdd === 'no' && report[this.involvementField].length === 0) {
@@ -127,6 +127,10 @@ export abstract class InvolvementSummary extends BaseController<Values> {
           return
         }
       }
+
+      // clear session since choice made
+      res.locals.clearSessionOnSuccess = true
+
       super.successHandler(req, res, next)
     }
   }

--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -100,6 +100,7 @@ describe('Error handling', () => {
       const fields: FormWizard.Fields = { name: { validate: ['required'] } }
       const formConfig: FormWizard.Config = {
         name: 'redirect-test',
+        journeyName: 'redirect-test',
         // TODO: will need to swap to an empty template if index page becomes complex and stops working
         template: 'pages/index',
         checkSession: false,

--- a/server/routes/debug.ts
+++ b/server/routes/debug.ts
@@ -17,8 +17,10 @@ export default function makeDebugRoutes(services: Services): Record<string, Requ
 
       const event = await incidentReportingApi.getEventById(eventId)
       const usernames = event.reports.map(report => report.reportedBy)
-      const usersLookup = await userService.getUsers(res.locals.systemToken, usernames)
-      const prisonsLookup = await prisonApi.getPrisons()
+      const [usersLookup, prisonsLookup] = await Promise.all([
+        userService.getUsers(res.locals.systemToken, usernames),
+        prisonApi.getPrisons(),
+      ])
 
       res.render('pages/debug/eventDetails', { event, usersLookup, prisonsLookup })
     },

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,5 +1,6 @@
 import { type RequestHandler, Router } from 'express'
 
+import config from '../config'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import { logoutIf } from '../middleware/permissions'
 import type { Services } from '../services'
@@ -28,8 +29,17 @@ export default function routes(services: Services): Router {
   })
 
   // view-only debug pages
+  // TODO: remove once not needed
   const debugRoutes = makeDebugRoutes(services)
   get('/incidents/:eventId', debugRoutes.eventDetails)
+  if (config.environment !== 'prod') {
+    router.get('/inspect-session', (req, res) => {
+      const sessionAsJson = JSON.stringify({
+        ...req.session,
+      })
+      res.send(sessionAsJson)
+    })
+  }
 
   // creating and editing a report
   router.use('/reports', dashboard(services))

--- a/server/routes/reports/details/changeType.ts
+++ b/server/routes/reports/details/changeType.ts
@@ -60,7 +60,7 @@ class TypeController extends BaseTypeController<TypeValues> {
       logger.info(`Report ${report.reportReference} type changed to ${type}`)
 
       // clear session since report has been saved
-      req.journeyModel.reset()
+      res.locals.clearSessionOnSuccess = true
 
       super.successHandler(req, res, next)
     } catch (e) {

--- a/server/routes/reports/details/changeType.ts
+++ b/server/routes/reports/details/changeType.ts
@@ -98,6 +98,7 @@ const changeTypeFields: FormWizard.Fields<TypeValues> = { ...typeFields }
 
 const changeTypeConfig: FormWizard.Config<TypeValues> = {
   name: 'changeType',
+  journeyName: 'changeType',
   checkSession: false,
   csrf: false,
   templatePath: 'pages/reports',

--- a/server/routes/reports/details/createReport.ts
+++ b/server/routes/reports/details/createReport.ts
@@ -42,7 +42,7 @@ class DetailsController extends BaseDetailsController<CreateReportValues> {
       res.locals.reportSubUrlPrefix = `/create-report/${report.id}`
 
       // clear session since report has been saved
-      req.journeyModel.reset()
+      res.locals.clearSessionOnSuccess = true
 
       super.successHandler(req, res, next)
     } catch (e) {

--- a/server/routes/reports/details/createReport.ts
+++ b/server/routes/reports/details/createReport.ts
@@ -92,6 +92,7 @@ const createReportFields: FormWizard.Fields<CreateReportValues> = { ...typeField
 
 const createReportConfig: FormWizard.Config<CreateReportValues> = {
   name: 'createReport',
+  journeyName: 'createReport',
   checkSession: false,
   csrf: false,
   templatePath: 'pages/reports',

--- a/server/routes/reports/details/updateReportDetails.ts
+++ b/server/routes/reports/details/updateReportDetails.ts
@@ -61,7 +61,7 @@ class DetailsController extends BaseDetailsController<DetailsValues> {
       logger.info(`Report ${report.reportReference} details updated`)
 
       // clear session since report has been saved
-      req.journeyModel.reset()
+      res.locals.clearSessionOnSuccess = true
 
       super.successHandler(req, res, next)
     } catch (e) {

--- a/server/routes/reports/details/updateReportDetails.ts
+++ b/server/routes/reports/details/updateReportDetails.ts
@@ -91,6 +91,7 @@ const updateDetailsFields: FormWizard.Fields<DetailsValues> = { ...detailsFields
 
 const updateDetailsConfig: FormWizard.Config<DetailsValues> = {
   name: 'updateDetails',
+  journeyName: 'updateDetails',
   checkSession: false,
   csrf: false,
   templatePath: 'pages/reports',

--- a/server/routes/reports/prisoners/involvement/add.ts
+++ b/server/routes/reports/prisoners/involvement/add.ts
@@ -63,6 +63,7 @@ class AddPrisonerInvolvementController extends PrisonerInvolvementController {
 // eslint-disable-next-line import/prefer-default-export
 export const addRouter = FormWizard(steps, fields, {
   name: 'addPrisonerInvolvement',
+  journeyName: 'addPrisonerInvolvement',
   checkSession: false,
   csrf: false,
   template: 'pages/prisoners/involvement',

--- a/server/routes/reports/prisoners/involvement/add.ts
+++ b/server/routes/reports/prisoners/involvement/add.ts
@@ -48,8 +48,10 @@ class AddPrisonerInvolvementController extends PrisonerInvolvementController {
         comment: allValues.comment ?? '',
       })
       logger.info('Prisoner involvement added to report %s', report.id)
+
       // clear session since involvement has been saved
-      req.journeyModel.reset()
+      res.locals.clearSessionOnSuccess = true
+
       next()
     } catch (e) {
       logger.error(e, 'Prisoner involvement could not be added to report %s: %j', report.id, e)

--- a/server/routes/reports/prisoners/involvement/edit.ts
+++ b/server/routes/reports/prisoners/involvement/edit.ts
@@ -107,6 +107,7 @@ class EditPrisonerInvolvementController extends PrisonerInvolvementController {
 // eslint-disable-next-line import/prefer-default-export
 export const editRouter = FormWizard(steps, fields, {
   name: 'editPrisonerInvolvement',
+  journeyName: 'editPrisonerInvolvement',
   checkSession: false,
   csrf: false,
   template: 'pages/prisoners/involvement',

--- a/server/routes/reports/prisoners/involvement/edit.ts
+++ b/server/routes/reports/prisoners/involvement/edit.ts
@@ -92,8 +92,10 @@ class EditPrisonerInvolvementController extends PrisonerInvolvementController {
         comment: allValues.comment ?? '',
       })
       logger.info('Prisoner involvement %d updated in report %s', index, report.id)
+
       // clear session since involvement has been saved
-      req.journeyModel.reset()
+      res.locals.clearSessionOnSuccess = true
+
       next()
     } catch (e) {
       logger.error(e, 'Prisoner involvement %d could not be updated in report %s: %j', index, report.id, e)

--- a/server/routes/reports/prisoners/remove/index.ts
+++ b/server/routes/reports/prisoners/remove/index.ts
@@ -7,6 +7,7 @@ import { steps } from './steps'
 // eslint-disable-next-line import/prefer-default-export
 export const removeRouter = FormWizard(steps, fields, {
   name: 'removePrisoner',
+  journeyName: 'removePrisoner',
   template: 'pages/prisoners/remove',
   checkSession: false,
   csrf: false,

--- a/server/routes/reports/prisoners/search/index.ts
+++ b/server/routes/reports/prisoners/search/index.ts
@@ -7,6 +7,7 @@ import { steps } from './steps'
 // eslint-disable-next-line import/prefer-default-export
 export const searchRouter = FormWizard(steps, fields, {
   name: 'prisonerInvolvementSearch',
+  journeyName: 'prisonerInvolvementSearch',
   checkSession: false,
   csrf: false,
   template: 'pages/prisoners/search',

--- a/server/routes/reports/prisoners/summary/index.ts
+++ b/server/routes/reports/prisoners/summary/index.ts
@@ -7,6 +7,7 @@ import { steps } from './steps'
 // eslint-disable-next-line import/prefer-default-export
 export const summaryRouter = FormWizard(steps, fields, {
   name: 'prisonerSummary',
+  journeyName: 'prisonerSummary',
   checkSession: false,
   csrf: false,
   template: 'pages/prisoners/summary',

--- a/server/routes/reports/questions/controller.ts
+++ b/server/routes/reports/questions/controller.ts
@@ -298,6 +298,9 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
             await incidentReportingApi.deleteQuestionsAndTheirResponses(report.id, questionsToDelete)
             logger.info('Removed obsolete questions from report %s', report.id)
           }
+
+          // clear session since questions have been saved
+          res.locals.clearSessionOnSuccess = true
         } catch (e) {
           logger.error(e, 'Questions could not be updated in report %s: %j', report.id, e)
           const err = this.convertIntoValidationError(e)
@@ -311,21 +314,5 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
         next()
       }
     })
-  }
-
-  successHandler(
-    req: FormWizard.Request<FormWizard.MultiValues, string>,
-    res: express.Response,
-    next: express.NextFunction,
-  ): void {
-    // clear session since questions have been saved
-    // NB: there is no method to override and next callback is unused,
-    // so this seems to be the only way to do it at the right time
-    const actualRedirect = res.redirect.bind(res)
-    res.redirect = (...args: unknown[]) => {
-      req.journeyModel.reset()
-      actualRedirect(...args)
-    }
-    super.successHandler(req, res, next)
   }
 }

--- a/server/routes/reports/questions/index.ts
+++ b/server/routes/reports/questions/index.ts
@@ -19,6 +19,7 @@ questionsRouter.use(populateReportConfiguration(), (req, res, next) => {
 
   const wizardRouter = wizard(res.locals.questionSteps, res.locals.questionFields, {
     name: `${reportId}-questions`,
+    journeyName: `${reportId}-questions`,
     template: 'pages/reports/questions',
     // Needs to be false, session already handled by application
     checkSession: false,

--- a/server/routes/reports/staff/involvement/add.ts
+++ b/server/routes/reports/staff/involvement/add.ts
@@ -54,6 +54,7 @@ export class AddStaffInvolvementController<V extends Values = Values> extends St
 
 export const addRouter = FormWizard(steps, fields, {
   name: 'addStaffInvolvement',
+  journeyName: 'addStaffInvolvement',
   checkSession: false,
   csrf: false,
   template: 'pages/staff/involvement',

--- a/server/routes/reports/staff/involvement/add.ts
+++ b/server/routes/reports/staff/involvement/add.ts
@@ -26,8 +26,10 @@ export class AddStaffInvolvementController<V extends Values = Values> extends St
         comment: allValues.comment ?? '',
       })
       logger.info('Staff involvement added to report %s', report.id)
+
       // clear session since involvement has been saved
-      req.journeyModel.reset()
+      res.locals.clearSessionOnSuccess = true
+
       next()
     } catch (e) {
       logger.error(e, 'Staff involvement could not be added to report %s: %j', report.id, e)

--- a/server/routes/reports/staff/involvement/edit.ts
+++ b/server/routes/reports/staff/involvement/edit.ts
@@ -71,8 +71,10 @@ class EditStaffInvolvementController extends StaffInvolvementController {
         comment: allValues.comment ?? '',
       })
       logger.info('Staff involvement %d updated in report %s', index, report.id)
+
       // clear session since involvement has been saved
-      req.journeyModel.reset()
+      res.locals.clearSessionOnSuccess = true
+
       next()
     } catch (e) {
       logger.error(e, 'Staff involvement %d could not be updated in report %s: %j', index, report.id, e)

--- a/server/routes/reports/staff/involvement/edit.ts
+++ b/server/routes/reports/staff/involvement/edit.ts
@@ -85,6 +85,7 @@ class EditStaffInvolvementController extends StaffInvolvementController {
 // eslint-disable-next-line import/prefer-default-export
 export const editRouter = FormWizard(steps, fields, {
   name: 'editStaffInvolvement',
+  journeyName: 'editStaffInvolvement',
   checkSession: false,
   csrf: false,
   template: 'pages/staff/involvement',

--- a/server/routes/reports/staff/involvement/manual/add.ts
+++ b/server/routes/reports/staff/involvement/manual/add.ts
@@ -6,6 +6,7 @@ import { steps } from './steps'
 // eslint-disable-next-line import/prefer-default-export
 export const manualAddRouter = FormWizard(steps, fields, {
   name: 'addManualStaffInvolvement',
+  journeyName: 'addManualStaffInvolvement',
   checkSession: false,
   csrf: false,
 })

--- a/server/routes/reports/staff/remove/index.ts
+++ b/server/routes/reports/staff/remove/index.ts
@@ -7,6 +7,7 @@ import { steps } from './steps'
 // eslint-disable-next-line import/prefer-default-export
 export const removeRouter = FormWizard(steps, fields, {
   name: 'removeStaff',
+  journeyName: 'removeStaff',
   template: 'pages/staff/remove',
   checkSession: false,
   csrf: false,

--- a/server/routes/reports/staff/search/index.ts
+++ b/server/routes/reports/staff/search/index.ts
@@ -7,6 +7,7 @@ import { steps } from './steps'
 // eslint-disable-next-line import/prefer-default-export
 export const searchRouter = FormWizard(steps, fields, {
   name: 'staffInvolvementSearch',
+  journeyName: 'staffInvolvementSearch',
   checkSession: false,
   csrf: false,
   template: 'pages/staff/search',

--- a/server/routes/reports/staff/summary/index.ts
+++ b/server/routes/reports/staff/summary/index.ts
@@ -7,6 +7,7 @@ import { steps } from './steps'
 // eslint-disable-next-line import/prefer-default-export
 export const summaryRouter = FormWizard(steps, fields, {
   name: 'staffSummary',
+  journeyName: 'staffSummary',
   checkSession: false,
   csrf: false,
   template: 'pages/staff/summary',


### PR DESCRIPTION
Form wizard sessions were being cleared slightly too early. The root controller class’ success handler [adds a history step to the journey model](https://github.com/HMPO/hmpo-form-wizard/blob/f9ad4df65d500eea2128e6773f09980e17e53d3b/lib/controller/index.js#L360) _after_ we cleared the session. It’s presence in the session later meant those same controller could not tell where to send the user.