### PR TITLE
Undo IR-1040: Remove “Post-incident update” status

### DIFF
--- a/server/reportConfiguration/constants/statuses.ts
+++ b/server/reportConfiguration/constants/statuses.ts
@@ -10,6 +10,7 @@ export const statuses = [
   { code: 'NEEDS_UPDATING', description: 'Needs updating', nomisCode: 'INREQ' },
   { code: 'UPDATED', description: 'Updated', nomisCode: 'INAME' },
   { code: 'CLOSED', description: 'Closed', nomisCode: 'CLOSE' },
+  { code: 'POST_INCIDENT_UPDATE', description: 'Post-incident update', nomisCode: 'PIU' },
   { code: 'DUPLICATE', description: 'Duplicate', nomisCode: 'DUP' },
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore because typescript treats nomisCode as `any`

--- a/server/reportConfiguration/constants/workLists.ts
+++ b/server/reportConfiguration/constants/workLists.ts
@@ -25,3 +25,6 @@ export const workListMapping = workLists.reduce(
 
 /** Work list codes */
 export const workListCodes = workLists.map(workList => workList.code)
+
+// TODO: map these final statuses appropriately if necessary – not needed yet and they will eventually be removed from NOMIS
+// { code: 'POST_INCIDENT_UPDATE', description: 'Post-incident update', nomisCode: 'PIU' },

--- a/server/routes/reports/actions/actionReport.test.ts
+++ b/server/routes/reports/actions/actionReport.test.ts
@@ -505,7 +505,8 @@ describe('Actioning reports', () => {
             const noActionsPermitted =
               (userType === 'reporting officers' && status === 'ON_HOLD') ||
               (userType === 'data wardens' && status === 'DRAFT') ||
-              userType === 'HQ viewers'
+              userType === 'HQ viewers' ||
+              status === 'POST_INCIDENT_UPDATE'
             if (noActionsPermitted) {
               expect(res.text).toContain('You do not have permission to action this report')
             } else {

--- a/server/routes/reports/actions/reopen/index.test.ts
+++ b/server/routes/reports/actions/reopen/index.test.ts
@@ -172,13 +172,16 @@ describe('Reopening a report', () => {
       shouldRedirectToReportPage()
     })
 
-    describe.each(['DRAFT', 'ON_HOLD', 'NEEDS_UPDATING', 'REOPENED'] as const)('if the status is %s', status => {
-      beforeEach(() => {
-        mockedReport.status = status
-      })
+    describe.each(['DRAFT', 'ON_HOLD', 'NEEDS_UPDATING', 'POST_INCIDENT_UPDATE', 'REOPENED'] as const)(
+      'if the status is %s',
+      status => {
+        beforeEach(() => {
+          mockedReport.status = status
+        })
 
-      shouldNotBeAllowed()
-    })
+        shouldNotBeAllowed()
+      },
+    )
   })
 
   describe('by data wardens', () => {
@@ -202,7 +205,7 @@ describe('Reopening a report', () => {
       shouldRedirectToReportPage()
     })
 
-    describe.each(['DRAFT', 'AWAITING_REVIEW', 'ON_HOLD', 'UPDATED', 'WAS_CLOSED'] as const)(
+    describe.each(['DRAFT', 'AWAITING_REVIEW', 'ON_HOLD', 'UPDATED', 'POST_INCIDENT_UPDATE', 'WAS_CLOSED'] as const)(
       'if the status is %s',
       status => {
         beforeEach(() => {

--- a/server/routes/reports/actions/requestRemoval/index.test.ts
+++ b/server/routes/reports/actions/requestRemoval/index.test.ts
@@ -398,6 +398,7 @@ describe('Requesting removal of a report', () => {
       'ON_HOLD',
       'UPDATED',
       'CLOSED',
+      'POST_INCIDENT_UPDATE',
       'DUPLICATE',
       'NOT_REPORTABLE',
       'WAS_CLOSED',

--- a/server/routes/reports/details/changeType.test.ts
+++ b/server/routes/reports/details/changeType.test.ts
@@ -65,20 +65,25 @@ describe('Changing incident type', () => {
       })
   })
 
-  it.each(['UPDATED', 'ON_HOLD', 'WAS_CLOSED', 'DUPLICATE', 'NOT_REPORTABLE', 'CLOSED'] as const)(
-    'should not be allowed if report has status %s',
-    status => {
-      mockedReport.status = status
+  it.each([
+    'UPDATED',
+    'ON_HOLD',
+    'WAS_CLOSED',
+    'DUPLICATE',
+    'NOT_REPORTABLE',
+    'CLOSED',
+    'POST_INCIDENT_UPDATE',
+  ] as const)('should not be allowed if report has status %s', status => {
+    mockedReport.status = status
 
-      return agent
-        .get(confirmationUrl)
-        .expect(302)
-        .expect(res => {
-          expect(res.redirect).toBe(true)
-          expect(res.header.location).toEqual('/sign-out')
-        })
-    },
-  )
+    return agent
+      .get(confirmationUrl)
+      .expect(302)
+      .expect(res => {
+        expect(res.redirect).toBe(true)
+        expect(res.header.location).toEqual('/sign-out')
+      })
+  })
 
   it.each(['DRAFT', 'AWAITING_REVIEW', 'NEEDS_UPDATING', 'REOPENED'] as const)(
     'should show a confirmation page first if report status is %s',


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-incident-reporting#515
Depends ministryofjustice/hmpps-incident-reporting-api#378