### PR TITLE
IR-1047: Categorise users into types before determining permissions

### DIFF
--- a/server/data/constants.ts
+++ b/server/data/constants.ts
@@ -6,7 +6,7 @@ export type OutsidePrisonId = typeof outsidePrisonId
 
 /**
  * HQ role for viewing incident reports.
- * This allows a user to view  incident reports in within their caseloads.
+ * This allows a user to view  incident reports in within their caseloads, but not change them in any way.
  * Viewing PECS reports is granted with additional role.
  */
 export const roleReadOnly = 'INCIDENT_REPORTS__RO' as const
@@ -14,14 +14,14 @@ export const roleReadOnly = 'INCIDENT_REPORTS__RO' as const
 /**
  * Reporting Officer role for incident reporting.
  * This allows a user to view and create new incident reports in within their caseloads.
- * It does not allow approval of incident reports nor creating of reports outside their caseloads.
+ * It does not allow reviewing incident reports nor creating of reports outside their caseloads.
  * Viewing PECS reports is granted with additional role.
  */
 export const roleReadWrite = 'INCIDENT_REPORTS__RW' as const
 
 /**
  * Data Warden role.
- * This allows users to view and approve or reject incident reports, raised by reporting officers.
+ * This allows users to view and review incident reports, raised by reporting officers.
  * Caseloads are required to perform an action.
  * Creating and editing PECS reports is granted with additional role.
  */
@@ -38,5 +38,6 @@ export const rolePecs = 'INCIDENT_REPORTS__PECS' as const
 
 /**
  * Used by DPS/NOMIS central admin/support.
+ * TODO: will they need any special access?
  */
 export const roleCentralAdmin = 'CADM_I' as const

--- a/server/data/testData/users.ts
+++ b/server/data/testData/users.ts
@@ -25,16 +25,16 @@ export function mockUser(caseloads: CaseLoad[], roles: string[] = []): Express.U
 }
 
 /** Typical reporting officer with access to Moorland only */
-export const reportingUser = mockUser([makeMockCaseload(moorland)], [roleReadWrite])
+export const mockReportingOfficer = mockUser([makeMockCaseload(moorland)], [roleReadWrite])
 
 /** Data warden with write access to Leeds, Moorland and PECS regions */
-export const approverUser = mockUser(
+export const mockDataWarden = mockUser(
   [makeMockCaseload(moorland), makeMockCaseload(leeds)],
   [roleApproveReject, rolePecs],
 )
 
 /** HQ user with read-only access to Leeds and Moorland */
-export const hqUser = mockUser([makeMockCaseload(moorland), makeMockCaseload(leeds)], [roleReadOnly])
+export const mockHqViewer = mockUser([makeMockCaseload(moorland), makeMockCaseload(leeds)], [roleReadOnly])
 
 /** General DPS user in Moorland without access */
-export const unauthorisedUser = mockUser([makeMockCaseload(moorland)])
+export const mockUnauthorisedUser = mockUser([makeMockCaseload(moorland)])

--- a/server/routes/dashboard/index.test.ts
+++ b/server/routes/dashboard/index.test.ts
@@ -9,7 +9,7 @@ import { convertBasicReportDates } from '../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../data/testData/incidentReporting'
 import { unsortedPageOf } from '../../data/testData/paginatedResponses'
 import { mockSharedUser } from '../../data/testData/manageUsers'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../data/testData/users'
+import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../data/testData/users'
 import { mockThrownError } from '../../data/testData/thrownErrors'
 import UserService from '../../services/userService'
 import { Status } from '../../reportConfiguration/constants'
@@ -50,10 +50,10 @@ describe('Dashboard permissions', () => {
   const hide = 'hide' as const
 
   it.each([
-    { userType: 'reporting officer', user: reportingUser, action: show },
-    { userType: 'data warden', user: approverUser, action: hide },
-    { userType: 'HQ view-only user', user: hqUser, action: hide },
-    { userType: 'unauthorised user', user: unauthorisedUser, action: hide },
+    { userType: 'reporting officer', user: mockReportingOfficer, action: show },
+    { userType: 'data warden', user: mockDataWarden, action: hide },
+    { userType: 'HQ view-only user', user: mockHqViewer, action: hide },
+    { userType: 'unauthorised user', user: mockUnauthorisedUser, action: hide },
   ])('should $action report button for $userType', ({ user, action }) => {
     return request(appWithAllRoutes({ services: { userService }, userSupplier: () => user }))
       .get('/reports')
@@ -69,7 +69,7 @@ describe('Dashboard permissions', () => {
   it('should hide report button for reporting officer when their active caseload in not active in the service', () => {
     config.activePrisons = ['LEI']
 
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => reportingUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockReportingOfficer }))
       .get('/reports')
       .expect(res => {
         expect(res.text).not.toContain('Report an incident')
@@ -167,7 +167,7 @@ describe('GET dashboard', () => {
       incidentStatuses: 'toDo',
     }
 
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => reportingUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockReportingOfficer }))
       .get('/reports')
       .query(queryParams)
       .expect('Content-Type', /html/)
@@ -202,7 +202,7 @@ describe('GET dashboard', () => {
       incidentStatuses: 'DRAFT',
     }
 
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => approverUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockDataWarden }))
       .get('/reports')
       .query(queryParams)
       .expect('Content-Type', /html/)
@@ -220,7 +220,7 @@ describe('GET dashboard', () => {
       typeFamily: 'FIND',
     }
 
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => approverUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockDataWarden }))
       .get('/reports')
       .query(queryParams)
       .expect('Content-Type', /html/)
@@ -277,7 +277,7 @@ describe('GET dashboard', () => {
       status: ['DRAFT', 'NEEDS_UPDATING', 'REOPENED'],
       type: undefined,
     }
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => reportingUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockReportingOfficer }))
       .get('/reports')
       .expect('Content-Type', /html/)
       .expect(200)
