### PR TITLE
IR-1134: Handle 404 from /agencies-switches

### DIFF
--- a/server/data/prisonApi.test.ts
+++ b/server/data/prisonApi.test.ts
@@ -89,8 +89,23 @@ describe('prisonApi', () => {
         .matchHeader('authorization', `Bearer ${accessToken}`)
         .reply(200, expectedResponse satisfies ActiveAgency[])
 
-      const activeAgenciesMiss = await apiClient.getAgenciesSwitchedOn()
-      expect(activeAgenciesMiss).toEqual(expectedActiveAgencies)
+      const activeAgencies = await apiClient.getAgenciesSwitchedOn()
+      expect(activeAgencies).toEqual(expectedActiveAgencies)
+    })
+
+    it('returns empty list when API responds 404 NOT FOUND', async () => {
+      // Mock API responding 404 NOT FOUND
+      fakeApiClient
+        .get('/api/agency-switches/INCIDENTS')
+        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .reply(404, {
+          status: 404,
+          userMessage: 'Service code INCIDENTS does not exist',
+          developerMessage: 'Service code INCIDENTS does not exist',
+        })
+
+      const activeAgencies = await apiClient.getAgenciesSwitchedOn()
+      expect(activeAgencies).toEqual([])
     })
   })
 

--- a/server/data/prisonApi.ts
+++ b/server/data/prisonApi.ts
@@ -196,13 +196,21 @@ export class PrisonApi extends RestClient {
    */
   async getAgenciesSwitchedOn(): Promise<string[]> {
     const SERVICE_CODE = 'INCIDENTS'
-    const activeAgencies = await this.get<ActiveAgency[]>(
-      {
-        path: `/api/agency-switches/${encodeURIComponent(SERVICE_CODE)}`,
-      },
-      asSystem(),
-    )
-    return activeAgencies.map(activeAgency => activeAgency.agencyId)
+    try {
+      const activeAgencies = await this.get<ActiveAgency[]>(
+        {
+          path: `/api/agency-switches/${encodeURIComponent(SERVICE_CODE)}`,
+        },
+        asSystem(),
+      )
+      return activeAgencies.map(activeAgency => activeAgency.agencyId)
+    } catch (error) {
+      if (error?.responseStatus === 404) {
+        // endpoint returns 404s when no agencies are active
+        return []
+      }
+      throw error
+    }
   }
 
   async getPhoto(prisonerNumber: string): Promise<Buffer | null> {


### PR DESCRIPTION
In productions we are seeing 404 Not Found errors. These are handled ok but the interesting thing is
that this is the way that endpoing behaves when no agencies are active.

This commit handle this scenario more explicitly so that the errors are not concerning anybody and also to document this is the way the endpoint works.