### PR TITLE
IR-1054: Update report titles when prisoner involvements change

### DIFF
--- a/integration_tests/e2e/createCompletedReport.cy.ts
+++ b/integration_tests/e2e/createCompletedReport.cy.ts
@@ -105,6 +105,7 @@ context('Creating a completed draft report', () => {
     let prisonerSearchPage = Page.verifyOnPage(PrisonerSearchPage)
     prisonerSearchPage.enterQuery('Andrew Arnold')
     cy.task('stubOffenderSearchInPrison', { prisonId: 'MDI', term: 'Andrew Arnold', results: [andrew] })
+    cy.task('stubPrisonApiMockPrisonerPhoto', andrew.prisonerNumber)
     prisonerSearchPage.submit()
     prisonerSearchPage = Page.verifyOnPage(PrisonerSearchPage)
     cy.task('stubOffenderSearchMockPrisoners')

--- a/integration_tests/e2e/createCompletedReport.cy.ts
+++ b/integration_tests/e2e/createCompletedReport.cy.ts
@@ -144,6 +144,11 @@ context('Creating a completed draft report', () => {
       },
       response: reportWithDetails.prisonersInvolved,
     })
+    cy.task('stubPrisonApiMockPrison', moorland)
+    cy.task('stubIncidentReportingApiUpdateReport', {
+      request: { title: 'Attempted escape from establishment: Arnold A1111AA (Moorland (HMP & YOI))' },
+      report: reportWithDetails, // technically, missing title update
+    })
     addPrisonerInvolvementsPage.submit()
 
     // choose to add no further prisoners

--- a/integration_tests/e2e/involvements/prisoners/add.cy.ts
+++ b/integration_tests/e2e/involvements/prisoners/add.cy.ts
@@ -1,6 +1,7 @@
 import { RelatedObjectUrlSlug } from '../../../../server/data/incidentReportingApi'
 import { mockReport } from '../../../../server/data/testData/incidentReporting'
 import { andrew, barry } from '../../../../server/data/testData/offenderSearch'
+import { moorland } from '../../../../server/data/testData/prisonApi'
 import Page from '../../../pages/page'
 import { AddPrisonerInvolvementsPage, PrisonerInvolvementsPage } from '../../../pages/reports/involvements/prisoners'
 
@@ -36,6 +37,7 @@ context('Add prisoner involvement page', () => {
     cy.signIn()
     cy.task('stubIncidentReportingApiGetReportWithDetailsById', { report: reportWithDetails })
     cy.task('stubOffenderSearchMockPrisoners')
+    cy.task('stubPrisonApiMockPrison', moorland)
     cy.visit(`/reports/${reportWithDetails.id}/prisoners/add/${andrew.prisonerNumber}`)
     addPrisonerInvolvementsPage = Page.verifyOnPage(AddPrisonerInvolvementsPage, 'Andrew Arnold’s')
   })
@@ -95,6 +97,10 @@ context('Add prisoner involvement page', () => {
       },
       response: reportWithDetails.prisonersInvolved, // technically, missing new person
     })
+    cy.task('stubIncidentReportingApiUpdateReport', {
+      request: { title: 'Miscellaneous: Benjamin A2222BB (Moorland (HMP & YOI))' },
+      report: reportWithDetails, // technically, missing title update
+    })
     addPrisonerInvolvementsPage.selectRole('ACTIVE_INVOLVEMENT')
     addPrisonerInvolvementsPage.enterComment('Was there')
     addPrisonerInvolvementsPage.submit()
@@ -115,6 +121,10 @@ context('Add prisoner involvement page', () => {
         comment: '',
       },
       response: reportWithDetails.prisonersInvolved, // technically, missing new person
+    })
+    cy.task('stubIncidentReportingApiUpdateReport', {
+      request: { title: 'Miscellaneous: Benjamin A2222BB (Moorland (HMP & YOI))' },
+      report: reportWithDetails, // technically, missing title update
     })
     addPrisonerInvolvementsPage.selectRole('SUSPECTED_INVOLVED')
     addPrisonerInvolvementsPage.submit()

