### PR TITLE
IR-1054: Regenerate report title when type changes

### DIFF
--- a/integration_tests/e2e/changeType.cy.ts
+++ b/integration_tests/e2e/changeType.cy.ts
@@ -1,4 +1,5 @@
 import { mockReport } from '../../server/data/testData/incidentReporting'
+import { moorland } from '../../server/data/testData/prisonApi'
 import Page from '../pages/page'
 import { ChangeTypeConfirmationPage, TypePage } from '../pages/reports/type'
 import { PrisonerInvolvementsPage } from '../pages/reports/involvements/prisoners'
@@ -9,7 +10,7 @@ context('Change incident type', () => {
     type: 'DISORDER_2',
     reportReference: '6544',
     reportDateAndTime: now,
-    withDetails: true, // needed when redirecting back to view page
+    withDetails: true,
   })
   reportWithDetails.prisonersInvolved = []
   reportWithDetails.prisonerInvolvementDone = false
@@ -22,7 +23,8 @@ context('Change incident type', () => {
     cy.resetBasicStubs()
 
     cy.signIn()
-    cy.task('stubIncidentReportingApiGetReportById', { report: reportWithDetails })
+    cy.task('stubIncidentReportingApiGetReportWithDetailsById', { report: reportWithDetails })
+    cy.task('stubPrisonApiMockPrison', moorland)
     cy.visit(`/reports/${reportWithDetails.id}/change-type`)
   })
 
@@ -166,9 +168,19 @@ context('Change incident type', () => {
 
     cy.task('stubIncidentReportingApiChangeReportType', {
       request: { newType: 'MISCELLANEOUS_1' },
-      report: reportWithDetails,
+      report: {
+        ...reportWithDetails,
+        type: 'MISCELLANEOUS_1',
+      },
     })
-    cy.task('stubIncidentReportingApiGetReportWithDetailsById', { report: reportWithDetails })
+    cy.task('stubIncidentReportingApiUpdateReport', {
+      request: { title: 'Disorder (Moorland (HMP & YOI))' }, // NB: still using old type because wiremock stubs are not changed mid-request
+      report: {
+        ...reportWithDetails,
+        type: 'MISCELLANEOUS_1',
+        title: 'Disorder (Moorland (HMP & YOI))',
+      },
+    })
     cy.task('stubPrisonApiMockPrisons')
     cy.task('stubManageKnownUsers')
 

--- a/integration_tests/e2e/involvements/prisoners/edit.cy.ts
+++ b/integration_tests/e2e/involvements/prisoners/edit.cy.ts
@@ -1,6 +1,7 @@
 import { RelatedObjectUrlSlug } from '../../../../server/data/incidentReportingApi'
 import { mockReport } from '../../../../server/data/testData/incidentReporting'
 import { barry } from '../../../../server/data/testData/offenderSearch'
+import { moorland } from '../../../../server/data/testData/prisonApi'
 import Page from '../../../pages/page'
 import { EditPrisonerInvolvementPage, PrisonerInvolvementsPage } from '../../../pages/reports/involvements/prisoners'
 
@@ -35,6 +36,7 @@ context('Edit prisoner involvement page', () => {
 
     cy.signIn()
     cy.task('stubIncidentReportingApiGetReportWithDetailsById', { report: reportWithDetails })
+    cy.task('stubPrisonApiMockPrison', moorland)
     cy.visit(`/reports/${reportWithDetails.id}/prisoners`)
     Page.verifyOnPage(PrisonerInvolvementsPage).editLink(0).click()
     editPrisonerInvolvementPage = Page.verifyOnPage(EditPrisonerInvolvementPage, 'Barry Benjamin’s')
@@ -97,6 +99,10 @@ context('Edit prisoner involvement page', () => {
       },
       response: reportWithDetails.prisonersInvolved, // technically, missing update
     })
+    cy.task('stubIncidentReportingApiUpdateReport', {
+      request: { title: 'Miscellaneous: Benjamin A2222BB (Moorland (HMP & YOI))' },
+      report: reportWithDetails, // technically, missing title update
+    })
     editPrisonerInvolvementPage.selectRole('ACTIVE_INVOLVEMENT')
     editPrisonerInvolvementPage.enterComment('Was there')
     editPrisonerInvolvementPage.submit()
@@ -115,6 +121,10 @@ context('Edit prisoner involvement page', () => {
         comment: '',
       },
       response: reportWithDetails.prisonersInvolved, // technically, missing update
+    })
+    cy.task('stubIncidentReportingApiUpdateReport', {
+      request: { title: 'Miscellaneous: Benjamin A2222BB (Moorland (HMP & YOI))' },
+      report: reportWithDetails, // technically, missing title update
     })
     editPrisonerInvolvementPage.selectRole('SUSPECTED_INVOLVED')
     editPrisonerInvolvementPage.commentBox.clear()


### PR DESCRIPTION
Adds to changes in #496:
- when type is changed, the title should definitely be regenerated
- when a prisoner involvement is updated, technically the title remains the same but seems prudent to keep the code more consistent with respect to prisoner involvements