### PR TITLE
Tweaked start/stop schedule

### DIFF
--- a/helm_deploy/hmpps-incident-reporting/values.yaml
+++ b/helm_deploy/hmpps-incident-reporting/values.yaml
@@ -57,7 +57,9 @@ generic-service:
       - private_prisons
 
   scheduledDowntime:
-    timeZone: Europe/London
+    # NOTE: API starts at 6.49am UTC, stops at 21:58pm UTC
+    startup: '00 7 * * 1-5' # Start at 7.00am UTC Monday-Friday
+    shutdown: '50 21 * * 1-5' # Stop at 9.50pm UTC Monday-Friday
 
 generic-prometheus-alerts:
   targetApplication: hmpps-incident-reporting

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -2,6 +2,9 @@ generic-service:
   ingress:
     host: incident-reporting.hmpps.service.justice.gov.uk
 
+  scheduledDowntime:
+    enabled: false
+
   env:
     ENVIRONMENT: prod
 


### PR DESCRIPTION
Currently there is a mismatch between the API's start/stop schedule and the UI start/stop schedule and 'retry-dlq' CronJob schedule (this is specified in UTC time)

This changes the UI schedule so that:
- time is now specified in UTC like in other places and also we don't have to worry about summer time difference
- API will start at 6:49am, UI will start later at 7:00am
- UI will stop before at at 9:50pm, API will stop later at 9:58pm

**NOTE**: _Ideally_ this should be applied around the same time as [this sibling API PR](https://github.com/ministryofjustice/hmpps-incident-reporting-api/pull/361/files).