### PR TITLE
IR-1054: Report validity

### DIFF
--- a/server/routes/reports/viewReport.test.ts
+++ b/server/routes/reports/viewReport.test.ts
@@ -27,6 +27,8 @@ let incidentReportingApi: jest.Mocked<IncidentReportingApi>
 let userService: jest.Mocked<UserService>
 let prisonApi: jest.Mocked<PrisonApi>
 
+const { validateReport } = reportValidity as jest.Mocked<typeof import('../../data/reportValidity')>
+
 beforeEach(() => {
   userService = UserService.prototype as jest.Mocked<UserService>
   app = appWithAllRoutes({ services: { userService } })
@@ -43,8 +45,7 @@ beforeEach(() => {
   }
   prisonApi.getPrisons.mockResolvedValue(prisons)
 
-  // ban checking report validity – it (currently) should only happen on requestReview action
-  ;(reportValidity as jest.Mocked<typeof import('../../data/reportValidity')>).validateReport.mockImplementation(() => {
+  validateReport.mockImplementationOnce(() => {
     throw new Error('should not be called')
   })
 })
@@ -52,6 +53,13 @@ beforeEach(() => {
 afterEach(() => {
   jest.resetAllMocks()
 })
+
+function makeReportValid() {
+  validateReport.mockReset()
+  validateReport.mockImplementationOnce(function* generator() {
+    /* empty */
+  })
+}
 
 // TODO: links need checking. especially when they appear and when they hide
 
@@ -544,6 +552,7 @@ describe('View report page', () => {
   ])('“Check your answers” title', ({ userType, user, checkAnswersStatuses }) => {
     beforeEach(() => {
       app = appWithAllRoutes({ services: { userService }, userSupplier: () => user })
+      makeReportValid()
     })
 
     it.each(

--- a/server/routes/reports/viewReport.ts
+++ b/server/routes/reports/viewReport.ts
@@ -254,6 +254,17 @@ export function viewReportRouter(): Router {
             href: '#userAction',
           })
         }
+      } else if (
+        !report.createdInNomis &&
+        reportTransitions.CLOSE?.mustBeValid &&
+        allowedActionsNeedingForm.has('CLOSE')
+      ) {
+        // check DPS report is valid and hide “Close” option otherwise; reports made in NOMIS do not get validated
+        // TODO: conflicts with PECS journey
+        const errorGenerator = validateReport(report, reportConfig, questionProgressSteps, reportUrl)
+        if (errorGenerator.next().value) {
+          allowedActionsNeedingForm.delete('CLOSE')
+        }
       }
 
       // Gather notification banner entries if they exist


### PR DESCRIPTION
1) should not be checked for reports created in NOMIS because there are potentially thousands that would suddenly become invalid and require amendments before they can be closed. We can be conservative and only fully validate new reports so that data wardens won’t need to send many back. In fact, data wardens aren’t warned that a report is invalid and that is why they cannot close it.
2) hide “Close” option from data wardens when a DPS report is invalid (alas, without explanation)