### PR TITLE
Renovate: Fix DPR rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,7 @@
     {
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["@ministryofjustice/hmpps-digital-prison-reporting-frontend"],
       "groupName": "hmpps-digital-prison-reporting-frontend",
       "groupSlug": "hmpps-digital-prison-reporting-frontend"
     },


### PR DESCRIPTION
It was missing the `matchPackageNames`!