@@ -314,7 +314,7 @@ describe('GET dashboard', () => {
       status: undefined,
       type: undefined,
     }
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => reportingUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockReportingOfficer }))
       .get('/reports')
       .query({ incidentStatuses: '' })
       .expect('Content-Type', /html/)
@@ -352,7 +352,7 @@ describe('GET dashboard', () => {
       status: ['DRAFT', 'NEEDS_UPDATING', 'REOPENED'],
       type: undefined,
     }
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => reportingUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockReportingOfficer }))
       .get('/reports')
       .expect('Content-Type', /html/)
       .expect(200)
@@ -380,7 +380,7 @@ describe('GET dashboard', () => {
       status: undefined,
       type: undefined,
     }
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => approverUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockDataWarden }))
       .get('/reports')
       .expect('Content-Type', /html/)
       .expect(200)
@@ -408,7 +408,7 @@ describe('GET dashboard', () => {
       status: undefined,
       type: undefined,
     }
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => approverUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockDataWarden }))
       .get('/reports')
       .expect('Content-Type', /html/)
       .expect(200)
@@ -458,7 +458,7 @@ describe('search validations', () => {
       type: undefined,
     }
 
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => reportingUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockReportingOfficer }))
       .get('/reports')
       .query({ searchID: searchValue })
       .expect('Content-Type', /html/)
@@ -665,7 +665,7 @@ describe('work list filter validations in RO view', () => {
       status: expectedArgs as Status[],
       type: undefined,
     }
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => reportingUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockReportingOfficer }))
       .get('/reports')
       .query({ incidentStatuses: statusQuery })
       .expect('Content-Type', /html/)
@@ -701,7 +701,7 @@ describe('work list filter validations in DW view', () => {
       status: expectedArgs as Status[],
       type: undefined,
     }
-    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => approverUser }))
+    return request(appWithAllRoutes({ services: { userService }, userSupplier: () => mockDataWarden }))
       .get('/reports')
       .query({ incidentStatuses: statusQuery })
       .expect('Content-Type', /html/)
