### PR TITLE
IR-677: Show latest correction requests / comments first

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -30,6 +30,7 @@ import {
 import { isBeingTransferred, isOutside, isInPrison } from '../data/offenderSearchApi'
 import format from './format'
 import { isLocationActiveInService, isPrisonActiveInService } from '../middleware/permissions'
+import { sortCorrectionRequests } from './sortCorrectionRequests'
 
 export default function nunjucksSetup(app: express.Express): void {
   app.set('view engine', 'njk')
@@ -87,6 +88,7 @@ export default function nunjucksSetup(app: express.Express): void {
   })
   njkEnv.addGlobal('now', () => new Date())
   njkEnv.addExtension('panic', new PanicExtension())
+  njkEnv.addFilter('sortCorrectionRequests', sortCorrectionRequests)
 
   // name formatting
   njkEnv.addFilter('convertToTitleCase', convertToTitleCase)

--- a/server/utils/sortCorrectionRequests.test.ts
+++ b/server/utils/sortCorrectionRequests.test.ts
@@ -1,0 +1,61 @@
+import { sortCorrectionRequests } from './sortCorrectionRequests'
+
+describe('Sorting correction requests', () => {
+  it('should work on empty lists', () => {
+    const result = sortCorrectionRequests([])
+    expect(result).toEqual([])
+  })
+
+  it('should sort comments', () => {
+    const result = sortCorrectionRequests([
+      {
+        descriptionOfChange: 'Firstly, change X',
+        correctionRequestedBy: 'lev79n',
+        correctionRequestedAt: new Date(2023, 11, 5, 12, 34, 56),
+      },
+      {
+        descriptionOfChange: 'Secondly, change Y',
+        correctionRequestedBy: 'abc12a',
+        correctionRequestedAt: new Date(2023, 11, 6, 9, 10, 20),
+      },
+      {
+        descriptionOfChange: 'Thirdly, change Z',
+        correctionRequestedBy: 'abc12a',
+        correctionRequestedAt: new Date(2023, 11, 6, 13),
+      },
+    ])
+    expect(result).toEqual([
+      {
+        descriptionOfChange: 'Thirdly, change Z',
+        correctionRequestedBy: 'abc12a',
+        correctionRequestedAt: new Date(2023, 11, 6, 13),
+      },
+      {
+        descriptionOfChange: 'Secondly, change Y',
+        correctionRequestedBy: 'abc12a',
+        correctionRequestedAt: new Date(2023, 11, 6, 9, 10, 20),
+      },
+      {
+        descriptionOfChange: 'Firstly, change X',
+        correctionRequestedBy: 'lev79n',
+        correctionRequestedAt: new Date(2023, 11, 5, 12, 34, 56),
+      },
+    ])
+  })
+
+  it('should preserve the order of comments with the same timestamp', () => {
+    const result = sortCorrectionRequests([
+      {
+        descriptionOfChange: 'Change X',
+        correctionRequestedBy: 'lev79n',
+        correctionRequestedAt: new Date(2023, 11, 5, 12, 34, 56),
+      },
+      {
+        descriptionOfChange: 'Change Y',
+        correctionRequestedBy: 'lev79n',
+        correctionRequestedAt: new Date(2023, 11, 5, 12, 34, 56),
+      },
+    ])
+    expect(result.map(comment => comment.descriptionOfChange)).toEqual(['Change X', 'Change Y'])
+  })
+})

--- a/server/utils/sortCorrectionRequests.ts
+++ b/server/utils/sortCorrectionRequests.ts
@@ -1,0 +1,14 @@
+import type { CorrectionRequest } from '../data/incidentReportingApi'
+
+// eslint-disable-next-line import/prefer-default-export
+export function sortCorrectionRequests(correctionRequests: CorrectionRequest[]): CorrectionRequest[] {
+  return correctionRequests.toSorted((request1, request2) => {
+    if (request1.correctionRequestedAt > request2.correctionRequestedAt) {
+      return -1
+    }
+    if (request1.correctionRequestedAt < request2.correctionRequestedAt) {
+      return 1
+    }
+    return 0
+  })
+}

--- a/server/views/pages/reports/view/_correction-requests.njk
+++ b/server/views/pages/reports/view/_correction-requests.njk
@@ -5,7 +5,7 @@
 {% if report.correctionRequests.length > 0 %}
 
   {% set items = [] %}
-  {% for correctionRequest in report.correctionRequests %}
+  {% for correctionRequest in report.correctionRequests | sortCorrectionRequests %}
     {% set comment %}
       {# TODO: preliminary build: does not support all possible forms of comments #}
       {{ correctionRequest.descriptionOfChange | escape | nl2br }}


### PR DESCRIPTION
Preliminary: we’re not sure what this list will end up looking like, but the designs to be tested now show newest items first