### PR TITLE
IR-68: Add more context to Azure Application Insights logging

### DIFF
--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,6 +1,10 @@
-import { setup, defaultClient, type TelemetryClient, DistributedTracingModes } from 'applicationinsights'
+import { defaultClient, setup, Contracts, DistributedTracingModes, type TelemetryClient } from 'applicationinsights'
+import type { EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
 
 import type { ApplicationInfo } from '../applicationInfo'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ContextObject = Record<string, any>
 
 export function initialiseAppInsights(): void {
   if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
@@ -18,7 +22,40 @@ export function buildAppInsightsClient(
   if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
     defaultClient.context.tags['ai.cloud.role'] = overrideName || applicationName
     defaultClient.context.tags['ai.application.ver'] = buildNumber
+    defaultClient.addTelemetryProcessor(ignorePathsProcessor)
+    defaultClient.addTelemetryProcessor(addUserDataToRequests)
     return defaultClient
   }
   return null
+}
+
+export function addUserDataToRequests(envelope: EnvelopeTelemetry, contextObjects: ContextObject): boolean {
+  const isRequest = envelope.data.baseType === Contracts.TelemetryTypeString.Request
+  if (isRequest) {
+    const { username, activeCaseLoadId } = contextObjects?.['http.ServerRequest']?.res?.locals?.user || {}
+    if (username) {
+      const { properties } = envelope.data.baseData
+      // eslint-disable-next-line no-param-reassign
+      envelope.data.baseData.properties = {
+        username,
+        activeCaseLoadId,
+        ...properties,
+      }
+    }
+  }
+  return true
+}
+
+const prefixesToIgnore = ['GET /info', 'GET /ping', 'GET /health', 'GET /metrics']
+
+export function ignorePathsProcessor(envelope: EnvelopeTelemetry): boolean {
+  const isRequest = envelope.data.baseType === Contracts.TelemetryTypeString.Request
+  if (isRequest) {
+    const requestData = envelope.data.baseData
+    if (requestData instanceof Contracts.RequestData) {
+      const { name } = requestData
+      return !prefixesToIgnore.some(prefix => name.startsWith(prefix))
+    }
+  }
+  return true
 }

--- a/server/utils/azureAppinsights.test.ts
+++ b/server/utils/azureAppinsights.test.ts
@@ -1,0 +1,107 @@
+import { RequestData, type DataTelemetry, type EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
+
+import { addUserDataToRequests, ignorePathsProcessor, type ContextObject } from './azureAppInsights'
+
+const user = {
+  activeCaseLoadId: 'LII',
+  username: 'test-user',
+}
+
+function createEnvelope(name: string, properties: Record<string, string | boolean>, baseType = 'RequestData') {
+  const baseData = new RequestData()
+  baseData.name = name
+  baseData.properties = properties
+  return {
+    data: {
+      baseType,
+      baseData,
+    } as DataTelemetry,
+  } as EnvelopeTelemetry
+}
+
+function createContext(username: string, activeCaseLoadId: string): ContextObject {
+  return {
+    'http.ServerRequest': {
+      res: {
+        locals: {
+          user: {
+            username,
+            activeCaseLoadId,
+          },
+        },
+      },
+    },
+  }
+}
+
+const context = createContext(user.username, user.activeCaseLoadId)
+
+describe('Azure Application Insights', () => {
+  describe('addUserDataToRequests', () => {
+    it('adds user data to properties when present', () => {
+      const envelope = createEnvelope('GET /', { other: 'things' })
+
+      addUserDataToRequests(envelope, context)
+
+      expect(envelope.data.baseData.properties).toStrictEqual({
+        ...user,
+        other: 'things',
+      })
+    })
+
+    it('handles absent user data', () => {
+      const envelope = createEnvelope('GET /', { other: 'things' })
+
+      addUserDataToRequests(envelope, createContext(undefined, user.activeCaseLoadId))
+
+      expect(envelope.data.baseData.properties).toStrictEqual({ other: 'things' })
+    })
+
+    it('returns true when not RequestData type', () => {
+      const envelope = createEnvelope('GET /', {}, 'NOT_REQUEST_DATA')
+
+      const response = addUserDataToRequests(envelope, context)
+
+      expect(response).toBe(true)
+    })
+
+    it('handles when no properties have been set', () => {
+      const envelope = createEnvelope('GET /', undefined)
+
+      addUserDataToRequests(envelope, context)
+
+      expect(envelope.data.baseData.properties).toStrictEqual(user)
+    })
+
+    it('handles missing user details', () => {
+      const envelope = createEnvelope('GET /', { other: 'things' })
+
+      addUserDataToRequests(envelope, {
+        'http.ServerRequest': {},
+      } as ContextObject)
+
+      expect(envelope.data.baseData.properties).toEqual({
+        other: 'things',
+      })
+    })
+  })
+
+  describe('ignorePathsProcessor', () => {
+    it.each(['/metrics', '/info', '/ping', '/health', '/health?service=abc'])(
+      'ignores pre-specified path: %s',
+      path => {
+        const envelope = createEnvelope(`GET ${path}`, {})
+
+        const result = ignorePathsProcessor(envelope)
+        expect(result).toBe(false)
+      },
+    )
+
+    it.each(['/', '/reports'])('allows path: %s', path => {
+      const envelope = createEnvelope(`GET ${path}`, {})
+
+      const result = ignorePathsProcessor(envelope)
+      expect(result).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
…and ignore boring HTTP request paths. Copied from non-associations app.