### PR TITLE
Added response code to api calls for question responses

### DIFF
--- a/integration_tests/e2e/createCompletedReport.cy.ts
+++ b/integration_tests/e2e/createCompletedReport.cy.ts
@@ -412,13 +412,19 @@ context('Creating a completed draft report', () => {
 })
 
 /** Question as returned by API */
-const apiQuestionResponse = (code: string, question: string, response: string): DatesAsStrings<Question> => ({
+const apiQuestionResponse = (
+  code: string,
+  question: string,
+  response: string,
+  responseCode: string,
+): DatesAsStrings<Question> => ({
   code,
   question,
   additionalInformation: null,
   responses: [
     {
       response,
+      code: responseCode,
       responseDate: null,
       additionalInformation: null,
       recordedBy: 'user1',
@@ -441,31 +447,40 @@ const putQuestionRequest = (question: DatesAsStrings<Question>): unknown => ({
 })
 
 const questionsPage1 = [
-  apiQuestionResponse('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', 'NO'),
-  apiQuestionResponse('44919', 'THE INCIDENT IS SUBJECT TO', 'INVESTIGATION INTERNALLY'),
-  apiQuestionResponse('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'NO'),
-  apiQuestionResponse('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO'),
-  apiQuestionResponse('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'NO'),
+  apiQuestionResponse('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', 'NO', '181153'),
+  apiQuestionResponse('44919', 'THE INCIDENT IS SUBJECT TO', 'INVESTIGATION INTERNALLY', '181649'),
+  apiQuestionResponse('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'NO', '182083'),
+  apiQuestionResponse('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO', '180711'),
+  apiQuestionResponse('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'NO', '181103'),
 ]
 const questionsPage2 = [
-  apiQuestionResponse('44594', 'WHERE WAS THE PRISONER PRIOR TO THE START OF THE ATTEMPTED ESCAPE', 'RECEPTION'),
+  apiQuestionResponse(
+    '44594',
+    'WHERE WAS THE PRISONER PRIOR TO THE START OF THE ATTEMPTED ESCAPE',
+    'RECEPTION',
+    '180586',
+  ),
 ]
-const questionsPage3 = [apiQuestionResponse('44545', 'DID PRISONER GAIN ACCESS TO THE EXTERNAL PERIMETER', 'NO')]
+const questionsPage3 = [
+  apiQuestionResponse('44545', 'DID PRISONER GAIN ACCESS TO THE EXTERNAL PERIMETER', 'NO', '180421'),
+]
 const questionsPage4 = [
-  apiQuestionResponse('44441', 'DID THE PRISONER ATTEMPT TO GAIN ACCESS TO THE EXTERNAL PERIMETER', 'NO'),
+  apiQuestionResponse('44441', 'DID THE PRISONER ATTEMPT TO GAIN ACCESS TO THE EXTERNAL PERIMETER', 'NO', '179954'),
 ]
 const questionsPage5 = [
-  apiQuestionResponse('44746', 'ARE THE GROUNDS PATROLLED BY DOGS', 'NO'),
-  apiQuestionResponse('44595', 'WAS AN AIRCRAFT INVOLVED', 'NO'),
+  apiQuestionResponse('44746', 'ARE THE GROUNDS PATROLLED BY DOGS', 'NO', '181096'),
+  apiQuestionResponse('44595', 'WAS AN AIRCRAFT INVOLVED', 'NO', '180592'),
 ]
-const questionsPage6 = [apiQuestionResponse('44983', 'WAS OUTSIDE ASSISTANCE INVOLVED IN THE ATTEMPTED ESCAPE', 'NO')]
-const questionsPage7 = [apiQuestionResponse('44320', 'WERE ANY WEAPONS USED', 'NO')]
-const questionsPage8 = [apiQuestionResponse('44731', 'WERE ANY INJURIES RECEIVED DURING THIS INCIDENT', 'NO')]
+const questionsPage6 = [
+  apiQuestionResponse('44983', 'WAS OUTSIDE ASSISTANCE INVOLVED IN THE ATTEMPTED ESCAPE', 'NO', '181911'),
+]
+const questionsPage7 = [apiQuestionResponse('44320', 'WERE ANY WEAPONS USED', 'NO', '179561')]
+const questionsPage8 = [apiQuestionResponse('44731', 'WERE ANY INJURIES RECEIVED DURING THIS INCIDENT', 'NO', '181059')]
 const questionsPage9 = [
-  apiQuestionResponse('45073', 'HOW WAS THE ESCAPE ATTEMPT DISCOVERED', 'STAFF VIGILANCE'),
-  apiQuestionResponse('44349', 'HOW WAS THE ESCAPE ATTEMPT FOILED', 'STAFF INTERVENTION'),
-  apiQuestionResponse('44447', 'WAS DAMAGE CAUSED TO PRISON PROPERTY', 'NO'),
+  apiQuestionResponse('45073', 'HOW WAS THE ESCAPE ATTEMPT DISCOVERED', 'STAFF VIGILANCE', '182267'),
+  apiQuestionResponse('44349', 'HOW WAS THE ESCAPE ATTEMPT FOILED', 'STAFF INTERVENTION', '179676'),
+  apiQuestionResponse('44447', 'WAS DAMAGE CAUSED TO PRISON PROPERTY', 'NO', '179978'),
 ]
 const questionsPage10 = [
-  apiQuestionResponse('44863', 'WAS THE TELEPHONE/IT SYSTEM SHUT DOWN DURING THE INCIDENT?', 'NO'),
+  apiQuestionResponse('44863', 'WAS THE TELEPHONE/IT SYSTEM SHUT DOWN DURING THE INCIDENT?', 'NO', '181444'),
 ]

--- a/integration_tests/e2e/respondToQuestions.cy.ts
+++ b/integration_tests/e2e/respondToQuestions.cy.ts
@@ -32,6 +32,7 @@ context('Responding to questions', () => {
         responses: [
           {
             response: 'NO',
+            code: '181153',
             responseDate: null,
             additionalInformation: null,
             recordedBy: 'user1',
@@ -46,6 +47,7 @@ context('Responding to questions', () => {
         responses: [
           {
             response: 'INVESTIGATION BY POLICE',
+            code: '181648',
             responseDate: null,
             additionalInformation: null,
             recordedBy: 'user1',
@@ -53,6 +55,7 @@ context('Responding to questions', () => {
           },
           {
             response: 'INVESTIGATION INTERNALLY',
+            code: '181649',
             responseDate: null,
             additionalInformation: null,
             recordedBy: 'user1',
@@ -67,6 +70,7 @@ context('Responding to questions', () => {
         responses: [
           {
             response: 'NO',
+            code: '182083',
             responseDate: null,
             additionalInformation: null,
             recordedBy: 'user1',
@@ -81,6 +85,7 @@ context('Responding to questions', () => {
         responses: [
           {
             response: 'NO',
+            code: '180711',
             responseDate: null,
             additionalInformation: null,
             recordedBy: 'user1',
@@ -95,6 +100,7 @@ context('Responding to questions', () => {
         responses: [
           {
             response: 'YES',
+            code: '181104',
             responseDate: '2025-03-19',
             additionalInformation: null,
             recordedBy: 'user1',
@@ -189,6 +195,7 @@ context('Responding to questions', () => {
             responses: [
               {
                 response: 'NO',
+                code: '181153',
                 responseDate: null,
                 additionalInformation: null,
               },
@@ -201,11 +208,13 @@ context('Responding to questions', () => {
             responses: [
               {
                 response: 'INVESTIGATION BY POLICE',
+                code: '181648',
                 responseDate: null,
                 additionalInformation: null,
               },
               {
                 response: 'INVESTIGATION INTERNALLY',
+                code: '181649',
                 responseDate: null,
                 additionalInformation: null,
               },
@@ -218,6 +227,7 @@ context('Responding to questions', () => {
             responses: [
               {
                 response: 'NO',
+                code: '182083',
                 responseDate: null,
                 additionalInformation: null,
               },
@@ -230,6 +240,7 @@ context('Responding to questions', () => {
             responses: [
               {
                 response: 'NO',
+                code: '180711',
                 responseDate: null,
                 additionalInformation: null,
               },
@@ -242,6 +253,7 @@ context('Responding to questions', () => {
             responses: [
               {
                 response: 'YES',
+                code: '181104',
                 responseDate: '2025-03-19',
                 additionalInformation: null,
               },
@@ -374,6 +386,7 @@ context('Responding to questions', () => {
             responses: [
               {
                 response: 'NO',
+                code: '181153',
                 responseDate: null,
                 additionalInformation: null,
               },
@@ -386,11 +399,13 @@ context('Responding to questions', () => {
             responses: [
               {
                 response: 'INVESTIGATION INTERNALLY',
+                code: '181649',
                 responseDate: null,
                 additionalInformation: null,
               },
               {
                 response: 'NO INVESTIGATION',
+                code: '181650',
                 responseDate: null,
                 additionalInformation: null,
               },
@@ -403,6 +418,7 @@ context('Responding to questions', () => {
             responses: [
               {
                 response: 'NO',
+                code: '182083',
                 responseDate: null,
                 additionalInformation: null,
               },
@@ -415,6 +431,7 @@ context('Responding to questions', () => {
             responses: [
               {
                 response: 'NO',
+                code: '180711',
                 responseDate: null,
                 additionalInformation: null,
               },
@@ -427,6 +444,7 @@ context('Responding to questions', () => {
             responses: [
               {
                 response: 'YES',
+                code: '181104',
                 responseDate: '2025-03-19',
                 additionalInformation: null,
               },

--- a/integration_tests/e2e/viewReport.cy.ts
+++ b/integration_tests/e2e/viewReport.cy.ts
@@ -128,6 +128,7 @@ context('View report', () => {
         responses: [
           {
             response: 'INCIDENT AT HEIGHT',
+            code: '214687',
             responseDate: null,
             additionalInformation: null,
             recordedBy: 'USER1',

--- a/server/data/incidentReportingApi.test.ts
+++ b/server/data/incidentReportingApi.test.ts
@@ -250,7 +250,7 @@ describe('Incident reporting API client', () => {
             {
               code: '1',
               question: 'Was the police informed?',
-              responses: [{ response: 'Yes', responseDate: now }],
+              responses: [{ code: '11', response: 'Yes', responseDate: now }],
             },
           ]),
       },
@@ -462,7 +462,7 @@ describe('Incident reporting API client', () => {
             {
               code: '1',
               question: 'Was the police informed?',
-              responses: [{ response: 'Yes', responseDate: now }],
+              responses: [{ code: '11', response: 'Yes', responseDate: now }],
             },
           ]),
         mockResponse: { status: 201, data: [] },
@@ -595,7 +595,7 @@ describe('Incident reporting API client', () => {
             {
               code: '1',
               question: 'Was the police informed?',
-              responses: [{ response: 'Yes', responseDate: now }],
+              responses: [{ code: '11', response: 'Yes', responseDate: now }],
             },
           ]),
       },

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -130,6 +130,7 @@ export type Question = {
 
 export type Response = {
   response: string
+  code: string
   responseDate: Date | null
   additionalInformation: string | null
   recordedBy: string
@@ -201,6 +202,7 @@ export type AddOrUpdateQuestionWithResponsesRequest = {
 
 export type AddOrUpdateQuestionResponseRequest = {
   response: string
+  code: string
   responseDate?: Date
   additionalInformation?: string
 }

--- a/server/data/incidentTypeConfiguration/questionProgress.test.ts
+++ b/server/data/incidentTypeConfiguration/questionProgress.test.ts
@@ -199,6 +199,7 @@ describe('Question progress', () => {
         responses: [
           {
             response: 'A1-1',
+            code: '1-1',
             responseDate: null,
             additionalInformation: null,
             recordedAt: new Date(),
@@ -262,6 +263,7 @@ describe('Question progress', () => {
         responses: [
           {
             response: 'A1-2',
+            code: '1-2',
             responseDate: null,
             additionalInformation: null,
             recordedAt: new Date(),
@@ -328,6 +330,7 @@ describe('Question progress', () => {
         responses: [
           {
             response: 'A1-1',
+            code: '1-1',
             responseDate: null,
             additionalInformation: null,
             recordedAt: new Date(),
@@ -342,6 +345,7 @@ describe('Question progress', () => {
         responses: [
           {
             response: 'A2-2',
+            code: '2-2',
             responseDate: null,
             additionalInformation: null,
             recordedAt: new Date(),
@@ -356,6 +360,7 @@ describe('Question progress', () => {
         responses: [
           {
             response: 'A3-2',
+            code: '3-2',
             responseDate: null,
             additionalInformation: null,
             recordedAt: new Date(),
@@ -370,6 +375,7 @@ describe('Question progress', () => {
         responses: [
           {
             response: 'A4-1',
+            code: '4-1',
             responseDate: null,
             additionalInformation: null,
             recordedAt: new Date(),
@@ -468,6 +474,7 @@ describe('Question progress', () => {
           responses: [
             {
               response: 'A1-10',
+              code: '1-10',
               responseDate: null,
               additionalInformation: null,
               recordedAt: new Date(),
@@ -571,6 +578,7 @@ describe('Question progress', () => {
           [
             {
               response: 'A1',
+              code: '1',
               responseDate: null,
               additionalInformation: null,
               recordedAt: new Date(),
@@ -589,6 +597,7 @@ describe('Question progress', () => {
           [
             {
               response: 'A2',
+              code: '2',
               responseDate: provided ? new Date() : null,
               additionalInformation: null,
               recordedAt: new Date(),
@@ -607,6 +616,7 @@ describe('Question progress', () => {
           [
             {
               response: 'A3',
+              code: '3',
               responseDate: null,
               additionalInformation: provided ? 'COMMENT' : null,
               recordedAt: new Date(),
@@ -627,6 +637,7 @@ describe('Question progress', () => {
           [
             {
               response: 'A4',
+              code: '4',
               responseDate: commentProvided ? new Date() : null,
               additionalInformation: dateProvided ? 'COMMENT' : null,
               recordedAt: new Date(),
@@ -642,6 +653,7 @@ describe('Question progress', () => {
           [
             {
               response: 'A1',
+              code: '1',
               responseDate: new Date(),
               additionalInformation: 'COMMENT',
               recordedAt: new Date(),
@@ -657,6 +669,7 @@ describe('Question progress', () => {
           [
             {
               response: 'A1',
+              code: '1',
               responseDate: null,
               additionalInformation: null,
               recordedAt: new Date(),
@@ -664,6 +677,7 @@ describe('Question progress', () => {
             },
             {
               response: 'A4',
+              code: '4',
               responseDate: new Date(),
               additionalInformation: 'COMMENT',
               recordedAt: new Date(),
@@ -758,6 +772,7 @@ describe('Question progress', () => {
             // complete
             {
               response: 'A1',
+              code: '1',
               responseDate: null,
               additionalInformation: null,
               recordedAt: new Date(),
@@ -766,6 +781,7 @@ describe('Question progress', () => {
             // complete
             {
               response: 'A3',
+              code: '3',
               responseDate: null,
               additionalInformation: 'COMMENT',
               recordedAt: new Date(),
@@ -782,6 +798,7 @@ describe('Question progress', () => {
             // complete
             {
               response: 'A1',
+              code: '1',
               responseDate: null,
               additionalInformation: null,
               recordedAt: new Date(),
@@ -790,6 +807,7 @@ describe('Question progress', () => {
             // incomplete
             {
               response: 'A3',
+              code: '3',
               responseDate: null,
               additionalInformation: null,
               recordedAt: new Date(),
@@ -856,6 +874,7 @@ describe('Question progress', () => {
           responses: [
             {
               response: 'A1',
+              code: '1',
               responseDate: null,
               additionalInformation: null,
               recordedAt: new Date(),

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -97,6 +97,7 @@ export function mockReport({
           additionalInformation: '',
           responses: buildArray(2, responseIndex => ({
             response: `Historic response #${responseIndex + 1}`,
+            code: `${responseIndex + 1}`,
             responseDate: format.isoDate(reportDateAndTime),
             additionalInformation: `Historic comment #${responseIndex + 1}`,
             recordedBy: 'some-user-2',
@@ -211,6 +212,7 @@ export function mockQuestion(
     additionalInformation: `Explanation #${questionIndex + 1}`,
     responses: buildArray(numberOfResponses, responseIndex => ({
       response: `Response #${responseIndex + 1}`,
+      code: `${responseIndex + 1}`,
       responseDate: format.isoDate(responseDate),
       recordedBy: 'some-user',
       recordedAt: format.isoDateTime(responseDate),

--- a/server/data/testData/incidentReportingJest.ts
+++ b/server/data/testData/incidentReportingJest.ts
@@ -7,14 +7,15 @@ but typescript thinks that jest types are needed
 */
 
 // eslint-disable-next-line import/prefer-default-export
-export function makeSimpleQuestion(code: string, question: string, ...responseCodes: string[]): Question {
+export function makeSimpleQuestion(code: string, question: string, ...responses: [string, string][]): Question {
   return {
     code,
     question,
     additionalInformation: null,
-    responses: responseCodes.map(responseCode => {
+    responses: responses.map(([responseCode, responseId]) => {
       const response: Response = {
         response: responseCode,
+        code: responseId,
         responseDate: null,
         additionalInformation: null,
         recordedBy: 'USER1',

--- a/server/routes/reports/history/type.test.ts
+++ b/server/routes/reports/history/type.test.ts
@@ -91,6 +91,7 @@ describe('Report incident type history', () => {
             responses: [
               {
                 response: 'CELL',
+                code: '212870',
                 responseDate: new Date(2023, 11, 4),
                 additionalInformation: 'A-003',
                 recordedBy: 'user1',
@@ -112,6 +113,7 @@ describe('Report incident type history', () => {
             responses: [
               {
                 response: 'YES',
+                code: '179784',
                 responseDate: null,
                 additionalInformation: null,
                 recordedBy: 'user2',

--- a/server/routes/reports/questions/controller.ts
+++ b/server/routes/reports/questions/controller.ts
@@ -268,6 +268,7 @@ export default class QuestionsController extends BaseController<FormWizard.Multi
 
             const response: AddOrUpdateQuestionResponseRequest = {
               response: responseCode,
+              code: answerConfig.id,
               responseDate: null,
               additionalInformation: null,
             }

--- a/server/routes/reports/questions/index.test.ts
+++ b/server/routes/reports/questions/index.test.ts
@@ -101,6 +101,7 @@ describe('Displaying questions and responses', () => {
           responses: [
             {
               response: 'YES',
+              code: '182204',
               responseDate: now,
               additionalInformation: null,
               recordedBy: 'USER1',
@@ -129,10 +130,10 @@ describe('Displaying questions and responses', () => {
         makeSimpleQuestion(
           '67179',
           'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)',
-          'BOSS CHAIR',
-          'DOG SEARCH',
+          ['BOSS CHAIR', '218686'],
+          ['DOG SEARCH', '218688'],
         ),
-        makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', 'NO'),
+        makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', ['NO', '218710']),
       ]
 
       return agent
@@ -150,11 +151,14 @@ describe('Displaying questions and responses', () => {
     it('form is prefilled with report answers, multiple questions answered', () => {
       reportWithDetails.type = 'ASSAULT_5'
       reportWithDetails.questions = [
-        makeSimpleQuestion('61279', 'WHAT WAS THE MAIN MANAGEMENT OUTCOME OF THE INCIDENT', 'POLICE REFERRAL'),
-        makeSimpleQuestion('61280', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'NO'),
-        makeSimpleQuestion('61281', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('61282', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'NO'),
-        makeSimpleQuestion('61283', 'IS THE LOCATION OF THE INCDENT KNOWN', 'YES'),
+        makeSimpleQuestion('61279', 'WHAT WAS THE MAIN MANAGEMENT OUTCOME OF THE INCIDENT', [
+          'POLICE REFERRAL',
+          '213065',
+        ]),
+        makeSimpleQuestion('61280', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', ['NO', '213067']),
+        makeSimpleQuestion('61281', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', ['NO', '213069']),
+        makeSimpleQuestion('61282', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', ['NO', '213071']),
+        makeSimpleQuestion('61283', 'IS THE LOCATION OF THE INCDENT KNOWN', ['YES', '213072']),
       ]
 
       return agent
@@ -197,11 +201,11 @@ describe('Displaying questions and responses', () => {
 
       it('should show question numbers on second page', async () => {
         const questionsResponse: Question[] = [
-          makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', 'NO'),
-          makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', 'INVESTIGATION INTERNALLY'),
-          makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'NO'),
-          makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO'),
-          makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'NO'),
+          makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', ['NO', '181153']),
+          makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', ['INVESTIGATION INTERNALLY', '181649']),
+          makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', ['NO', '182083']),
+          makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', ['NO', '180711']),
+          makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', ['NO', '181103']),
         ]
         reportWithDetails.type = 'ATTEMPTED_ESCAPE_FROM_PRISON_1'
         reportWithDetails.questions = questionsResponse
@@ -260,6 +264,7 @@ describe('Displaying questions and responses', () => {
             responses: [
               {
                 response: 'CELL SEARCH',
+                code: '218687',
                 responseDate: null,
                 additionalInformation: null,
                 recordedBy: 'USER_1',
@@ -316,7 +321,12 @@ describe('Displaying questions and responses', () => {
         ({ someResponses }) => {
           reportWithDetails.type = 'FIND_6'
           reportWithDetails.questions = someResponses
-            ? [makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', 'CELL SEARCH')]
+            ? [
+                makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', [
+                  'CELL SEARCH',
+                  '218687',
+                ]),
+              ]
             : []
           return agent
             .get(reportQuestionsUrl(createJourney))
@@ -333,8 +343,11 @@ describe('Displaying questions and responses', () => {
         answeredQuestionId => {
           reportWithDetails.type = 'FIND_6'
           reportWithDetails.questions = [
-            makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', 'CELL SEARCH'),
-            makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', 'NO'),
+            makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', [
+              'CELL SEARCH',
+              '218687',
+            ]),
+            makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', ['NO', '218710']),
           ]
           return agent
             .get(`${reportQuestionsUrl(createJourney)}/${answeredQuestionId}`)
@@ -349,8 +362,11 @@ describe('Displaying questions and responses', () => {
       it('should allow skipping directly to the next page after existing responses', () => {
         reportWithDetails.type = 'FIND_6'
         reportWithDetails.questions = [
-          makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', 'CELL SEARCH'),
-          makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', 'NO'),
+          makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', [
+            'CELL SEARCH',
+            '218687',
+          ]),
+          makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', ['NO', '218710']),
         ]
         return agent
           .get(`${reportQuestionsUrl(createJourney)}/67182`)
@@ -364,8 +380,11 @@ describe('Displaying questions and responses', () => {
       it('should redirect to first page of questions if one tries to skip ahead', () => {
         reportWithDetails.type = 'FIND_6'
         reportWithDetails.questions = [
-          makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', 'CELL SEARCH'),
-          makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', 'NO'),
+          makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', [
+            'CELL SEARCH',
+            '218687',
+          ]),
+          makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', ['NO', '218710']),
         ]
         return agent
           .get(`${reportQuestionsUrl(createJourney)}/67184`)
@@ -474,11 +493,11 @@ describe('Submitting questions’ responses', () => {
 
     it('submitting with missing comment shows errors', () => {
       const questionsResponse: Question[] = [
-        makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', 'NO'),
-        makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', 'INVESTIGATION INTERNALLY'),
-        makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'NO'),
-        makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'NO'),
+        makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', ['NO', '181153']),
+        makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', ['INVESTIGATION INTERNALLY', '181649']),
+        makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', ['NO', '182083']),
+        makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', ['NO', '180711']),
+        makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', ['NO', '181103']),
       ]
       reportWithDetails.type = 'ATTEMPTED_ESCAPE_FROM_PRISON_1'
       reportWithDetails.questions = questionsResponse
@@ -558,6 +577,7 @@ describe('Submitting questions’ responses', () => {
           responses: [
             {
               response: 'YES',
+              code: '182204',
               responseDate: parseDateInput(responseDate),
               additionalInformation: null,
             },
@@ -573,6 +593,7 @@ describe('Submitting questions’ responses', () => {
           responses: [
             {
               response: 'YES',
+              code: '182204',
               responseDate: parseDateInput(responseDate),
               recordedAt: new Date(),
               recordedBy: 'USER_1',
@@ -617,11 +638,13 @@ describe('Submitting questions’ responses', () => {
           responses: [
             {
               response: 'BOSS CHAIR',
+              code: '218686',
               responseDate: null,
               additionalInformation: null,
             },
             {
               response: 'DOG SEARCH',
+              code: '218688',
               responseDate: null,
               additionalInformation: null,
             },
@@ -633,8 +656,8 @@ describe('Submitting questions’ responses', () => {
         makeSimpleQuestion(
           '67179',
           'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)',
-          'BOSS CHAIR',
-          'DOG SEARCH',
+          ['BOSS CHAIR', '218686'],
+          ['DOG SEARCH', '218688'],
         ),
       ]
       incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(reportWithDetails)
@@ -681,6 +704,7 @@ describe('Submitting questions’ responses', () => {
           responses: [
             {
               response: 'POLICE REFERRAL',
+              code: '213065',
               responseDate: null,
               additionalInformation: null,
             },
@@ -693,6 +717,7 @@ describe('Submitting questions’ responses', () => {
           responses: [
             {
               response: 'YES',
+              code: '213066',
               responseDate: null,
               additionalInformation: null,
             },
@@ -705,6 +730,7 @@ describe('Submitting questions’ responses', () => {
           responses: [
             {
               response: 'NO',
+              code: '213069',
               responseDate: null,
               additionalInformation: null,
             },
@@ -717,6 +743,7 @@ describe('Submitting questions’ responses', () => {
           responses: [
             {
               response: 'YES',
+              code: '213070',
               responseDate: null,
               additionalInformation: null,
             },
@@ -729,6 +756,7 @@ describe('Submitting questions’ responses', () => {
           responses: [
             {
               response: 'NO',
+              code: '213073',
               responseDate: null,
               additionalInformation: null,
             },
@@ -737,18 +765,21 @@ describe('Submitting questions’ responses', () => {
       ]
 
       const questionsResponse: Question[] = [
-        makeSimpleQuestion('61279', 'WHAT WAS THE MAIN MANAGEMENT OUTCOME OF THE INCIDENT', 'POLICE REFERRAL'),
-        makeSimpleQuestion('61280', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'YES'),
-        makeSimpleQuestion('61281', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('61282', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'YES'),
+        makeSimpleQuestion('61279', 'WHAT WAS THE MAIN MANAGEMENT OUTCOME OF THE INCIDENT', [
+          'POLICE REFERRAL',
+          '213065',
+        ]),
+        makeSimpleQuestion('61280', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', ['YES', '213066']),
+        makeSimpleQuestion('61281', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', ['NO', '213069']),
+        makeSimpleQuestion('61282', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', ['YES', '213070']),
         // NOTE: Answer changed from 'YES' to 'NO'
-        makeSimpleQuestion('61283', 'IS THE LOCATION OF THE INCDENT KNOWN', 'NO'),
+        makeSimpleQuestion('61283', 'IS THE LOCATION OF THE INCDENT KNOWN', ['NO', '213073']),
         // NOTE: This question will need to be deleted.
         // Answer to previous question changed so branch where this
         // sits is no longer entered now
-        makeSimpleQuestion('61284', 'WHAT WAS THE LOCATION OF THE INCIDENT', 'GYM'),
+        makeSimpleQuestion('61284', 'WHAT WAS THE LOCATION OF THE INCIDENT', ['GYM', '213083']),
         // NOTE: This question asked regardless of branching, will be retained
-        makeSimpleQuestion('61285', 'WAS THIS A SEXUAL ASSAULT', 'NO'),
+        makeSimpleQuestion('61285', 'WAS THIS A SEXUAL ASSAULT', ['NO', '213112']),
       ]
       incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(reportWithDetails)
       incidentReportingApi.addOrUpdateQuestionsWithResponses.mockResolvedValueOnce(questionsResponse)
@@ -774,11 +805,11 @@ describe('Submitting questions’ responses', () => {
 
     it('should allow exiting to report view when saving', () => {
       const questionsResponse: Question[] = [
-        makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', 'NO'),
-        makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', 'INVESTIGATION INTERNALLY'),
-        makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'NO'),
-        makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'NO'),
+        makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', ['NO', '181153']),
+        makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', ['INVESTIGATION INTERNALLY', '181649']),
+        makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', ['NO', '182083']),
+        makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', ['NO', '180711']),
+        makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', ['NO', '181103']),
       ]
       reportWithDetails.type = 'ATTEMPTED_ESCAPE_FROM_PRISON_1'
       reportWithDetails.questions = questionsResponse
@@ -805,27 +836,29 @@ describe('Submitting questions’ responses', () => {
       // simulate last 1-question page being unanswered
       reportWithDetails.type = 'ATTEMPTED_ESCAPE_FROM_PRISON_1'
       const questionsResponse: Question[] = [
-        makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', 'NO'),
-        makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', 'INVESTIGATION INTERNALLY'),
-        makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'NO'),
-        makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'NO'),
-        makeSimpleQuestion(
-          '44594',
-          'WHERE WAS THE PRISONER PRIOR TO THE START OF THE ATTEMPTED ESCAPE',
+        makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', ['NO', '181153']),
+        makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', ['INVESTIGATION INTERNALLY', '181649']),
+        makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', ['NO', '182083']),
+        makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', ['NO', '180711']),
+        makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', ['NO', '181103']),
+        makeSimpleQuestion('44594', 'WHERE WAS THE PRISONER PRIOR TO THE START OF THE ATTEMPTED ESCAPE', [
           'ADMINISTRATION',
-        ),
-        makeSimpleQuestion('44545', 'DID PRISONER GAIN ACCESS TO THE EXTERNAL PERIMETER', 'NO'),
-        makeSimpleQuestion('44441', 'DID THE PRISONER ATTEMPT TO GAIN ACCESS TO THE EXTERNAL PERIMETER', 'NO'),
-        makeSimpleQuestion('44746', 'ARE THE GROUNDS PATROLLED BY DOGS', 'NO'),
-        makeSimpleQuestion('44595', 'WAS AN AIRCRAFT INVOLVED', 'NO'),
-        makeSimpleQuestion('44983', 'WAS OUTSIDE ASSISTANCE INVOLVED IN THE ATTEMPTED ESCAPE', 'NO'),
-        makeSimpleQuestion('44320', 'WERE ANY WEAPONS USED', 'NO'),
-        makeSimpleQuestion('44731', 'WERE ANY INJURIES RECEIVED DURING THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('45073', 'HOW WAS THE ESCAPE ATTEMPT DISCOVERED', 'STAFF VIGILANCE'),
-        makeSimpleQuestion('44349', 'HOW WAS THE ESCAPE ATTEMPT FOILED', 'STAFF INTERVENTION'),
-        makeSimpleQuestion('44447', 'WAS DAMAGE CAUSED TO PRISON PROPERTY', 'NO'),
-        makeSimpleQuestion('44863', 'WAS THE TELEPHONE/IT SYSTEM SHUT DOWN DURING THE INCIDENT?', 'NO'),
+          '180575',
+        ]),
+        makeSimpleQuestion('44545', 'DID PRISONER GAIN ACCESS TO THE EXTERNAL PERIMETER', ['NO', '180421']),
+        makeSimpleQuestion('44441', 'DID THE PRISONER ATTEMPT TO GAIN ACCESS TO THE EXTERNAL PERIMETER', [
+          'NO',
+          '179954',
+        ]),
+        makeSimpleQuestion('44746', 'ARE THE GROUNDS PATROLLED BY DOGS', ['NO', '181096']),
+        makeSimpleQuestion('44595', 'WAS AN AIRCRAFT INVOLVED', ['NO', '180592']),
+        makeSimpleQuestion('44983', 'WAS OUTSIDE ASSISTANCE INVOLVED IN THE ATTEMPTED ESCAPE', ['NO', '181911']),
+        makeSimpleQuestion('44320', 'WERE ANY WEAPONS USED', ['NO', '179561']),
+        makeSimpleQuestion('44731', 'WERE ANY INJURIES RECEIVED DURING THIS INCIDENT', ['NO', '181059']),
+        makeSimpleQuestion('45073', 'HOW WAS THE ESCAPE ATTEMPT DISCOVERED', ['STAFF VIGILANCE', '182267']),
+        makeSimpleQuestion('44349', 'HOW WAS THE ESCAPE ATTEMPT FOILED', ['STAFF INTERVENTION', '179676']),
+        makeSimpleQuestion('44447', 'WAS DAMAGE CAUSED TO PRISON PROPERTY', ['NO', '179978']),
+        makeSimpleQuestion('44863', 'WAS THE TELEPHONE/IT SYSTEM SHUT DOWN DURING THE INCIDENT?', ['NO', '181444']),
       ]
       reportWithDetails.questions = questionsResponse.slice(0, -1)
       incidentReportingApi.addOrUpdateQuestionsWithResponses.mockResolvedValueOnce(questionsResponse)
@@ -851,26 +884,28 @@ describe('Submitting questions’ responses', () => {
       // simulate last 1-question page being unanswered
       reportWithDetails.type = 'ATTEMPTED_ESCAPE_FROM_PRISON_1'
       reportWithDetails.questions = [
-        makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', 'NO'),
-        makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', 'INVESTIGATION INTERNALLY'),
-        makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'NO'),
-        makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'NO'),
-        makeSimpleQuestion(
-          '44594',
-          'WHERE WAS THE PRISONER PRIOR TO THE START OF THE ATTEMPTED ESCAPE',
+        makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', ['NO', '181153']),
+        makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', ['INVESTIGATION INTERNALLY', '181649']),
+        makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', ['NO', '182083']),
+        makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', ['NO', '180711']),
+        makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', ['NO', '181103']),
+        makeSimpleQuestion('44594', 'WHERE WAS THE PRISONER PRIOR TO THE START OF THE ATTEMPTED ESCAPE', [
           'ADMINISTRATION',
-        ),
-        makeSimpleQuestion('44545', 'DID PRISONER GAIN ACCESS TO THE EXTERNAL PERIMETER', 'NO'),
-        makeSimpleQuestion('44441', 'DID THE PRISONER ATTEMPT TO GAIN ACCESS TO THE EXTERNAL PERIMETER', 'NO'),
-        makeSimpleQuestion('44746', 'ARE THE GROUNDS PATROLLED BY DOGS', 'NO'),
-        makeSimpleQuestion('44595', 'WAS AN AIRCRAFT INVOLVED', 'NO'),
-        makeSimpleQuestion('44983', 'WAS OUTSIDE ASSISTANCE INVOLVED IN THE ATTEMPTED ESCAPE', 'NO'),
-        makeSimpleQuestion('44320', 'WERE ANY WEAPONS USED', 'NO'),
-        makeSimpleQuestion('44731', 'WERE ANY INJURIES RECEIVED DURING THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('45073', 'HOW WAS THE ESCAPE ATTEMPT DISCOVERED', 'STAFF VIGILANCE'),
-        makeSimpleQuestion('44349', 'HOW WAS THE ESCAPE ATTEMPT FOILED', 'STAFF INTERVENTION'),
-        makeSimpleQuestion('44447', 'WAS DAMAGE CAUSED TO PRISON PROPERTY', 'NO'),
+          '180575',
+        ]),
+        makeSimpleQuestion('44545', 'DID PRISONER GAIN ACCESS TO THE EXTERNAL PERIMETER', ['NO', '180421']),
+        makeSimpleQuestion('44441', 'DID THE PRISONER ATTEMPT TO GAIN ACCESS TO THE EXTERNAL PERIMETER', [
+          'NO',
+          '179954',
+        ]),
+        makeSimpleQuestion('44746', 'ARE THE GROUNDS PATROLLED BY DOGS', ['NO', '181096']),
+        makeSimpleQuestion('44595', 'WAS AN AIRCRAFT INVOLVED', ['NO', '180592']),
+        makeSimpleQuestion('44983', 'WAS OUTSIDE ASSISTANCE INVOLVED IN THE ATTEMPTED ESCAPE', ['NO', '181911']),
+        makeSimpleQuestion('44320', 'WERE ANY WEAPONS USED', ['NO', '179561']),
+        makeSimpleQuestion('44731', 'WERE ANY INJURIES RECEIVED DURING THIS INCIDENT', ['NO', '181059']),
+        makeSimpleQuestion('45073', 'HOW WAS THE ESCAPE ATTEMPT DISCOVERED', ['STAFF VIGILANCE', '182267']),
+        makeSimpleQuestion('44349', 'HOW WAS THE ESCAPE ATTEMPT FOILED', ['STAFF INTERVENTION', '179676']),
+        makeSimpleQuestion('44447', 'WAS DAMAGE CAUSED TO PRISON PROPERTY', ['NO', '179978']),
       ]
       incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(reportWithDetails)
 
@@ -902,11 +937,11 @@ describe('Submitting questions’ responses', () => {
         '44749': 'NO',
       }
       const questionsResponse: Question[] = [
-        makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', 'NO'),
-        makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', 'INVESTIGATION INTERNALLY'),
-        makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'NO'),
-        makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'NO'),
+        makeSimpleQuestion('44769', 'WERE THE POLICE INFORMED OF THE INCIDENT', ['NO', '181153']),
+        makeSimpleQuestion('44919', 'THE INCIDENT IS SUBJECT TO', ['INVESTIGATION INTERNALLY', '181649']),
+        makeSimpleQuestion('45033', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', ['NO', '182083']),
+        makeSimpleQuestion('44636', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', ['NO', '180711']),
+        makeSimpleQuestion('44749', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', ['NO', '181103']),
       ]
       reportWithDetails.questions = questionsResponse
       incidentReportingApi.addOrUpdateQuestionsWithResponses.mockResolvedValueOnce(questionsResponse)

--- a/server/routes/reports/viewReport.test.ts
+++ b/server/routes/reports/viewReport.test.ts
@@ -60,10 +60,10 @@ describe('View report page', () => {
       makeSimpleQuestion(
         '67179',
         'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)',
-        'CELL SEARCH',
-        'INFORMATION RECEIVED',
+        ['CELL SEARCH', '218687'],
+        ['INFORMATION RECEIVED', '218695'],
       ),
-      makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', 'YES'),
+      makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', ['YES', '218711']),
     ]
     incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(mockedReport)
     viewReportUrl = `/reports/${mockedReport.id}`
@@ -277,14 +277,14 @@ describe('View report page', () => {
       mockedReport.status = 'CLOSED'
       mockedReport.description = 'An old drone sighting'
       mockedReport.questions = [
-        makeSimpleQuestion('57179', 'Was a drone sighted in mid-flight', 'Yes'),
-        makeSimpleQuestion('57180', 'What time was the drone(s) sighted.', '12am to 6am'),
-        makeSimpleQuestion('57181', 'Number of drones observed', '1'),
+        makeSimpleQuestion('57179', 'Was a drone sighted in mid-flight', ['Yes', '208684']),
+        makeSimpleQuestion('57180', 'What time was the drone(s) sighted.', ['12am to 6am', '208686']),
+        makeSimpleQuestion('57181', 'Number of drones observed', ['1', '208690']),
         makeSimpleQuestion(
           '57184',
           'Where was the drone(s) sighted',
-          'Beyond the external perimeter border',
-          'Exercise yard',
+          ['Beyond the external perimeter border', '208696'],
+          ['Exercise yard', '208697'],
         ),
       ]
     })
@@ -529,23 +529,26 @@ describe('View report page', () => {
         }),
       )
       mockedReport.questions = [
-        makeSimpleQuestion('61279', 'WHAT WAS THE MAIN MANAGEMENT OUTCOME OF THE INCIDENT', 'IEP REGRESSION'),
-        makeSimpleQuestion('61280', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', 'NO'),
-        makeSimpleQuestion('61281', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('61282', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', 'NO'),
-        makeSimpleQuestion('61283', 'IS THE LOCATION OF THE INCDENT KNOWN', 'NO'),
-        makeSimpleQuestion('61285', 'WAS THIS A SEXUAL ASSAULT', 'NO'),
-        makeSimpleQuestion('61286', 'DID THE ASSAULT OCCUR DURING A FIGHT', 'NO'),
-        makeSimpleQuestion('61287', 'WHAT TYPE OF ASSAULT WAS IT', 'PRISONER ON STAFF'),
-        makeSimpleQuestion('61289', 'DESCRIBE THE TYPE OF STAFF', 'OPERATIONAL STAFF - OTHER'),
-        makeSimpleQuestion('61290', 'WAS SPITTING USED IN THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('61294', 'WERE ANY WEAPONS USED', 'NO'),
-        makeSimpleQuestion('61296', 'WERE ANY INJURIES RECEIVED DURING THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('61306', 'ARE THERE ANY STAFF NOW OFF DUTY AS A RESULT OF THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('61307', 'ARE ANY STAFF ON SICK LEAVE AS A RESULT OF THIS INCIDENT', 'NO'),
-        makeSimpleQuestion('61308', 'DID THE ASSAULT OCCUR IN PUBLIC VIEW', 'YES'),
-        makeSimpleQuestion('61309', 'IS THERE ANY AUDIO OR VISUAL FOOTAGE OF THE ASSAULT', 'NO'),
-        makeSimpleQuestion('61311', 'WAS THERE AN APPARENT REASON FOR THE ASSAULT', 'NO'),
+        makeSimpleQuestion('61279', 'WHAT WAS THE MAIN MANAGEMENT OUTCOME OF THE INCIDENT', [
+          'IEP REGRESSION',
+          '213063',
+        ]),
+        makeSimpleQuestion('61280', 'IS ANY MEMBER OF STAFF FACING DISCIPLINARY CHARGES', ['NO', '213067']),
+        makeSimpleQuestion('61281', 'IS THERE ANY MEDIA INTEREST IN THIS INCIDENT', ['NO', '213069']),
+        makeSimpleQuestion('61282', 'HAS THE PRISON SERVICE PRESS OFFICE BEEN INFORMED', ['NO', '213071']),
+        makeSimpleQuestion('61283', 'IS THE LOCATION OF THE INCDENT KNOWN', ['NO', '213073']),
+        makeSimpleQuestion('61285', 'WAS THIS A SEXUAL ASSAULT', ['NO', '213112']),
+        makeSimpleQuestion('61286', 'DID THE ASSAULT OCCUR DURING A FIGHT', ['NO', '213114']),
+        makeSimpleQuestion('61287', 'WHAT TYPE OF ASSAULT WAS IT', ['PRISONER ON STAFF', '213116']),
+        makeSimpleQuestion('61289', 'DESCRIBE THE TYPE OF STAFF', ['OPERATIONAL STAFF - OTHER', '213122']),
+        makeSimpleQuestion('61290', 'WAS SPITTING USED IN THIS INCIDENT', ['NO', '213125']),
+        makeSimpleQuestion('61294', 'WERE ANY WEAPONS USED', ['NO', '213136']),
+        makeSimpleQuestion('61296', 'WERE ANY INJURIES RECEIVED DURING THIS INCIDENT', ['NO', '213150']),
+        makeSimpleQuestion('61306', 'ARE THERE ANY STAFF NOW OFF DUTY AS A RESULT OF THIS INCIDENT', ['NO', '213200']),
+        makeSimpleQuestion('61307', 'ARE ANY STAFF ON SICK LEAVE AS A RESULT OF THIS INCIDENT', ['NO', '213202']),
+        makeSimpleQuestion('61308', 'DID THE ASSAULT OCCUR IN PUBLIC VIEW', ['YES', '213203']),
+        makeSimpleQuestion('61309', 'IS THERE ANY AUDIO OR VISUAL FOOTAGE OF THE ASSAULT', ['NO', '213205']),
+        makeSimpleQuestion('61311', 'WAS THERE AN APPARENT REASON FOR THE ASSAULT', ['NO', '213213']),
       ]
       incidentReportingApi.getReportWithDetailsById.mockReset()
       incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(mockedReport)
@@ -699,26 +702,23 @@ describe('View report page', () => {
       beforeEach(() => {
         mockedReport.type = 'FIND_6'
         mockedReport.questions = [
-          makeSimpleQuestion(
-            '67179',
-            'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)',
+          makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', [
             'INFORMATION RECEIVED',
-          ),
-          makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', 'NO'),
-          makeSimpleQuestion('67182', 'DESCRIBE THE METHOD OF ENTRY INTO THE ESTABLISHMENT', 'UNKNOWN'),
-          makeSimpleQuestion('67184', 'IF FOUND IN POSSESSION, WHOSE WAS IT FOUND IN?', 'NOT APPLICABLE'),
-          makeSimpleQuestion('67186', 'WHAT WAS THE METHOD OF CONCEALMENT', 'IN HAND'),
-          makeSimpleQuestion(
-            '67187',
-            'PLEASE SELECT CATEGORY OF FIND',
+            '218695',
+          ]),
+          makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', ['NO', '218710']),
+          makeSimpleQuestion('67182', 'DESCRIBE THE METHOD OF ENTRY INTO THE ESTABLISHMENT', ['UNKNOWN', '218741']),
+          makeSimpleQuestion('67184', 'IF FOUND IN POSSESSION, WHOSE WAS IT FOUND IN?', ['NOT APPLICABLE', '218756']),
+          makeSimpleQuestion('67186', 'WHAT WAS THE METHOD OF CONCEALMENT', ['IN HAND', '218774']),
+          makeSimpleQuestion('67187', 'PLEASE SELECT CATEGORY OF FIND', [
             'OTHER REPORTABLE ITEMS (BY NATIONAL OR LOCAL POLICY)',
-          ),
-          makeSimpleQuestion(
-            '67204',
-            'OTHER REPORTABLE ITEMS FOUND (BY NATIONAL OR LOCAL POLICY)',
+            '218790',
+          ]),
+          makeSimpleQuestion('67204', 'OTHER REPORTABLE ITEMS FOUND (BY NATIONAL OR LOCAL POLICY)', [
             'YES (NOOSE / LIGATURE)',
-          ),
-          makeSimpleQuestion('67226', 'WERE THE ITEMS OBTAINED ON TEMPORARY RELEASE?', 'NO'),
+            '218951',
+          ]),
+          makeSimpleQuestion('67226', 'WERE THE ITEMS OBTAINED ON TEMPORARY RELEASE?', ['NO', '219123']),
         ]
       })
 
@@ -827,22 +827,23 @@ describe('View report page', () => {
       )
       mockedReport.questions = [
         // NB: all questions are complete
-        makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', 'INFORMATION RECEIVED'),
-        makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', 'NO'),
-        makeSimpleQuestion('67182', 'DESCRIBE THE METHOD OF ENTRY INTO THE ESTABLISHMENT', 'UNKNOWN'),
-        makeSimpleQuestion('67184', 'IF FOUND IN POSSESSION, WHOSE WAS IT FOUND IN?', 'NOT APPLICABLE'),
-        makeSimpleQuestion('67186', 'WHAT WAS THE METHOD OF CONCEALMENT', 'IN HAND'),
-        makeSimpleQuestion(
-          '67187',
-          'PLEASE SELECT CATEGORY OF FIND',
+        makeSimpleQuestion('67179', 'DESCRIBE HOW THE ITEM WAS FOUND (SELECT ALL THAT APPLY)', [
+          'INFORMATION RECEIVED',
+          '218695',
+        ]),
+        makeSimpleQuestion('67180', 'IS THE LOCATION OF THE INCIDENT KNOWN?', ['NO', '218710']),
+        makeSimpleQuestion('67182', 'DESCRIBE THE METHOD OF ENTRY INTO THE ESTABLISHMENT', ['UNKNOWN', '218741']),
+        makeSimpleQuestion('67184', 'IF FOUND IN POSSESSION, WHOSE WAS IT FOUND IN?', ['NOT APPLICABLE', '218756']),
+        makeSimpleQuestion('67186', 'WHAT WAS THE METHOD OF CONCEALMENT', ['IN HAND', '218774']),
+        makeSimpleQuestion('67187', 'PLEASE SELECT CATEGORY OF FIND', [
           'OTHER REPORTABLE ITEMS (BY NATIONAL OR LOCAL POLICY)',
-        ),
-        makeSimpleQuestion(
-          '67204',
-          'OTHER REPORTABLE ITEMS FOUND (BY NATIONAL OR LOCAL POLICY)',
+          '218790',
+        ]),
+        makeSimpleQuestion('67204', 'OTHER REPORTABLE ITEMS FOUND (BY NATIONAL OR LOCAL POLICY)', [
           'YES (NOOSE / LIGATURE)',
-        ),
-        makeSimpleQuestion('67226', 'WERE THE ITEMS OBTAINED ON TEMPORARY RELEASE?', 'NO'),
+          '218951',
+        ]),
+        makeSimpleQuestion('67226', 'WERE THE ITEMS OBTAINED ON TEMPORARY RELEASE?', ['NO', '219123']),
       ]
       incidentReportingApi.getReportWithDetailsById.mockReset()
       incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(mockedReport)


### PR DESCRIPTION
Controller handling question responses now parses in response code/ID into the api call. 

Along with this, some types in Incident reporting API needed to be altered. This had a knock on effect to many tests. 