### PR TITLE
IR-1054: Hide original incident number input if a request to mark as duplicate was made

### DIFF
--- a/server/data/incidentReportingApiUtils.ts
+++ b/server/data/incidentReportingApiUtils.ts
@@ -35,6 +35,11 @@ export function convertReportWithDetailsDates(report: DatesAsStrings<ReportWithD
   }
 }
 
+export function convertReportDates(report: DatesAsStrings<ReportWithDetails>): ReportWithDetails
+export function convertReportDates(report: DatesAsStrings<ReportBasic>): ReportBasic
+export function convertReportDates(
+  report: DatesAsStrings<ReportBasic | ReportWithDetails>,
+): ReportBasic | ReportWithDetails
 export function convertReportDates(
   report: DatesAsStrings<ReportBasic | ReportWithDetails>,
 ): ReportBasic | ReportWithDetails {

--- a/server/data/incidentTypeConfiguration/questionProgress.test.ts
+++ b/server/data/incidentTypeConfiguration/questionProgress.test.ts
@@ -1,6 +1,6 @@
 import { now } from '../../testutils/fakeClock'
 import type { Response } from '../incidentReportingApi'
-import { convertReportWithDetailsDates } from '../incidentReportingApiUtils'
+import { convertReportDates } from '../incidentReportingApiUtils'
 import { mockReport } from '../testData/incidentReporting'
 import type { IncidentTypeConfiguration } from './types'
 import { generateSteps } from './formWizard'
@@ -154,7 +154,7 @@ describe('Question progress', () => {
   const steps = generateSteps(config)
 
   describe('before any responses have been entered', () => {
-    const report = convertReportWithDetailsDates(
+    const report = convertReportDates(
       mockReport({ type: 'MISCELLANEOUS_1', reportReference: '6543', reportDateAndTime: now, withDetails: true }),
     )
     // no responses
@@ -188,7 +188,7 @@ describe('Question progress', () => {
   })
 
   describe('once a response has been entered', () => {
-    const report = convertReportWithDetailsDates(
+    const report = convertReportDates(
       mockReport({ type: 'MISCELLANEOUS_1', reportReference: '6543', reportDateAndTime: now, withDetails: true }),
     )
     // '11' response for question '1'
@@ -254,7 +254,7 @@ describe('Question progress', () => {
   })
 
   describe('once a differently branching response has been entered', () => {
-    const report = convertReportWithDetailsDates(
+    const report = convertReportDates(
       mockReport({ type: 'MISCELLANEOUS_1', reportReference: '6543', reportDateAndTime: now, withDetails: true }),
     )
     // '12' response for question '1'
@@ -320,7 +320,7 @@ describe('Question progress', () => {
   })
 
   describe('once all responses have been entered', () => {
-    const report = convertReportWithDetailsDates(
+    const report = convertReportDates(
       mockReport({ type: 'MISCELLANEOUS_1', reportReference: '6543', reportDateAndTime: now, withDetails: true }),
     )
     // '11' response for question '1'
@@ -475,7 +475,7 @@ describe('Question progress', () => {
 
   describe('should validate comment and/or date responses along the way', () => {
     it('when a response is not one of the possible choices', () => {
-      const report = convertReportWithDetailsDates(
+      const report = convertReportDates(
         mockReport({ type: 'MISCELLANEOUS_1', reportReference: '6543', reportDateAndTime: now, withDetails: true }),
       )
       // non-existent response for question '1'
@@ -561,7 +561,7 @@ describe('Question progress', () => {
         },
       }
       const simplestSteps = generateSteps(simplestConfig)
-      const report = convertReportWithDetailsDates(
+      const report = convertReportDates(
         mockReport({ type: 'MISCELLANEOUS_1', reportReference: '6543', reportDateAndTime: now, withDetails: true }),
       )
 
@@ -766,7 +766,7 @@ describe('Question progress', () => {
         },
       }
       const multiChoiceSteps = generateSteps(multiChoiceConfig)
-      const report = convertReportWithDetailsDates(
+      const report = convertReportDates(
         mockReport({ type: 'MISCELLANEOUS_1', reportReference: '6543', reportDateAndTime: now, withDetails: true }),
       )
 
@@ -891,7 +891,7 @@ describe('Question progress', () => {
         },
       }
       const stepsWithInactiveResponses = generateSteps(configWithInactiveResponses)
-      const report = convertReportWithDetailsDates(
+      const report = convertReportDates(
         mockReport({ type: 'MISCELLANEOUS_1', reportReference: '6543', reportDateAndTime: now, withDetails: true }),
       )
       report.questions = [

--- a/server/data/reportValidity.test.ts
+++ b/server/data/reportValidity.test.ts
@@ -3,7 +3,7 @@ import { getIncidentTypeConfiguration } from '../reportConfiguration/types'
 import { generateSteps } from './incidentTypeConfiguration/formWizard'
 import { QuestionProgress } from './incidentTypeConfiguration/questionProgress'
 import type { ReportWithDetails } from './incidentReportingApi'
-import { convertReportWithDetailsDates } from './incidentReportingApiUtils'
+import { convertReportDates } from './incidentReportingApiUtils'
 import { mockReport } from './testData/incidentReporting'
 import { makeSimpleQuestion } from './testData/incidentReportingJest'
 import { validateReport } from './reportValidity'
@@ -22,7 +22,7 @@ describe('Checking that a report can be submitted for review', () => {
     let report: ReportWithDetails
 
     beforeEach(() => {
-      report = convertReportWithDetailsDates(
+      report = convertReportDates(
         mockReport({
           reportReference: '6543',
           reportDateAndTime: now,
@@ -177,7 +177,7 @@ describe('Checking that a report can be submitted for review', () => {
     let report: ReportWithDetails
 
     beforeEach(() => {
-      report = convertReportWithDetailsDates(
+      report = convertReportDates(
         mockReport({
           reportReference: '6543',
           reportDateAndTime: now,

--- a/server/routes/dashboard/index.test.ts
+++ b/server/routes/dashboard/index.test.ts
@@ -4,7 +4,7 @@ import request from 'supertest'
 import { appWithAllRoutes } from '../testutils/appSetup'
 import { now } from '../../testutils/fakeClock'
 import { type GetReportsParams, IncidentReportingApi } from '../../data/incidentReportingApi'
-import { convertBasicReportDates } from '../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../data/testData/incidentReporting'
 import { unsortedPageOf } from '../../data/testData/paginatedResponses'
 import { mockSharedUser } from '../../data/testData/manageUsers'
@@ -78,8 +78,8 @@ describe('Dashboard permissions', () => {
 describe('GET dashboard', () => {
   beforeEach(() => {
     const mockedReports = [
-      convertBasicReportDates(mockReport({ reportReference: '6543', reportDateAndTime: now })),
-      convertBasicReportDates(mockReport({ reportReference: '6544', reportDateAndTime: now })),
+      convertReportDates(mockReport({ reportReference: '6543', reportDateAndTime: now })),
+      convertReportDates(mockReport({ reportReference: '6544', reportDateAndTime: now })),
     ]
     const pageOfReports = unsortedPageOf(mockedReports)
     incidentReportingApi.getReports.mockResolvedValueOnce(pageOfReports)
@@ -235,10 +235,10 @@ describe('GET dashboard', () => {
 
   it('should show actual name when username found, username if not', () => {
     const mockedReports = [
-      convertBasicReportDates(
+      convertReportDates(
         mockReport({ reportReference: '6543', reportDateAndTime: now, reportingUsername: 'JOHN_SMITH' }),
       ),
-      convertBasicReportDates(
+      convertReportDates(
         mockReport({ reportReference: '6544', reportDateAndTime: now, reportingUsername: 'JOHN_WICK' }),
       ),
     ]

--- a/server/routes/reports/actions/actionReport.test.ts
+++ b/server/routes/reports/actions/actionReport.test.ts
@@ -15,7 +15,7 @@ import {
   type AddCorrectionRequestRequest,
   type UpdateCorrectionRequestRequest,
 } from '../../../data/incidentReportingApi'
-import { convertBasicReportDates, convertReportWithDetailsDates } from '../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../data/incidentReportingApiUtils'
 import * as reportValidity from '../../../data/reportValidity'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockSharedUser } from '../../../data/testData/manageUsers'
@@ -94,7 +94,7 @@ describe('Actioning reports', () => {
   let viewReportUrl: string
 
   beforeEach(() => {
-    mockedReport = convertReportWithDetailsDates(
+    mockedReport = convertReportDates(
       mockReport({
         reportReference: '6543',
         reportDateAndTime: now,
@@ -887,7 +887,7 @@ describe('Actioning reports', () => {
           incidentReportingApi.getReportByReference.mockRejectedValueOnce(new Error('should not be called'))
         })
 
-        const mockedDuplicateReport = convertBasicReportDates(
+        const mockedDuplicateReport = convertReportDates(
           mockReport({ reportReference: '1234', reportDateAndTime: now }),
         )
         function makeOriginalReportReferenceExistIfNeeded() {

--- a/server/routes/reports/actions/actionReport.test.ts
+++ b/server/routes/reports/actions/actionReport.test.ts
@@ -187,10 +187,14 @@ describe('Actioning reports', () => {
         formOptions: [
           'Close',
           'Send back',
+          'Explain why you’re sending the report back',
           'Put on hold',
           'Describe why the report is being put on hold',
           'Mark as a duplicate',
+          'Enter incident report number of the original report',
+          'Describe why it is a duplicate report (optional)',
           'Mark as not reportable',
+          'Describe why it is not reportable',
         ],
       },
       {
@@ -278,6 +282,30 @@ describe('Actioning reports', () => {
           .expect(res => {
             expect(res.text).toContain('app-view-report__user-action-form')
             formOptions.forEach(option => expect(res.text).toContain(option))
+          })
+      },
+    )
+
+    it.each(['AWAITING_REVIEW', 'UPDATED', 'ON_HOLD', 'WAS_CLOSED'] as const)(
+      'should hide original incident number input from data wardens if there is a recent request to mark as duplicate',
+      status => {
+        setupAppForUser(mockDataWarden)
+        mockedReport.status = status
+        mockedReport.correctionRequests.push({
+          descriptionOfChange: '(Report is a duplicate of 1235)',
+          userAction: 'REQUEST_DUPLICATE',
+          userType: 'REPORTING_OFFICER',
+          originalReportReference: '1235',
+          correctionRequestedBy: 'user1',
+          correctionRequestedAt: now,
+        })
+
+        return request(app)
+          .get(viewReportUrl)
+          .expect(200)
+          .expect(res => {
+            expect(res.text).not.toContain('Enter incident report number of the original report')
+            expect(res.text).toContain('value="1235"')
           })
       },
     )

--- a/server/routes/reports/actions/findRequestDuplicate.test.ts
+++ b/server/routes/reports/actions/findRequestDuplicate.test.ts
@@ -1,0 +1,146 @@
+import { now } from '../../../testutils/fakeClock'
+import type { ReportWithDetails } from '../../../data/incidentReportingApi'
+import { convertReportDates } from '../../../data/incidentReportingApiUtils'
+import { mockReport } from '../../../data/testData/incidentReporting'
+import { statuses } from '../../../reportConfiguration/constants'
+import { findRequestDuplicate } from './findRequestDuplicate'
+
+describe('Finding recent duplicate requests', () => {
+  let report: ReportWithDetails
+
+  beforeEach(() => {
+    report = convertReportDates(
+      mockReport({
+        reportReference: '6544',
+        reportDateAndTime: now,
+        withDetails: true,
+      }),
+    )
+  })
+
+  it('should return null when there are no correction requests', () => {
+    report.status = 'AWAITING_REVIEW'
+    report.correctionRequests = []
+
+    const duplicateRequest = findRequestDuplicate(report)
+    expect(duplicateRequest).toBeNull()
+  })
+
+  it('should return a duplicate request if it was the only action that just took the report into the submitted work list', () => {
+    report.status = 'AWAITING_REVIEW'
+    report.correctionRequests = [
+      {
+        descriptionOfChange: '(Report is a duplicate of 1235)',
+        userAction: 'REQUEST_DUPLICATE',
+        userType: 'REPORTING_OFFICER',
+        originalReportReference: '1235',
+        correctionRequestedBy: 'user1',
+        correctionRequestedAt: now,
+      },
+    ]
+
+    const duplicateRequest = findRequestDuplicate(report)
+    expect(duplicateRequest).toHaveProperty('originalReportReference', '1235')
+  })
+
+  it('should return a duplicate request if it was the last action that took the report into the submitted work list', () => {
+    report.status = 'UPDATED'
+    report.correctionRequests = [
+      {
+        descriptionOfChange: 'This seems to be a duplicate of incident 1235',
+        userAction: 'REQUEST_CORRECTION',
+        userType: 'DATA_WARDEN',
+        correctionRequestedBy: 'user1',
+        correctionRequestedAt: now,
+      },
+      {
+        descriptionOfChange: '(Report is a duplicate of 1235)',
+        userAction: 'REQUEST_DUPLICATE',
+        userType: 'REPORTING_OFFICER',
+        originalReportReference: '1235',
+        correctionRequestedBy: 'user1',
+        correctionRequestedAt: now,
+      },
+    ]
+
+    const duplicateRequest = findRequestDuplicate(report)
+    expect(duplicateRequest).toHaveProperty('originalReportReference', '1235')
+  })
+
+  it('should return a duplicate request if it was the last action that took the report into the submitted work list, even if it was put on hold afterwards', () => {
+    report.status = 'ON_HOLD'
+    report.correctionRequests = [
+      {
+        descriptionOfChange: '(Report is a duplicate of 1235)',
+        userAction: 'REQUEST_DUPLICATE',
+        userType: 'REPORTING_OFFICER',
+        originalReportReference: '1235',
+        correctionRequestedBy: 'user1',
+        correctionRequestedAt: now,
+      },
+      {
+        descriptionOfChange: 'Checking up on some details…',
+        userAction: 'HOLD',
+        userType: 'DATA_WARDEN',
+        correctionRequestedBy: 'user1',
+        correctionRequestedAt: now,
+      },
+    ]
+
+    const duplicateRequest = findRequestDuplicate(report)
+    expect(duplicateRequest).toHaveProperty('originalReportReference', '1235')
+  })
+
+  it('should return null if report had left the submitted work list since the last duplicate request', () => {
+    report.status = 'UPDATED'
+    report.correctionRequests = [
+      {
+        descriptionOfChange: '(Report is a duplicate of 1235)',
+        userAction: 'REQUEST_DUPLICATE',
+        userType: 'REPORTING_OFFICER',
+        originalReportReference: '1235',
+        correctionRequestedBy: 'user1',
+        correctionRequestedAt: now,
+      },
+      {
+        descriptionOfChange: 'This does NOT seem to be a duplicate of incident 1235',
+        userAction: 'REQUEST_CORRECTION',
+        userType: 'DATA_WARDEN',
+        correctionRequestedBy: 'user1',
+        correctionRequestedAt: now,
+      },
+      {
+        descriptionOfChange: 'I agree, all questions are now completed',
+        userAction: 'REQUEST_REVIEW',
+        userType: 'REPORTING_OFFICER',
+        correctionRequestedBy: 'user1',
+        correctionRequestedAt: now,
+      },
+    ]
+
+    const duplicateRequest = findRequestDuplicate(report)
+    expect(duplicateRequest).toBeNull()
+  })
+
+  it.each(
+    statuses
+      .map(({ code: status }) => status)
+      .filter(status => !['AWAITING_REVIEW', 'UPDATED', 'ON_HOLD', 'WAS_CLOSED'].includes(status)),
+  )('should return null if report has status %s, not in the submitted work list', status => {
+    report.status = status
+    report.correctionRequests = [
+      // unrealistic scenario: in most cases, this cannot be the last correction request
+      {
+        descriptionOfChange: '(Report is a duplicate of 1235)',
+        userAction: 'REQUEST_DUPLICATE',
+        userType: 'REPORTING_OFFICER',
+        originalReportReference: '1235',
+        correctionRequestedBy: 'user1',
+        correctionRequestedAt: now,
+      },
+    ]
+
+    const duplicateRequest = findRequestDuplicate(report)
+    expect(duplicateRequest).toBeNull()
+  })
+})

--- a/server/routes/reports/actions/findRequestDuplicate.ts
+++ b/server/routes/reports/actions/findRequestDuplicate.ts
@@ -1,0 +1,29 @@
+import type { CorrectionRequest, ReportWithDetails } from '../../../data/incidentReportingApi'
+import { workListMapping } from '../../../reportConfiguration/constants'
+
+/**
+ * When a report has a status in the submitted work list, there might be a request to mark it as a duplicate.
+ * Once a report leaves this set of statuses, any prior request is cleared.
+ *
+ * This helper function finds the last such request if it was the latest correction request
+ * to take the report into the submitted work list.
+ *
+ * Assumes the list is presorted in ascending date order (as currently returned by api; though that is technically insertion order).
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function findRequestDuplicate(report: ReportWithDetails): CorrectionRequest | null {
+  if (!workListMapping.submitted.includes(report.status)) {
+    // not in submitted work list so there cannot be a recent enough request
+    return null
+  }
+  for (const correctionRequest of report.correctionRequests.toReversed()) {
+    if (correctionRequest.userAction === 'REQUEST_DUPLICATE') {
+      return correctionRequest
+    }
+    if (correctionRequest.userAction !== 'HOLD') {
+      // any action other than HOLD would have taken the report out of the submitted work list
+      break
+    }
+  }
+  return null
+}

--- a/server/routes/reports/actions/reopen/index.test.ts
+++ b/server/routes/reports/actions/reopen/index.test.ts
@@ -13,7 +13,7 @@ import {
   type AddCorrectionRequestRequest,
   type UpdateCorrectionRequestRequest,
 } from '../../../../data/incidentReportingApi'
-import { convertBasicReportDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
 import {
@@ -57,7 +57,7 @@ describe('Reopening a report', () => {
   let reopenReportUrl: string
 
   beforeEach(() => {
-    mockedReport = convertBasicReportDates(
+    mockedReport = convertReportDates(
       mockReport({
         reportReference: '6543',
         reportDateAndTime: now,

--- a/server/routes/reports/actions/requestRemoval/index.test.ts
+++ b/server/routes/reports/actions/requestRemoval/index.test.ts
@@ -12,7 +12,7 @@ import {
   type AddCorrectionRequestRequest,
   type UpdateCorrectionRequestRequest,
 } from '../../../../data/incidentReportingApi'
-import { convertBasicReportDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
 import {
@@ -64,7 +64,7 @@ describe('Requesting removal of a report', () => {
   let requestRemoveReportUrl: string
 
   beforeEach(() => {
-    mockedReport = convertBasicReportDates(
+    mockedReport = convertReportDates(
       mockReport({
         reportReference: '6543',
         reportDateAndTime: now,
@@ -142,9 +142,7 @@ describe('Requesting removal of a report', () => {
           })
       })
 
-      const mockedDuplicateReport = convertBasicReportDates(
-        mockReport({ reportReference: '1234', reportDateAndTime: now }),
-      )
+      const mockedDuplicateReport = convertReportDates(mockReport({ reportReference: '1234', reportDateAndTime: now }))
 
       it(`should allow requesting removal of a duplicate report changing the status to ${newStatus}`, () => {
         incidentReportingApi.getReportByReference.mockResolvedValueOnce(mockedDuplicateReport)

--- a/server/routes/reports/details/addDescription.test.ts
+++ b/server/routes/reports/details/addDescription.test.ts
@@ -9,7 +9,7 @@ import {
   type AddDescriptionAddendumRequest,
   type UpdateDescriptionAddendumRequest,
 } from '../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
 import { mockSharedUser } from '../../../data/testData/manageUsers'
@@ -49,7 +49,7 @@ afterEach(() => {
 
 describe('Adding a description addendum to report', () => {
   const incidentDateAndTime = new Date('2024-10-21T16:32:00+01:00')
-  const mockedReport = convertReportWithDetailsDates(
+  const mockedReport = convertReportDates(
     mockReport({
       type: 'DISORDER_2',
       status: 'NEEDS_UPDATING',

--- a/server/routes/reports/details/changeType.test.ts
+++ b/server/routes/reports/details/changeType.test.ts
@@ -2,7 +2,7 @@ import request, { type Agent } from 'supertest'
 
 import { appWithAllRoutes } from '../../testutils/appSetup'
 import { IncidentReportingApi, type ReportBasic, ReportWithDetails } from '../../../data/incidentReportingApi'
-import { convertBasicReportDates } from '../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
 import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
@@ -30,7 +30,7 @@ describe('Changing incident type', () => {
   let selectUrl: string
 
   beforeEach(() => {
-    mockedReport = convertBasicReportDates(
+    mockedReport = convertReportDates(
       mockReport({
         type: 'DISORDER_2',
         reportReference: '6544',

--- a/server/routes/reports/details/createReport.test.ts
+++ b/server/routes/reports/details/createReport.test.ts
@@ -4,7 +4,7 @@ import request, { type Agent, type Response } from 'supertest'
 import format from '../../../utils/format'
 import { appWithAllRoutes } from '../../testutils/appSetup'
 import { IncidentReportingApi } from '../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
 import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
@@ -239,7 +239,7 @@ describe('Creating a report', () => {
     })
 
     it('should send request to API if form is valid and proceed to next step', async () => {
-      const reportWithDetails = convertReportWithDetailsDates(
+      const reportWithDetails = convertReportDates(
         mockReport({
           reportReference: '6544',
           reportDateAndTime: incidentDateAndTime,
@@ -273,7 +273,7 @@ describe('Creating a report', () => {
     })
 
     it('should send request to API if form is valid and return to report view if user chose to exit', () => {
-      const reportWithDetails = convertReportWithDetailsDates(
+      const reportWithDetails = convertReportDates(
         mockReport({
           reportReference: '6544',
           reportDateAndTime: incidentDateAndTime,
@@ -313,7 +313,7 @@ describe('Creating a report', () => {
     })
 
     it('should redirect from URL base of nested routers to report view page', () => {
-      const reportWithDetails = convertReportWithDetailsDates(
+      const reportWithDetails = convertReportDates(
         mockReport({
           reportReference: '6544',
           reportDateAndTime: incidentDateAndTime,

--- a/server/routes/reports/details/updateIncidentDateAndTime.test.ts
+++ b/server/routes/reports/details/updateIncidentDateAndTime.test.ts
@@ -4,7 +4,7 @@ import request, { type Agent, type Response } from 'supertest'
 import format from '../../../utils/format'
 import { appWithAllRoutes } from '../../testutils/appSetup'
 import { IncidentReportingApi } from '../../../data/incidentReportingApi'
-import { convertBasicReportDates } from '../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
 import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
@@ -26,7 +26,7 @@ afterEach(() => {
 
 describe('Updating report incident date and time', () => {
   const incidentDateAndTime = new Date('2024-10-21T16:32:00+01:00')
-  const reportBasic = convertBasicReportDates(
+  const reportBasic = convertReportDates(
     mockReport({
       type: 'DISORDER_2',
       status: 'NEEDS_UPDATING',

--- a/server/routes/reports/details/updateReportDetails.test.ts
+++ b/server/routes/reports/details/updateReportDetails.test.ts
@@ -4,7 +4,7 @@ import request, { type Agent, type Response } from 'supertest'
 import format from '../../../utils/format'
 import { appWithAllRoutes } from '../../testutils/appSetup'
 import { IncidentReportingApi } from '../../../data/incidentReportingApi'
-import { convertBasicReportDates } from '../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
 import { mockDataWarden, mockReportingOfficer, mockHqViewer, mockUnauthorisedUser } from '../../../data/testData/users'
@@ -26,7 +26,7 @@ afterEach(() => {
 
 describe('Updating report details', () => {
   const incidentDateAndTime = new Date('2024-10-21T16:32:00+01:00')
-  const reportBasic = convertBasicReportDates(
+  const reportBasic = convertReportDates(
     mockReport({
       type: 'DISORDER_2',
       reportReference: '6544',

--- a/server/routes/reports/history/status.test.ts
+++ b/server/routes/reports/history/status.test.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express'
 import request from 'supertest'
 
 import { IncidentReportingApi, type ReportWithDetails } from '../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockSharedUser, mockUser } from '../../../data/testData/manageUsers'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
@@ -37,7 +37,7 @@ describe('Report status history', () => {
   let statusHistoryUrl: string
 
   beforeEach(() => {
-    mockedReport = convertReportWithDetailsDates(
+    mockedReport = convertReportDates(
       mockReport({ reportReference: '6543', reportDateAndTime: now, withDetails: true }),
     )
     incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(mockedReport)

--- a/server/routes/reports/history/type.test.ts
+++ b/server/routes/reports/history/type.test.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express'
 import request from 'supertest'
 
 import { IncidentReportingApi, type ReportWithDetails } from '../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { mockSharedUser, mockUser } from '../../../data/testData/manageUsers'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
@@ -37,7 +37,7 @@ describe('Report incident type history', () => {
   let typeHistoryUrl: string
 
   beforeEach(() => {
-    mockedReport = convertReportWithDetailsDates(
+    mockedReport = convertReportDates(
       mockReport({ reportReference: '6543', type: 'MISCELLANEOUS_1', reportDateAndTime: now, withDetails: true }),
     )
     incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(mockedReport)

--- a/server/routes/reports/prisoners/involvement/add.test.ts
+++ b/server/routes/reports/prisoners/involvement/add.test.ts
@@ -9,7 +9,7 @@ import {
   type AddPrisonerInvolvementRequest,
   type UpdatePrisonerInvolvementRequest,
 } from '../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import { OffenderSearchApi } from '../../../../data/offenderSearchApi'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { andrew, barry } from '../../../../data/testData/offenderSearch'
@@ -57,7 +57,7 @@ describe('Adding a new prisoner to a report', () => {
   let report: ReportWithDetails
 
   beforeEach(() => {
-    report = convertReportWithDetailsDates(
+    report = convertReportDates(
       mockReport({
         type: 'FIND_6',
         reportReference: '6544',

--- a/server/routes/reports/prisoners/involvement/edit.test.ts
+++ b/server/routes/reports/prisoners/involvement/edit.test.ts
@@ -9,7 +9,7 @@ import {
   type AddPrisonerInvolvementRequest,
   type UpdatePrisonerInvolvementRequest,
 } from '../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { andrew, barry } from '../../../../data/testData/offenderSearch'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
@@ -51,7 +51,7 @@ describe('Editing an existing prisoner in a report', () => {
   let report: ReportWithDetails
 
   beforeEach(() => {
-    report = convertReportWithDetailsDates(
+    report = convertReportDates(
       mockReport({
         type: 'FIND_6',
         reportReference: '6544',

--- a/server/routes/reports/prisoners/remove/index.test.ts
+++ b/server/routes/reports/prisoners/remove/index.test.ts
@@ -9,7 +9,7 @@ import {
   type PrisonerInvolvement,
   type UpdatePrisonerInvolvementRequest,
 } from '../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { andrew } from '../../../../data/testData/offenderSearch'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
@@ -46,7 +46,7 @@ describe('Remove prisoner involvement', () => {
   let mockedReport: ReportWithDetails
 
   beforeEach(() => {
-    mockedReport = convertReportWithDetailsDates(
+    mockedReport = convertReportDates(
       mockReport({ reportReference: '6543', reportDateAndTime: now, withDetails: true }),
     )
     mockedReport.prisonersInvolved = [

--- a/server/routes/reports/prisoners/search/index.test.ts
+++ b/server/routes/reports/prisoners/search/index.test.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express'
 import request from 'supertest'
 
 import { IncidentReportingApi, type ReportWithDetails } from '../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import { OffenderSearchApi, type OffenderSearchResults } from '../../../../data/offenderSearchApi'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { andrew, barry, chris, donald, ernie, fred } from '../../../../data/testData/offenderSearch'
@@ -39,7 +39,7 @@ describe('Searching for a prisoner to add to a report', () => {
   let report: ReportWithDetails
 
   beforeEach(() => {
-    report = convertReportWithDetailsDates(
+    report = convertReportDates(
       mockReport({
         type: 'FIND_6',
         reportReference: '6544',

--- a/server/routes/reports/prisoners/summary/index.test.ts
+++ b/server/routes/reports/prisoners/summary/index.test.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express'
 import request from 'supertest'
 
 import { IncidentReportingApi, ReportWithDetails } from '../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
 import {
@@ -32,7 +32,7 @@ describe('Prisoner involvement summary for report', () => {
   let mockedReport: ReportWithDetails
 
   beforeEach(() => {
-    mockedReport = convertReportWithDetailsDates(
+    mockedReport = convertReportDates(
       mockReport({ reportReference: '6543', reportDateAndTime: now, withDetails: true }),
     )
     incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(mockedReport)
@@ -105,7 +105,7 @@ describe('Prisoner involvement summary for report', () => {
     ({ createJourney }) => {
       Object.assign(
         mockedReport,
-        convertReportWithDetailsDates(
+        convertReportDates(
           mockReport({ reportReference: '6543', reportDateAndTime: now, createdInNomis: true, withDetails: true }),
         ),
       )

--- a/server/routes/reports/questions/index.test.ts
+++ b/server/routes/reports/questions/index.test.ts
@@ -10,7 +10,7 @@ import {
   type Question,
   type ReportWithDetails,
 } from '../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../data/testData/incidentReporting'
 import { makeSimpleQuestion } from '../../../data/testData/incidentReportingJest'
 import { mockThrownError } from '../../../data/testData/thrownErrors'
@@ -43,7 +43,7 @@ describe('Displaying questions and responses', () => {
   beforeEach(() => {
     agent = request.agent(app)
 
-    reportWithDetails = convertReportWithDetailsDates(
+    reportWithDetails = convertReportDates(
       mockReport({
         type: 'FIND_6',
         reportReference: '6544',
@@ -406,7 +406,7 @@ describe('Submitting questions’ responses', () => {
   let agent: Agent
 
   // Report type/answers updated in each test
-  const reportWithDetails: ReportWithDetails = convertReportWithDetailsDates(
+  const reportWithDetails = convertReportDates(
     mockReport({
       type: 'FIND_6',
       reportReference: '6544',
@@ -1009,7 +1009,7 @@ describe('Submitting questions’ responses', () => {
 describe('Question editing permissions', () => {
   // NB: these test cases are simplified because the permissions class methods are thoroughly tested elsewhere
 
-  const reportWithDetails = convertReportWithDetailsDates(
+  const reportWithDetails = convertReportDates(
     mockReport({
       reportReference: '6544',
       reportDateAndTime: now,

--- a/server/routes/reports/staff/involvement/add.test.ts
+++ b/server/routes/reports/staff/involvement/add.test.ts
@@ -9,7 +9,7 @@ import {
   type AddStaffInvolvementRequest,
   type UpdateStaffInvolvementRequest,
 } from '../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import ManageUsersApiClient from '../../../../data/manageUsersApiClient'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockPrisonUser } from '../../../../data/testData/manageUsers'
@@ -57,7 +57,7 @@ describe('Adding a new staff member to a report', () => {
   let report: ReportWithDetails
 
   beforeEach(() => {
-    report = convertReportWithDetailsDates(
+    report = convertReportDates(
       mockReport({
         type: 'FIND_6',
         reportReference: '6544',

--- a/server/routes/reports/staff/involvement/edit.test.ts
+++ b/server/routes/reports/staff/involvement/edit.test.ts
@@ -9,7 +9,7 @@ import {
   type AddStaffInvolvementRequest,
   type UpdateStaffInvolvementRequest,
 } from '../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
 import {
@@ -50,7 +50,7 @@ describe('Editing an existing staff member in a report', () => {
   let report: ReportWithDetails
 
   beforeEach(() => {
-    report = convertReportWithDetailsDates(
+    report = convertReportDates(
       mockReport({
         type: 'FIND_6',
         reportReference: '6544',

--- a/server/routes/reports/staff/involvement/manual/add.test.ts
+++ b/server/routes/reports/staff/involvement/manual/add.test.ts
@@ -8,7 +8,7 @@ import {
   type AddStaffInvolvementRequest,
   type UpdateStaffInvolvementRequest,
 } from '../../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../../data/incidentReportingApiUtils'
 import ManageUsersApiClient from '../../../../../data/manageUsersApiClient'
 import { mockErrorResponse, mockReport } from '../../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../../data/testData/thrownErrors'
@@ -56,7 +56,7 @@ describe('Adding a new staff member to a report who does not have a DPS/NOMIS ac
   let report: ReportWithDetails
 
   beforeEach(() => {
-    report = convertReportWithDetailsDates(
+    report = convertReportDates(
       mockReport({
         type: 'FIND_6',
         reportReference: '6544',

--- a/server/routes/reports/staff/remove/index.test.ts
+++ b/server/routes/reports/staff/remove/index.test.ts
@@ -9,7 +9,7 @@ import {
   type StaffInvolvement,
   type UpdateStaffInvolvementRequest,
 } from '../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
 import {
@@ -45,7 +45,7 @@ describe('Remove staff involvement', () => {
   let mockedReport: ReportWithDetails
 
   beforeEach(() => {
-    mockedReport = convertReportWithDetailsDates(
+    mockedReport = convertReportDates(
       mockReport({ reportReference: '6543', reportDateAndTime: now, withDetails: true }),
     )
     mockedReport.staffInvolved = [

--- a/server/routes/reports/staff/search/index.test.ts
+++ b/server/routes/reports/staff/search/index.test.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express'
 import request from 'supertest'
 
 import { IncidentReportingApi, type ReportWithDetails } from '../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import ManageUsersApiClient, { type UsersSearchResponse } from '../../../../data/manageUsersApiClient'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockPrisonUserSearchResult } from '../../../../data/testData/manageUsers'
@@ -40,7 +40,7 @@ describe('Searching for a member of staff to add to a report', () => {
   let report: ReportWithDetails
 
   beforeEach(() => {
-    report = convertReportWithDetailsDates(
+    report = convertReportDates(
       mockReport({
         type: 'FIND_6',
         reportReference: '6544',

--- a/server/routes/reports/staff/summary/index.test.ts
+++ b/server/routes/reports/staff/summary/index.test.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express'
 import request from 'supertest'
 
 import { IncidentReportingApi, ReportWithDetails } from '../../../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../../../data/incidentReportingApiUtils'
 import { mockErrorResponse, mockReport } from '../../../../data/testData/incidentReporting'
 import { mockThrownError } from '../../../../data/testData/thrownErrors'
 import {
@@ -32,7 +32,7 @@ describe('Staff involvement summary for report', () => {
   let mockedReport: ReportWithDetails
 
   beforeEach(() => {
-    mockedReport = convertReportWithDetailsDates(
+    mockedReport = convertReportDates(
       mockReport({ reportReference: '6543', reportDateAndTime: now, withDetails: true }),
     )
     incidentReportingApi.getReportWithDetailsById.mockResolvedValueOnce(mockedReport)

--- a/server/routes/reports/viewReport.test.ts
+++ b/server/routes/reports/viewReport.test.ts
@@ -8,7 +8,7 @@ import UserService from '../../services/userService'
 import { type Status, statuses } from '../../reportConfiguration/constants'
 import { setActiveAgencies } from '../../data/activeAgencies'
 import { IncidentReportingApi, type ReportWithDetails } from '../../data/incidentReportingApi'
-import { convertReportWithDetailsDates } from '../../data/incidentReportingApiUtils'
+import { convertReportDates } from '../../data/incidentReportingApiUtils'
 import * as reportValidity from '../../data/reportValidity'
 import { mockErrorResponse, mockReport } from '../../data/testData/incidentReporting'
 import { makeSimpleQuestion } from '../../data/testData/incidentReportingJest'
@@ -60,7 +60,7 @@ describe('View report page', () => {
   let viewReportUrl: string
 
   beforeEach(() => {
-    mockedReport = convertReportWithDetailsDates(
+    mockedReport = convertReportDates(
       mockReport({ reportReference: '6543', reportDateAndTime: now, withDetails: true, withAddendums: true }),
     )
     mockedReport.questions = [
@@ -833,7 +833,7 @@ describe('View report page', () => {
     // NB: these test cases are simplified because the permissions class methods are thoroughly tested elsewhere
 
     beforeEach(() => {
-      mockedReport = convertReportWithDetailsDates(
+      mockedReport = convertReportDates(
         mockReport({ reportReference: '6543', reportDateAndTime: now, status: 'DRAFT', withDetails: true }),
       )
       mockedReport.questions = [

--- a/server/routes/reports/viewReport.ts
+++ b/server/routes/reports/viewReport.ts
@@ -30,6 +30,7 @@ import { validateReport } from '../../data/reportValidity'
 import type { GovukErrorSummaryItem } from '../../utils/govukFrontend'
 import { correctionRequestActionLabels } from './actions/correctionRequestLabels'
 import { placeholderForCorrectionRequest } from './actions/correctionRequestPlaceholder'
+import { findRequestDuplicate } from './actions/findRequestDuplicate'
 
 const typesLookup = Object.fromEntries(types.map(type => [type.code, type.description]))
 const statusLookup = Object.fromEntries(statuses.map(status => [status.code, status.description]))
@@ -89,6 +90,11 @@ export function viewReportRouter(): Router {
 
       // TODO: PECS lookup is different
       const reportTransitions = prisonReportTransitions?.[userType]?.[report.status] ?? {}
+
+      let requestedOriginalReportReference: string | undefined
+      if (allowedActions.has('MARK_DUPLICATE')) {
+        requestedOriginalReportReference = findRequestDuplicate(report)?.originalReportReference
+      }
 
       let formValues: object = {}
       const errors: GovukErrorSummaryItem[] = []
@@ -280,6 +286,7 @@ export function viewReportRouter(): Router {
         workListMapping,
         reportTransitions,
         formValues,
+        requestedOriginalReportReference,
       })
     },
   )

--- a/server/services/reportTitle.test.ts
+++ b/server/services/reportTitle.test.ts
@@ -1,4 +1,4 @@
-import { convertReportWithDetailsDates } from '../data/incidentReportingApiUtils'
+import { convertReportDates } from '../data/incidentReportingApiUtils'
 import { mockReport } from '../data/testData/incidentReporting'
 import { andrew } from '../data/testData/offenderSearch'
 import { newReportTitle, regenerateTitleForReport } from './reportTitle'
@@ -16,7 +16,7 @@ describe('Report title generation', () => {
   })
 
   it('should make a title from an existing report without prisoner involvements', () => {
-    const report = convertReportWithDetailsDates(
+    const report = convertReportDates(
       mockReport({
         type: 'FIND_6',
         reportReference: '6544',
@@ -30,7 +30,7 @@ describe('Report title generation', () => {
   })
 
   it('should make a title from an existing report with prisoner involvements', () => {
-    const report = convertReportWithDetailsDates(
+    const report = convertReportDates(
       mockReport({
         type: 'MISCELLANEOUS_1',
         location: 'LEI',

--- a/server/views/pages/reports/view/_actions--choices.njk
+++ b/server/views/pages/reports/view/_actions--choices.njk
@@ -9,16 +9,20 @@
     {% if transition.comment %}
       {% set textHtml %}
         {% if transition.originalReportReferenceRequired %}
-          {{ govukInput({
-            id: "originalReportReference",
-            name: "originalReportReference",
-            classes: "govuk-input--width-10",
-            label: {
-              text: "Enter incident report number of the original report"
-            },
-            value: formValues["originalReportReference"],
-            errorMessage: errors | findFieldInGovukErrorSummary("originalReportReference")
+          {% if requestedOriginalReportReference %}
+            <input type="hidden" name="originalReportReference" value="{{ requestedOriginalReportReference }}" />
+          {% else %}
+            {{ govukInput({
+              id: "originalReportReference",
+              name: "originalReportReference",
+              classes: "govuk-input--width-10",
+              label: {
+                text: "Enter incident report number of the original report"
+              },
+              value: formValues["originalReportReference"],
+              errorMessage: errors | findFieldInGovukErrorSummary("originalReportReference")
           }) }}
+          {% endif %}
         {% endif %}
 
         {% set commentFieldName = action + "_COMMENT" %}


### PR DESCRIPTION
for data wardens:
<img width="813" height="234" alt="Screenshot 2025-07-31 at 09 44 12" src="https://github.com/user-attachments/assets/422dd659-2dfd-4a95-98c8-dc9458ae85e0" />
