### PR TITLE
Added new css for status cell in dashboard table to remove bottom margin

### DIFF
--- a/assets/scss/page/_dashboard.scss
+++ b/assets/scss/page/_dashboard.scss
@@ -35,3 +35,9 @@
   -webkit-box-orient: vertical;
   box-orient: vertical;
 }
+
+.app-dashboard__status-cell {
+  .govuk-details{
+    margin-bottom: 0;
+  }
+}

--- a/server/views/pages/dashboard/index.njk
+++ b/server/views/pages/dashboard/index.njk
@@ -189,14 +189,16 @@
       {% endset %}
 
       {% set statusHtml %}
-        {% if report.status in statusHints %}
-          {{ govukDetails({
-            summaryText: statusesDescriptions[report.status] or report.status,
-            text: statusHints[report.status]
-          }) }}
-        {% else %}
-          statusesDescriptions[report.status] or report.status
-        {% endif %}
+        <div class="app-dashboard__status-cell">
+          {% if report.status in statusHints %}
+            {{ govukDetails({
+              summaryText: statusesDescriptions[report.status] or report.status,
+              text: statusHints[report.status]
+            }) }}
+          {% else %}
+            statusesDescriptions[report.status] or report.status
+          {% endif %}
+        </div>
       {% endset %}
 
       {% if showLocationFilter %}


### PR DESCRIPTION
Removes the bottom space in the expanded status details cell in the dashboard table. 

As per ticket IR-1176

[IR-1176]: https://dsdmoj.atlassian.net/browse/IR-1176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