@@ -722,14 +722,14 @@ describe('Establishment filter validations', () => {
       usertype: 'RO',
       queryLocation: 'ASH',
       expectedLocations: ['MDI'],
-      user: reportingUser,
+      user: mockReportingOfficer,
       expectedStatus: undefined,
     },
     {
       usertype: 'DW',
       queryLocation: 'ASH',
       expectedLocations: ['MDI', 'LEI'],
-      user: approverUser,
+      user: mockDataWarden,
       expectedStatus: undefined,
     },
   ])(
@@ -789,7 +789,7 @@ describe('Status/work list filter validations', () => {
       scenario: 'single invalid entry',
       usertype: 'RO',
       expectedLocations: ['MDI'],
-      user: reportingUser,
+      user: mockReportingOfficer,
       queryStatus: 'DRAFT',
       expectedStatus: undefined,
       expectedError: 'Work list filter submitted contains invalid values',
@@ -798,7 +798,7 @@ describe('Status/work list filter validations', () => {
       scenario: 'multiple invalid entries',
       usertype: 'RO',
       expectedLocations: ['MDI'],
-      user: reportingUser,
+      user: mockReportingOfficer,
       queryStatus: ['DRAFT', 'AWAITING_REVIEW'],
       expectedStatus: undefined,
       expectedError: 'Work list filter submitted contains invalid values',
@@ -807,7 +807,7 @@ describe('Status/work list filter validations', () => {
       scenario: 'invalid entries alongside valid entries',
       usertype: 'RO',
       expectedLocations: ['MDI'],
-      user: reportingUser,
+      user: mockReportingOfficer,
       queryStatus: ['submitted', 'done', 'DRAFT', 'AWAITING_REVIEW'],
       expectedStatus: undefined,
       expectedError: 'Work list filter submitted contains invalid values',
@@ -816,7 +816,7 @@ describe('Status/work list filter validations', () => {
       scenario: 'entry entirely invalid for any user',
       usertype: 'RO',
       expectedLocations: ['MDI'],
-      user: reportingUser,
+      user: mockReportingOfficer,
       queryStatus: 'random_status',
       expectedStatus: undefined,
       expectedError: 'Work list filter submitted contains invalid values',
@@ -825,7 +825,7 @@ describe('Status/work list filter validations', () => {
       scenario: 'entries entirely invalid for any user',
       usertype: 'RO',
       expectedLocations: ['MDI'],
-      user: reportingUser,
+      user: mockReportingOfficer,
       queryStatus: ['random_status', 'another_option'],
       expectedStatus: undefined,
       expectedError: 'Work list filter submitted contains invalid values',
@@ -834,7 +834,7 @@ describe('Status/work list filter validations', () => {
       scenario: 'single invalid entry',
       usertype: 'DW',
       expectedLocations: ['MDI', 'LEI'],
-      user: approverUser,
+      user: mockDataWarden,
       queryStatus: 'toDo',
       expectedStatus: undefined,
       expectedError: 'Status filter submitted contains invalid values',
@@ -843,7 +843,7 @@ describe('Status/work list filter validations', () => {
       scenario: 'multiple invalid entries',
       usertype: 'DW',
       expectedLocations: ['MDI', 'LEI'],
-      user: approverUser,
+      user: mockDataWarden,
       queryStatus: ['toDo', 'done'],
       expectedStatus: undefined,
       expectedError: 'Status filter submitted contains invalid values',
@@ -852,7 +852,7 @@ describe('Status/work list filter validations', () => {
       scenario: 'invalid entries alongside valid entries',
       usertype: 'DW',
       expectedLocations: ['MDI', 'LEI'],
-      user: approverUser,
+      user: mockDataWarden,
       queryStatus: ['submitted', 'done', 'DRAFT', 'AWAITING_REVIEW'],
       expectedStatus: undefined,
       expectedError: 'Status filter submitted contains invalid values',
@@ -861,7 +861,7 @@ describe('Status/work list filter validations', () => {
       scenario: 'entry entirely invalid for any user',
       usertype: 'DW',
       expectedLocations: ['MDI', 'LEI'],
-      user: approverUser,
+      user: mockDataWarden,
       queryStatus: 'random_status',
       expectedStatus: undefined,
       expectedError: 'Status filter submitted contains invalid values',
@@ -870,7 +870,7 @@ describe('Status/work list filter validations', () => {
       scenario: 'entries entirely invalid for any user',
       usertype: 'DW',
       expectedLocations: ['MDI', 'LEI'],
-      user: approverUser,
+      user: mockDataWarden,
       queryStatus: ['random_status', 'another_option'],
       expectedStatus: undefined,
       expectedError: 'Status filter submitted contains invalid values',

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express'
 import request from 'supertest'
 
 import { PrisonApi } from '../data/prisonApi'
-import { unauthorisedUser } from '../data/testData/users'
+import { mockUnauthorisedUser } from '../data/testData/users'
 import { appWithAllRoutes } from './testutils/appSetup'
 
 jest.mock('../data/prisonApi')
@@ -29,7 +29,7 @@ describe('GET /', () => {
   })
 
   it('should log user out if they do not have appropriate role', () => {
-    return request(appWithAllRoutes({ userSupplier: () => unauthorisedUser }))
+    return request(appWithAllRoutes({ userSupplier: () => mockUnauthorisedUser }))
       .get('/')
       .expect(302)
       .expect(res => {

--- a/server/routes/reports/details/addDescription.test.ts
+++ b/server/routes/reports/details/addDescription.test.ts
@@ -13,7 +13,7 @@ import { convertReportWithDetailsDates } from '../../../data/incidentReportingAp
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
 import { mockSharedUser } from '../../../data/testData/manageUsers'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../data/testData/users'
+import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
 import UserService from '../../../services/userService'
 import type { Status } from '../../../reportConfiguration/constants'
 
@@ -200,10 +200,10 @@ describe('Adding a description addendum to report', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request
         .agent(appWithAllRoutes({ services: { userService }, userSupplier: () => user }))

--- a/server/routes/reports/details/changeType.test.ts
+++ b/server/routes/reports/details/changeType.test.ts
@@ -5,7 +5,7 @@ import { IncidentReportingApi, type ReportBasic, ReportWithDetails } from '../..
 import { convertBasicReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../data/testData/users'
+import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
 import { types } from '../../../reportConfiguration/constants'
 import { now } from '../../../testutils/fakeClock'
 
@@ -174,10 +174,10 @@ describe('Changing incident type', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request
         .agent(appWithAllRoutes({ userSupplier: () => user }))

--- a/server/routes/reports/details/createReport.test.ts
+++ b/server/routes/reports/details/createReport.test.ts
@@ -8,7 +8,7 @@ import { IncidentReportingApi } from '../../../data/incidentReportingApi'
 import { convertReportWithDetailsDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../data/testData/users'
+import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
 
 jest.mock('../../../data/incidentReportingApi')
 
@@ -345,10 +345,10 @@ describe('Creating a report', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
         .get('/create-report')
@@ -362,8 +362,8 @@ describe('Creating a report', () => {
     })
 
     it.each([
-      { userType: 'reporting officer', user: reportingUser },
-      { userType: 'data warden', user: approverUser },
+      { userType: 'reporting officer', user: mockReportingOfficer },
+      { userType: 'data warden', user: mockDataWarden },
     ])('should be denied to $userType if active caseload is not an active prison', ({ user }) => {
       config.activePrisons = ['LEI']
 

--- a/server/routes/reports/details/updateIncidentDateAndTime.test.ts
+++ b/server/routes/reports/details/updateIncidentDateAndTime.test.ts
@@ -7,7 +7,7 @@ import { IncidentReportingApi } from '../../../data/incidentReportingApi'
 import { convertBasicReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../data/testData/users'
+import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
 import type { Status } from '../../../reportConfiguration/constants'
 
 jest.mock('../../../data/incidentReportingApi')
@@ -271,10 +271,10 @@ describe('Updating report incident date and time', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request
         .agent(appWithAllRoutes({ userSupplier: () => user }))

--- a/server/routes/reports/details/updateReportDetails.test.ts
+++ b/server/routes/reports/details/updateReportDetails.test.ts
@@ -7,7 +7,7 @@ import { IncidentReportingApi } from '../../../data/incidentReportingApi'
 import { convertBasicReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../data/testData/users'
+import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
 import type { Status } from '../../../reportConfiguration/constants'
 
 jest.mock('../../../data/incidentReportingApi')
@@ -275,10 +275,10 @@ describe('Updating report details', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request
         .agent(appWithAllRoutes({ userSupplier: () => user }))

--- a/server/routes/reports/history/status.test.ts
+++ b/server/routes/reports/history/status.test.ts
@@ -6,7 +6,7 @@ import { convertReportWithDetailsDates } from '../../../data/incidentReportingAp
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockSharedUser, mockUser } from '../../../data/testData/manageUsers'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
-import { reportingUser, approverUser, hqUser, unauthorisedUser } from '../../../data/testData/users'
+import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
 import UserService from '../../../services/userService'
 import { appWithAllRoutes } from '../../testutils/appSetup'
 import { now } from '../../../testutils/fakeClock'
@@ -122,10 +122,10 @@ describe('Report status history', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: granted },
-      { userType: 'HQ view-only user', user: hqUser, action: granted },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: granted },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: granted },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ services: { userService }, userSupplier: () => user }))
         .get(statusHistoryUrl)

--- a/server/routes/reports/history/type.test.ts
+++ b/server/routes/reports/history/type.test.ts
@@ -6,7 +6,7 @@ import { convertReportWithDetailsDates } from '../../../data/incidentReportingAp
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockSharedUser, mockUser } from '../../../data/testData/manageUsers'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
-import { reportingUser, approverUser, hqUser, unauthorisedUser } from '../../../data/testData/users'
+import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
 import UserService from '../../../services/userService'
 import { appWithAllRoutes } from '../../testutils/appSetup'
 import { now } from '../../../testutils/fakeClock'
@@ -161,10 +161,10 @@ describe('Report incident type history', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: granted },
-      { userType: 'HQ view-only user', user: hqUser, action: granted },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: granted },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: granted },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ services: { userService }, userSupplier: () => user }))
         .get(typeHistoryUrl)

--- a/server/routes/reports/prisoners/involvement/add.test.ts
+++ b/server/routes/reports/prisoners/involvement/add.test.ts
@@ -14,7 +14,12 @@ import { OffenderSearchApi } from '../../../../data/offenderSearchApi'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { andrew, barry } from '../../../../data/testData/offenderSearch'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../testutils/appSetup'
 import { now } from '../../../../testutils/fakeClock'
 import type { Values } from './fields'
@@ -442,10 +447,10 @@ describe('Adding a new prisoner to a report', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
         .get(addPageUrl(andrew.prisonerNumber))

--- a/server/routes/reports/prisoners/involvement/edit.test.ts
+++ b/server/routes/reports/prisoners/involvement/edit.test.ts
@@ -13,7 +13,12 @@ import { convertReportWithDetailsDates } from '../../../../data/incidentReportin
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { andrew, barry } from '../../../../data/testData/offenderSearch'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../testutils/appSetup'
 import { now } from '../../../../testutils/fakeClock'
 import type { Values } from './fields'
@@ -442,10 +447,10 @@ describe('Editing an existing prisoner in a report', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
         .get(editPageUrl(1))

--- a/server/routes/reports/prisoners/remove/index.test.ts
+++ b/server/routes/reports/prisoners/remove/index.test.ts
@@ -13,7 +13,12 @@ import { convertReportWithDetailsDates } from '../../../../data/incidentReportin
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { andrew } from '../../../../data/testData/offenderSearch'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../testutils/appSetup'
 import { now } from '../../../../testutils/fakeClock'
 
@@ -232,10 +237,10 @@ describe('Remove prisoner involvement', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
         .get(removePrisonerUrl(1))

--- a/server/routes/reports/prisoners/search/index.test.ts
+++ b/server/routes/reports/prisoners/search/index.test.ts
@@ -7,7 +7,12 @@ import { OffenderSearchApi, type OffenderSearchResults } from '../../../../data/
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { andrew, barry, chris, donald, ernie, fred } from '../../../../data/testData/offenderSearch'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../testutils/appSetup'
 import { now } from '../../../../testutils/fakeClock'
 import type { Values } from './fields'
@@ -417,10 +422,10 @@ describe('Searching for a prisoner to add to a report', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
         .get(searchPageUrl())

--- a/server/routes/reports/prisoners/summary/index.test.ts
+++ b/server/routes/reports/prisoners/summary/index.test.ts
@@ -5,7 +5,12 @@ import { IncidentReportingApi, ReportWithDetails } from '../../../../data/incide
 import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../testutils/appSetup'
 import { now } from '../../../../testutils/fakeClock'
 
@@ -367,10 +372,10 @@ describe('Prisoner involvement summary for report', () => {
       { scenario: 'normally', createJourney: false },
     ])('$scenario', ({ createJourney }) => {
       it.each([
-        { userType: 'reporting officer', user: reportingUser, action: granted },
-        { userType: 'data warden', user: approverUser, action: denied },
-        { userType: 'HQ view-only user', user: hqUser, action: denied },
-        { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+        { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+        { userType: 'data warden', user: mockDataWarden, action: denied },
+        { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+        { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
       ])('should be $action to $userType', ({ user, action }) => {
         const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
           .get(summaryUrl(createJourney))

--- a/server/routes/reports/questions/index.test.ts
+++ b/server/routes/reports/questions/index.test.ts
@@ -14,7 +14,7 @@ import { convertReportWithDetailsDates } from '../../../data/incidentReportingAp
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { makeSimpleQuestion } from '../../../data/testData/incidentReportingJest'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../data/testData/users'
+import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
 import { ASSAULT_5 } from '../../../reportConfiguration/types/ASSAULT_5'
 import { ATTEMPTED_ESCAPE_FROM_PRISON_1 } from '../../../reportConfiguration/types/ATTEMPTED_ESCAPE_FROM_PRISON_1'
 import { DEATH_OTHER_1 } from '../../../reportConfiguration/types/DEATH_OTHER_1'
@@ -981,10 +981,10 @@ describe('Question editing permissions', () => {
     { scenario: 'normally', createJourney: false },
   ])('$scenario', ({ createJourney }) => {
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request
         .agent(appWithAllRoutes({ userSupplier: () => user }))

--- a/server/routes/reports/staff/involvement/add.test.ts
+++ b/server/routes/reports/staff/involvement/add.test.ts
@@ -14,7 +14,12 @@ import ManageUsersApiClient from '../../../../data/manageUsersApiClient'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockPrisonUser } from '../../../../data/testData/manageUsers'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../testutils/appSetup'
 import { now } from '../../../../testutils/fakeClock'
 import type { Values } from './fields'
@@ -251,10 +256,10 @@ describe('Adding a new staff member to a report', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
         .get(addPageUrl(mockPrisonUser.username))

--- a/server/routes/reports/staff/involvement/edit.test.ts
+++ b/server/routes/reports/staff/involvement/edit.test.ts
@@ -12,7 +12,12 @@ import {
 import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../testutils/appSetup'
 import { now } from '../../../../testutils/fakeClock'
 import type { Values } from './fields'
@@ -248,10 +253,10 @@ describe('Editing an existing staff member in a report', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
         .get(editPageUrl(1))

--- a/server/routes/reports/staff/involvement/manual/add.test.ts
+++ b/server/routes/reports/staff/involvement/manual/add.test.ts
@@ -12,7 +12,12 @@ import { convertReportWithDetailsDates } from '../../../../../data/incidentRepor
 import ManageUsersApiClient from '../../../../../data/manageUsersApiClient'
 import { mockErrorResponse, mockReport } from '../../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../../testutils/appSetup'
 import { now } from '../../../../../testutils/fakeClock'
 import type { Values } from './fields'
@@ -275,10 +280,10 @@ describe('Adding a new staff member to a report who does not have a DPS/NOMIS ac
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(report)
 

--- a/server/routes/reports/staff/remove/index.test.ts
+++ b/server/routes/reports/staff/remove/index.test.ts
@@ -12,7 +12,12 @@ import {
 import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../testutils/appSetup'
 import { now } from '../../../../testutils/fakeClock'
 
@@ -230,10 +235,10 @@ describe('Remove staff involvement', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
         .get(removeStaffUrl(1))

--- a/server/routes/reports/staff/search/index.test.ts
+++ b/server/routes/reports/staff/search/index.test.ts
@@ -8,7 +8,12 @@ import { mockErrorResponse, mockReport } from '../../../../data/testData/inciden
 import { mockPrisonUserSearchResult } from '../../../../data/testData/manageUsers'
 import { leeds, moorland } from '../../../../data/testData/prisonApi'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../testutils/appSetup'
 import { now } from '../../../../testutils/fakeClock'
 import type { Values } from './fields'
@@ -357,10 +362,10 @@ describe('Searching for a member of staff to add to a report', () => {
     const granted = 'granted' as const
     const denied = 'denied' as const
     it.each([
-      { userType: 'reporting officer', user: reportingUser, action: granted },
-      { userType: 'data warden', user: approverUser, action: denied },
-      { userType: 'HQ view-only user', user: hqUser, action: denied },
-      { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+      { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+      { userType: 'data warden', user: mockDataWarden, action: denied },
+      { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
     ])('should be $action to $userType', ({ user, action }) => {
       const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
         .get(searchPageUrl())

--- a/server/routes/reports/staff/summary/index.test.ts
+++ b/server/routes/reports/staff/summary/index.test.ts
@@ -5,7 +5,12 @@ import { IncidentReportingApi, ReportWithDetails } from '../../../../data/incide
 import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
-import { approverUser, hqUser, reportingUser, unauthorisedUser } from '../../../../data/testData/users'
+import {
+  mockDataWarden,
+  mockReportingOfficer,
+  mockHqViewer,
+  mockUnauthorisedUser,
+} from '../../../../data/testData/users'
 import { appWithAllRoutes } from '../../../testutils/appSetup'
 import { now } from '../../../../testutils/fakeClock'
 
@@ -322,10 +327,10 @@ describe('Staff involvement summary for report', () => {
       { scenario: 'normally', createJourney: false },
     ])('$scenario', ({ createJourney }) => {
       it.each([
-        { userType: 'reporting officer', user: reportingUser, action: granted },
-        { userType: 'data warden', user: approverUser, action: denied },
-        { userType: 'HQ view-only user', user: hqUser, action: denied },
-        { userType: 'unauthorised user', user: unauthorisedUser, action: denied },
+        { userType: 'reporting officer', user: mockReportingOfficer, action: granted },
+        { userType: 'data warden', user: mockDataWarden, action: denied },
+        { userType: 'HQ view-only user', user: mockHqViewer, action: denied },
+        { userType: 'unauthorised user', user: mockUnauthorisedUser, action: denied },
       ])('should be $action to $userType', ({ user, action }) => {
         const testRequest = request(appWithAllRoutes({ userSupplier: () => user }))
           .get(summaryUrl(createJourney))

--- a/server/routes/reports/viewReport.test.ts
+++ b/server/routes/reports/viewReport.test.ts
@@ -14,7 +14,7 @@ import { makeSimpleQuestion } from '../../data/testData/incidentReportingJest'
 import { mockSharedUser } from '../../data/testData/manageUsers'
 import { leeds, moorland } from '../../data/testData/prisonApi'
 import { mockThrownError } from '../../data/testData/thrownErrors'
-import { reportingUser, approverUser, hqUser, unauthorisedUser } from '../../data/testData/users'
+import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../data/testData/users'
 
 jest.mock('../../data/prisonApi')
 jest.mock('../../data/incidentReportingApi')
@@ -850,10 +850,10 @@ describe('View report page', () => {
     })
 
     describe.each([
-      { userType: 'reporting officer', user: reportingUser, canView: true, canEdit: true, canSubmit: true },
-      { userType: 'data warden', user: approverUser, canView: true, canEdit: false, canSubmit: false },
-      { userType: 'HQ view-only user', user: hqUser, canView: true, canEdit: false, canSubmit: false },
-      { userType: 'unauthorised user', user: unauthorisedUser, canView: false, canEdit: false, canSubmit: false },
+      { userType: 'reporting officer', user: mockReportingOfficer, canView: true, canEdit: true, canSubmit: true },
+      { userType: 'data warden', user: mockDataWarden, canView: true, canEdit: false, canSubmit: false },
+      { userType: 'HQ view-only user', user: mockHqViewer, canView: true, canEdit: false, canSubmit: false },
+      { userType: 'unauthorised user', user: mockUnauthorisedUser, canView: false, canEdit: false, canSubmit: false },
     ])('for $userType', ({ user, canView, canEdit, canSubmit }) => {
       it(`should ${canView ? 'grant' : 'deny'} viewing a report`, () => {
         const testRequest = request(appWithAllRoutes({ services: { userService }, userSupplier: () => user }))

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -10,7 +10,7 @@ import nunjucksSetup from '../../utils/nunjucksSetup'
 import type { ApplicationInfo } from '../../applicationInfo'
 import errorHandler from '../../errorHandler'
 import type { Services } from '../../services'
-import { reportingUser } from '../../data/testData/users'
+import { mockReportingOfficer } from '../../data/testData/users'
 import { Permissions } from '../../middleware/permissions'
 import setApis from '../../middleware/setApis'
 
@@ -64,7 +64,7 @@ function appSetup(services: Services, production: boolean, userSupplier: () => E
 export function appWithAllRoutes({
   production = false,
   services = { applicationInfo: testAppInfo },
-  userSupplier = () => reportingUser,
+  userSupplier = () => mockReportingOfficer,
 }: {
   production?: boolean
   services?: Partial<Services>


### PR DESCRIPTION
This abstraction makes it easier to reason about the logic of each permission check and to compare against designs and requirements.

Previously, several checks required the presence of `roleReadWrite` _and the absence_ of `roleApproveReject`. That’s because `roleReadWrite` flagged a reporting officer and `roleApproveReject` flagged a data warden… but a user cannot be both!

Now this is just `isReportingOfficer` because the most powerful role determines the user type and all allowable actions stem from there.

---

Also, mock user variables have been renamed to follow these user type groupings.