### PR TITLE
IR-1083: Allow linking to a report by incident number (ie. reference)

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -6,6 +6,7 @@ import type { Services } from '../services'
 import { PrisonApi } from '../data/prisonApi'
 import makeDownloadConfigRouter from './downloadReportConfig'
 import { createReportRouter } from './reports/createReportRouter'
+import { lookupReference } from './reports/lookupReference'
 import { changeTypeRouter } from './reports/details/changeType'
 import { updateDetailsRouter } from './reports/details/updateReportDetails'
 import { updateIncidentDateAndTimeRouter } from './reports/details/updateIncidentDateAndTime'
@@ -42,6 +43,7 @@ export default function routes(services: Services): Router {
   // creating and editing a report
   router.use('/reports', dashboard())
   router.use('/create-report', createReportRouter)
+  router.get('/reports/incident-number/:reference', lookupReference)
   router.use('/reports/:reportId', viewReportRouter())
   router.use('/reports/:reportId/history', historyRouter())
   router.use('/reports/:reportId/reopen', reopenRouter)

--- a/server/routes/reports/lookupReference.test.ts
+++ b/server/routes/reports/lookupReference.test.ts
@@ -1,0 +1,84 @@
+import request from 'supertest'
+
+import { appWithAllRoutes } from '../testutils/appSetup'
+import { IncidentReportingApi } from '../../data/incidentReportingApi'
+import { convertBasicReportDates } from '../../data/incidentReportingApiUtils'
+import { mockErrorResponse, mockReport } from '../../data/testData/incidentReporting'
+import { mockThrownError } from '../../data/testData/thrownErrors'
+import { now } from '../../testutils/fakeClock'
+
+jest.mock('../../data/incidentReportingApi')
+
+let incidentReportingApi: jest.Mocked<IncidentReportingApi>
+
+beforeEach(() => {
+  incidentReportingApi = IncidentReportingApi.prototype as jest.Mocked<IncidentReportingApi>
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Look up report by incident number', () => {
+  it('should redirect to a report that user has permission to view', () => {
+    const report = convertBasicReportDates(
+      mockReport({
+        reportReference: '6543',
+        // prison accessible
+        location: 'MDI',
+        reportDateAndTime: now,
+      }),
+    )
+    incidentReportingApi.getReportByReference.mockResolvedValueOnce(report)
+
+    return request(appWithAllRoutes())
+      .get('/reports/incident-number/6543')
+      .expect(302)
+      .expect(res => {
+        expect(res.redirect).toBe(true)
+        expect(res.header.location).toEqual(`/reports/${report.id}`)
+      })
+  })
+
+  it('should 404 for a report that user does not have permission to view', () => {
+    const report = convertBasicReportDates(
+      mockReport({
+        reportReference: '6543',
+        // prison not accessible
+        location: 'LGI',
+        reportDateAndTime: now,
+      }),
+    )
+    incidentReportingApi.getReportByReference.mockResolvedValueOnce(report)
+
+    return request(appWithAllRoutes())
+      .get('/reports/incident-number/6543')
+      .expect(404)
+      .expect(res => {
+        expect(res.text).toContain('Page not found')
+      })
+  })
+
+  it('should 404 for a report that whose reference is not found', () => {
+    const error = mockThrownError(mockErrorResponse({ status: 404, message: 'Report not found' }), 404)
+    incidentReportingApi.getReportByReference.mockRejectedValueOnce(error)
+
+    return request(appWithAllRoutes())
+      .get('/reports/incident-number/6543')
+      .expect(404)
+      .expect(res => {
+        expect(res.text).toContain('Page not found')
+      })
+  })
+
+  it('should show an error if report cannot be looked up', () => {
+    const error = mockThrownError(mockErrorResponse({ status: 500, message: 'External problem' }), 500)
+    incidentReportingApi.getReportByReference.mockRejectedValueOnce(error)
+
+    return request(appWithAllRoutes())
+      .get('/reports/incident-number/6543')
+      .expect(res => {
+        expect(res.text).toContain('Sorry, there is a problem with the service')
+      })
+  })
+})

--- a/server/routes/reports/lookupReference.ts
+++ b/server/routes/reports/lookupReference.ts
@@ -1,0 +1,17 @@
+import type { Request, Response } from 'express'
+import { NotFound } from 'http-errors'
+
+// eslint-disable-next-line import/prefer-default-export
+export async function lookupReference(req: Request, res: Response): Promise<void> {
+  const { reference } = req.params
+  const { permissions } = res.locals
+  const { incidentReportingApi } = res.locals.apis
+
+  const report = await incidentReportingApi.getReportByReference(reference)
+  const allowedActions = permissions.allowedActionsOnReport(report)
+  if (allowedActions.has('view')) {
+    res.redirect(`/reports/${report.id}`)
+  } else {
+    throw new NotFound()
+  }
+}


### PR DESCRIPTION
… so that “this is a duplicate of  report X” comments can link to the report without first looking up it’s ID