### PR TITLE
IR-1026: Make heading and warning text consistent when users change incident type

### DIFF
--- a/integration_tests/pages/reports/type.ts
+++ b/integration_tests/pages/reports/type.ts
@@ -5,7 +5,7 @@ import type { PageElement } from '../page'
 
 export class ChangeTypeConfirmationPage extends FormWizardPage {
   constructor() {
-    super('Some of your answers will be deleted')
+    super('Most of your answers will be deleted')
   }
 }
 

--- a/server/routes/reports/details/changeType.test.ts
+++ b/server/routes/reports/details/changeType.test.ts
@@ -75,7 +75,7 @@ describe('Changing incident type', () => {
       .expect(res => {
         expect(res.request.url.endsWith('/change-type')).toBe(true)
         expect(res.text).toContain('app-confirm-change-type')
-        expect(res.text).toContain('Some of your answers will be deleted')
+        expect(res.text).toContain('Most of your answers will be deleted')
       })
   })
 

--- a/server/views/pages/reports/confirm-type-change.njk
+++ b/server/views/pages/reports/confirm-type-change.njk
@@ -1,6 +1,6 @@
 {% extends "partials/formWizardLayout.njk" %}
 
-{% set pageTitle = "Some of your answers will be deleted" %}
+{% set pageTitle = "Most of your answers will be deleted" %}
 {% set bodyClasses = "app-confirm-change-type" %}
 
 {% block formFields %}


### PR DESCRIPTION
Builds on #438