--- a/integration_tests/e2e/involvements/prisoners/involvements.cy.ts
+++ b/integration_tests/e2e/involvements/prisoners/involvements.cy.ts
@@ -57,6 +57,7 @@ context('Prisoner involvements page', () => {
 
       cy.task('stubIncidentReportingApiGetReportById', { report: reportWithDetails })
       cy.task('stubPrisonApiMockPrisons')
+      cy.task('stubManageKnownUsers')
 
       prisonerInvolvementsPage.selectRadioButton('No')
       prisonerInvolvementsPage.submit()
@@ -67,6 +68,7 @@ context('Prisoner involvements page', () => {
     it('should return to report if skip is chosen', () => {
       cy.task('stubIncidentReportingApiGetReportById', { report: reportWithDetails })
       cy.task('stubPrisonApiMockPrisons')
+      cy.task('stubManageKnownUsers')
 
       prisonerInvolvementsPage.selectRadioButton('Skip for now')
       prisonerInvolvementsPage.submit()
@@ -117,6 +119,7 @@ context('Prisoner involvements page', () => {
 
       cy.task('stubIncidentReportingApiGetReportById', { report: reportWithDetails })
       cy.task('stubPrisonApiMockPrisons')
+      cy.task('stubManageKnownUsers')
 
       prisonerInvolvementsPage.selectRadioButton('No')
       prisonerInvolvementsPage.submit()
@@ -179,6 +182,7 @@ context('Prisoner involvements page', () => {
     it('should return to report if no is chosen', () => {
       cy.task('stubIncidentReportingApiGetReportById', { report: reportWithDetails })
       cy.task('stubPrisonApiMockPrisons')
+      cy.task('stubManageKnownUsers')
 
       prisonerInvolvementsPage.selectRadioButton('No')
       prisonerInvolvementsPage.submit()

--- a/integration_tests/e2e/involvements/prisoners/remove.cy.ts
+++ b/integration_tests/e2e/involvements/prisoners/remove.cy.ts
@@ -1,6 +1,7 @@
 import { RelatedObjectUrlSlug } from '../../../../server/data/incidentReportingApi'
 import { mockReport } from '../../../../server/data/testData/incidentReporting'
 import { barry } from '../../../../server/data/testData/offenderSearch'
+import { moorland } from '../../../../server/data/testData/prisonApi'
 import Page from '../../../pages/page'
 import { PrisonerInvolvementsPage, RemovePrisonerInvolvementsPage } from '../../../pages/reports/involvements/prisoners'
 
@@ -35,6 +36,7 @@ context('Remove prisoner involvement page', () => {
 
     cy.signIn()
     cy.task('stubIncidentReportingApiGetReportWithDetailsById', { report: reportWithDetails })
+    cy.task('stubPrisonApiMockPrison', moorland)
     cy.visit(`/reports/${reportWithDetails.id}/prisoners`)
     Page.verifyOnPage(PrisonerInvolvementsPage).removeLink(0).click()
     removePrisonerInvolvementsPage = Page.verifyOnPage(RemovePrisonerInvolvementsPage, 'A2222BB', 'Barry Benjamin')
@@ -65,6 +67,10 @@ context('Remove prisoner involvement page', () => {
       reportId: reportWithDetails.id,
       index: 1,
       response: [],
+    })
+    cy.task('stubIncidentReportingApiUpdateReport', {
+      request: { title: 'Miscellaneous: Benjamin A2222BB (Moorland (HMP & YOI))' },
+      report: reportWithDetails, // technically, missing title update
     })
 
     removePrisonerInvolvementsPage.selectRadioButton('Yes')

--- a/integration_tests/e2e/involvements/prisoners/search.cy.ts
+++ b/integration_tests/e2e/involvements/prisoners/search.cy.ts
@@ -64,6 +64,8 @@ context('Prisoner search page', () => {
     context('and results were returned', () => {
       beforeEach(() => {
         cy.task('stubOffenderSearchInPrison', { prisonId: 'MDI', term: 'AR', results: [andrew, barry] })
+        cy.task('stubPrisonApiMockPrisonerPhoto', andrew.prisonerNumber)
+        cy.task('stubPrisonApiMockPrisonerPhoto', barry.prisonerNumber)
 
         cy.visit(`/reports/${reportWithDetails.id}/prisoners/search?page=1&global=no&q=AR`)
         prisonerSearchPage = Page.verifyOnPage(PrisonerSearchPage)
@@ -121,6 +123,7 @@ context('Prisoner search page', () => {
     context('and results were returned', () => {
       beforeEach(() => {
         cy.task('stubOffenderSearchGlobally', { prisonerIdentifier: 'A1111', results: [andrew] })
+        cy.task('stubPrisonApiMockPrisonerPhoto', andrew.prisonerNumber)
 
         cy.visit(`/reports/${reportWithDetails.id}/prisoners/search?page=1&global=yes&q=A1111`)
         prisonerSearchPage = Page.verifyOnPage(PrisonerSearchPage)

--- a/integration_tests/e2e/involvements/staff/involvements.cy.ts
+++ b/integration_tests/e2e/involvements/staff/involvements.cy.ts
@@ -57,6 +57,7 @@ context('Staff involvements page', () => {
 
       cy.task('stubIncidentReportingApiGetReportById', { report: reportWithDetails })
       cy.task('stubPrisonApiMockPrisons')
+      cy.task('stubManageKnownUsers')
 
       staffInvolvementsPage.selectRadioButton('No')
       staffInvolvementsPage.submit()
@@ -67,6 +68,7 @@ context('Staff involvements page', () => {
     it('should return to report if skip is chosen', () => {
       cy.task('stubIncidentReportingApiGetReportById', { report: reportWithDetails })
       cy.task('stubPrisonApiMockPrisons')
+      cy.task('stubManageKnownUsers')
 
       staffInvolvementsPage.selectRadioButton('Skip for now')
       staffInvolvementsPage.submit()
@@ -117,6 +119,7 @@ context('Staff involvements page', () => {
 
       cy.task('stubIncidentReportingApiGetReportById', { report: reportWithDetails })
       cy.task('stubPrisonApiMockPrisons')
+      cy.task('stubManageKnownUsers')
 
       staffInvolvementsPage.selectRadioButton('No')
       staffInvolvementsPage.submit()
@@ -177,6 +180,7 @@ context('Staff involvements page', () => {
     it('should return to report if no is chosen', () => {
       cy.task('stubIncidentReportingApiGetReportById', { report: reportWithDetails })
       cy.task('stubPrisonApiMockPrisons')
+      cy.task('stubManageKnownUsers')
 
       staffInvolvementsPage.selectRadioButton('No')
       staffInvolvementsPage.submit()

--- a/integration_tests/mockApis/prisonApi.ts
+++ b/integration_tests/mockApis/prisonApi.ts
@@ -79,6 +79,26 @@ export default {
     }),
 
   /**
+   * Stub a plaholder JPEG photo
+   */
+  stubPrisonApiMockPrisonerPhoto: (prisonerNumber: string): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `/prisonApi/api/bookings/offenderNo/${prisonerNumber}/image/data`,
+        queryParameters: {
+          fullSizeImage: { equalTo: 'false' },
+        },
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'image/jpeg' },
+        base64Body:
+          '/9j/4AAQSkZJRgABAQEBLAEsAAD/2wCEAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBABAwMDBAMECAQECBALCQsQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEP/AABEIAAEAAQMBEQACEQEDEQH/xABLAAEAAAAAAAAAAAAAAAAAAAAIEAEAAAAAAAAAAAAAAAAAAAAAAQEBAAAAAAAAAAAAAAAAAAAGCBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AVqFyt//Z',
+      },
+    }),
+
+  /**
    * Stub getting details for all mock staff
    */
   stubPrisonApiMockStaff: (): Promise<SuperAgentResponse[]> =>
@@ -97,6 +117,10 @@ export default {
         }),
       ),
     ),
+
+  /**
+   * Health check
+   */
   stubPrisonApiPing: (): SuperAgentRequest =>
     stubFor({
       request: {

--- a/server/data/prisonApi.ts
+++ b/server/data/prisonApi.ts
@@ -141,12 +141,13 @@ export class PrisonApi extends RestClient {
     })
   }
 
-  async getPrison(prisonId: string, activeOnly = true): Promise<Agency | null> {
+  /** Look up agency details (can be a prison, a PECS region, etc) */
+  async getPrison(prisonId: string, activeOnly = true, agencyType?: AgencyType): Promise<Agency | null> {
     try {
       return await this.get<Agency>(
         {
           path: `/api/agencies/${encodeURIComponent(prisonId)}`,
-          query: { activeOnly: activeOnly.toString() },
+          query: { activeOnly: activeOnly.toString(), agencyType },
         },
         asSystem(),
       )
@@ -160,6 +161,7 @@ export class PrisonApi extends RestClient {
     }
   }
 
+  /** List all prisons */
   async getPrisons(): Promise<Record<string, Agency>> {
     const prisons = await this.get<Agency[]>(
       {
@@ -172,6 +174,7 @@ export class PrisonApi extends RestClient {
     return prisons.reduce((prev, prisonInfo) => ({ ...prev, [prisonInfo.agencyId]: prisonInfo }), {})
   }
 
+  /** List all PECS regions */
   async getPecsRegions(activeOnly = true): Promise<Record<string, Agency>> {
     return this.getAgencies(AgencyType.PECS, activeOnly)
   }

--- a/server/routes/reports/viewReport.ts
+++ b/server/routes/reports/viewReport.ts
@@ -2,7 +2,7 @@ import { Router } from 'express'
 import { MethodNotAllowed } from 'http-errors'
 
 import logger from '../../../logger'
-import { regenerateTitleForReport } from '../../services/reportTitle'
+import { updateReportTitle } from '../../services/reportTitle'
 import {
   aboutTheType,
   prisonerInvolvementOutcomes,
@@ -185,15 +185,8 @@ export function viewReportRouter(): Router {
             // can submit action
             try {
               if (userAction === 'REQUEST_REVIEW') {
-                // TODO: regeneration will be moved elsewhere
-                // TODO: PECS regions need a different lookup
-                const newTitle = regenerateTitleForReport(
-                  report,
-                  prisonsLookup[report.location].description || report.location,
-                )
-                await incidentReportingApi.updateReport(report.id, {
-                  title: newTitle,
-                })
+                // TODO: update for requesting duplicate/not-reportable?
+                await updateReportTitle(res)
               }
 
               if (transition.postCorrectionRequest) {

--- a/server/services/reportTitle.test.ts
+++ b/server/services/reportTitle.test.ts
@@ -1,21 +1,67 @@
+import { setImmediate } from 'node:timers/promises'
+
+import type express from 'express'
+
 import { convertReportDates } from '../data/incidentReportingApiUtils'
-import { mockReport } from '../data/testData/incidentReporting'
+import { mockErrorResponse, mockReport } from '../data/testData/incidentReporting'
 import { andrew } from '../data/testData/offenderSearch'
-import { newReportTitle, regenerateTitleForReport } from './reportTitle'
+import { moorland } from '../data/testData/prisonApi'
+import { mockThrownError } from '../data/testData/thrownErrors'
+import { fallibleUpdateReportTitle, newReportTitle, regenerateTitleForReport, updateReportTitle } from './reportTitle'
 
-describe('Report title generation', () => {
-  it('should make a title for a new report from an incident type and location description', () => {
-    let title = newReportTitle('FIND_6', 'Moorland (HMP & YOI)')
-    expect(title).toEqual('Find of illicit items (Moorland (HMP & YOI))')
+describe('Report titles', () => {
+  describe('Generation', () => {
+    it('should make a title for a new report from an incident type and location description', () => {
+      let title = newReportTitle('FIND_6', 'Moorland (HMP & YOI)')
+      expect(title).toEqual('Find of illicit items (Moorland (HMP & YOI))')
 
-    title = newReportTitle('MISCELLANEOUS_1', 'Leeds (HMP)')
-    expect(title).toEqual('Miscellaneous (Leeds (HMP))')
+      title = newReportTitle('MISCELLANEOUS_1', 'Leeds (HMP)')
+      expect(title).toEqual('Miscellaneous (Leeds (HMP))')
 
-    title = newReportTitle('ATTEMPTED_ESCAPE_FROM_PRISON_1', 'PECS South')
-    expect(title).toEqual('Attempted escape from establishment (PECS South)')
+      title = newReportTitle('ATTEMPTED_ESCAPE_FROM_PRISON_1', 'PECS South')
+      expect(title).toEqual('Attempted escape from establishment (PECS South)')
+    })
+
+    it('should make a title from an existing report without prisoner involvements', () => {
+      const report = convertReportDates(
+        mockReport({
+          type: 'FIND_6',
+          reportReference: '6544',
+          reportDateAndTime: new Date(),
+          withDetails: true,
+        }),
+      )
+      report.prisonersInvolved = []
+      const title = regenerateTitleForReport(report, 'Moorland (HMP & YOI)')
+      expect(title).toEqual('Find of illicit items (Moorland (HMP & YOI))')
+    })
+
+    it('should make a title from an existing report with prisoner involvements', () => {
+      const report = convertReportDates(
+        mockReport({
+          type: 'MISCELLANEOUS_1',
+          location: 'LEI',
+          reportReference: '6544',
+          reportDateAndTime: new Date(),
+          withDetails: true,
+        }),
+      )
+      report.prisonersInvolved = [
+        {
+          prisonerNumber: andrew.prisonerNumber,
+          firstName: andrew.firstName,
+          lastName: andrew.lastName,
+          prisonerRole: 'IMPEDED_STAFF',
+          outcome: 'LOCAL_INVESTIGATION',
+          comment: 'Some comments',
+        },
+      ]
+      const title = regenerateTitleForReport(report, 'Leeds (HMP)')
+      expect(title).toEqual('Miscellaneous: Arnold A1111AA (Leeds (HMP))')
+    })
   })
 
-  it('should make a title from an existing report without prisoner involvements', () => {
+  describe('Updates', () => {
     const report = convertReportDates(
       mockReport({
         type: 'FIND_6',
@@ -25,31 +71,100 @@ describe('Report title generation', () => {
       }),
     )
     report.prisonersInvolved = []
-    const title = regenerateTitleForReport(report, 'Moorland (HMP & YOI)')
-    expect(title).toEqual('Find of illicit items (Moorland (HMP & YOI))')
-  })
+    Object.freeze(report)
 
-  it('should make a title from an existing report with prisoner involvements', () => {
-    const report = convertReportDates(
-      mockReport({
-        type: 'MISCELLANEOUS_1',
-        location: 'LEI',
-        reportReference: '6544',
-        reportDateAndTime: new Date(),
-        withDetails: true,
-      }),
-    )
-    report.prisonersInvolved = [
-      {
-        prisonerNumber: andrew.prisonerNumber,
-        firstName: andrew.firstName,
-        lastName: andrew.lastName,
-        prisonerRole: 'IMPEDED_STAFF',
-        outcome: 'LOCAL_INVESTIGATION',
-        comment: 'Some comments',
+    const updateReport = jest.fn()
+    const getPrison = jest.fn()
+
+    function mockResponse(): express.Response {
+      return {
+        locals: {
+          report,
+          apis: {
+            incidentReportingApi: { updateReport },
+            prisonApi: { getPrison },
+          },
+        },
+      } as unknown as express.Response
+    }
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    const updateFunctions = [
+      // if update fails, promise is rejected
+      { type: 'infallible', updateFunction: updateReportTitle, fallible: false },
+      // no promise is returned and failing update throws no error
+      { type: 'fallible', updateFunction: fallibleUpdateReportTitle, fallible: true },
+    ] as const
+
+    it.each(updateFunctions)('should be saved successfully with $type update', async ({ updateFunction }) => {
+      getPrison.mockResolvedValueOnce(moorland)
+      updateReport.mockResolvedValueOnce(report) // NB: response is ignored
+
+      const res = mockResponse()
+      await updateFunction(res)
+
+      await setImmediate() // await asynchronous function (ie. fallible one)
+      expect(getPrison).toHaveBeenCalledWith('MDI', false)
+      expect(updateReport).toHaveBeenCalledWith(report.id, { title: 'Find of illicit items (Moorland (HMP & YOI))' })
+    })
+
+    it.each(updateFunctions)(
+      'should be saved successfully with $type update when location is not found',
+      async ({ updateFunction }) => {
+        getPrison.mockResolvedValueOnce(null)
+        updateReport.mockResolvedValueOnce(report) // NB: response is ignored
+
+        const res = mockResponse()
+        await updateFunction(res)
+
+        await setImmediate() // await asynchronous function (ie. fallible one)
+        expect(getPrison).toHaveBeenCalledWith('MDI', false)
+        expect(updateReport).toHaveBeenCalledWith(report.id, { title: 'Find of illicit items (MDI)' })
       },
-    ]
-    const title = regenerateTitleForReport(report, 'Leeds (HMP)')
-    expect(title).toEqual('Miscellaneous: Arnold A1111AA (Leeds (HMP))')
+    )
+
+    it.each(updateFunctions)(
+      'should be saved successfully with $type update when location lookup fails',
+      async ({ updateFunction }) => {
+        const error = mockThrownError(mockErrorResponse({ status: 500, message: 'External problem' }), 500)
+        getPrison.mockRejectedValueOnce(error)
+        updateReport.mockResolvedValueOnce(report) // NB: response is ignored
+
+        const res = mockResponse()
+        await updateFunction(res)
+
+        await setImmediate() // await asynchronous function (ie. fallible one)
+        expect(getPrison).toHaveBeenCalledWith('MDI', false)
+        expect(updateReport).toHaveBeenCalledWith(report.id, { title: 'Find of illicit items (MDI)' })
+      },
+    )
+
+    it('should fail on infallible update if title cannot be saved', async () => {
+      getPrison.mockResolvedValueOnce(moorland)
+      const error = mockThrownError(mockErrorResponse({ status: 500, message: 'External problem' }), 500)
+      updateReport.mockRejectedValueOnce(error)
+
+      const res = mockResponse()
+      await expect(updateReportTitle(res)).rejects.toThrow()
+
+      expect(getPrison).toHaveBeenCalledWith('MDI', false)
+      expect(updateReport).toHaveBeenCalledWith(report.id, { title: 'Find of illicit items (Moorland (HMP & YOI))' })
+    })
+
+    it('should still proceed on fallible update if title cannot be saved', async () => {
+      getPrison.mockResolvedValueOnce(moorland)
+      const error = mockThrownError(mockErrorResponse({ status: 500, message: 'External problem' }), 500)
+      updateReport.mockRejectedValueOnce(error)
+
+      const res = mockResponse()
+      fallibleUpdateReportTitle(res) // note no error is thrown
+
+      await setImmediate() // await asynchronous function
+      expect(getPrison).toHaveBeenCalledWith('MDI', false)
+      expect(updateReport).toHaveBeenCalledWith(report.id, { title: 'Find of illicit items (Moorland (HMP & YOI))' })
+    })
   })
 })

--- a/server/services/reportTitle.ts
+++ b/server/services/reportTitle.ts
@@ -1,4 +1,8 @@
+import type express from 'express'
+
+import logger from '../../logger'
 import type { ReportWithDetails } from '../data/incidentReportingApi'
+import { reportHasDetails } from '../data/incidentReportingApiUtils'
 import { getTypeDetails, type Type } from '../reportConfiguration/constants'
 import { convertToTitleCase } from '../utils/utils'
 
@@ -23,4 +27,42 @@ export function regenerateTitleForReport(report: ReportWithDetails, locationDesc
     ? `: ${report.prisonersInvolved.map(prisoner => `${convertToTitleCase(prisoner.lastName)} ${prisoner.prisonerNumber}`).join(', ')}`
     : ''
   return `${typeDetails.description}${prisonerInvolvement} (${locationDescription})`
+}
+
+/** Updates report title */
+export async function updateReportTitle(res: express.Response): Promise<void> {
+  const { incidentReportingApi, prisonApi } = res.locals.apis
+  const { report } = res.locals
+
+  if (!reportHasDetails(report)) {
+    throw new Error('implementation error: regenerateTitleForReport should only be used on report with details')
+  }
+
+  const locationDescription = await prisonApi
+    .getPrison(report.location, false)
+    .then(prison => prison?.description || report.location)
+    // fall back to code
+    .catch(() => report.location)
+
+  const newTitle = regenerateTitleForReport(report, locationDescription)
+  return incidentReportingApi.updateReport(report.id, { title: newTitle }).then(() => {
+    logger.info('Title of report %s updated', report.id)
+  })
+}
+
+/**
+ * Asynchronously updates report title.
+ * NB: errors are logged but ignored!
+ * This is to facilitate a different action that should not be cancelled if prison lookup or title update fails.
+ * The title will again be regenerated on submission of the report, when such errors are not ignored.
+ */
+export function fallibleUpdateReportTitle(res: express.Response): void {
+  const {
+    report: { id: reportId },
+  } = res.locals
+
+  updateReportTitle(res).catch(e => {
+    // NB: errors are logged but ignored!
+    logger.error(e, 'Failed to update title of report %s, ignoring error: %j', reportId, e)
+  })
 }


### PR DESCRIPTION
Report titles are determined by prisoner involvements so need to be regenerated when they are added or removed.

Since at that point, the change in prisoner involvement is more important to save successfully, the update of title is allowed to fail. This is because when a report is submitted, the title is once again regenerated; at which point it isn’t allowed to fail.