### PR TITLE
Adding last updated field to top of view report page

### DIFF
--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -2,7 +2,12 @@ import type { Response as SuperAgentResponse, SuperAgentRequest } from 'superage
 
 import { stubFor } from './wiremock'
 import type { Staff } from '../../server/data/prisonApi'
-import { mockUser, mockSharedUser, mockPrisonUserSearchResult } from '../../server/data/testData/manageUsers'
+import {
+  mockUser,
+  mockSharedUser,
+  mockSharedUser2,
+  mockPrisonUserSearchResult,
+} from '../../server/data/testData/manageUsers'
 import { staffBarry, staffMary } from '../../server/data/testData/prisonApi'
 import ManageUsersApiClient, {
   type User,
@@ -35,7 +40,7 @@ export default {
       name?: string
       firstName?: string
       lastName?: string
-    }[] = [mockSharedUser, staffBarry, staffMary],
+    }[] = [mockSharedUser, mockSharedUser2, staffBarry, staffMary],
   ): Promise<SuperAgentResponse[]> =>
     Promise.all(
       users.map(user =>

--- a/integration_tests/pages/reports/report.ts
+++ b/integration_tests/pages/reports/report.ts
@@ -14,6 +14,10 @@ export class ReportPage extends Page {
     return cy.get('[data-qa=report-reported-by]')
   }
 
+  get updatedBy(): PageElement<HTMLSpanElement> {
+    return cy.get('[data-qa=report-updated-by]')
+  }
+
   get status(): PageElement<HTMLSpanElement> {
     return cy.get('[data-qa=report-status]')
   }

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -25,6 +25,8 @@ interface MockReportConfig {
   status?: Status
   type?: Type
   reportingUsername?: string
+  modifyingUsername?: string
+  modifiedDateAndTime?: Date
   withAddendums?: boolean
 }
 
@@ -41,6 +43,8 @@ export function mockReport({
   status = 'DRAFT',
   type = 'FIND_6',
   reportingUsername = 'user1',
+  modifyingUsername = 'user1',
+  modifiedDateAndTime = reportDateAndTime,
   withDetails = false,
   withAddendums = false,
 }: MockReportConfig & { withDetails?: boolean }): DatesAsStrings<ReportBasic | ReportWithDetails> {
@@ -61,8 +65,8 @@ export function mockReport({
     reportedAt: format.isoDateTime(reportDateAndTime),
     status,
     createdAt: format.isoDateTime(reportDateAndTime),
-    modifiedAt: format.isoDateTime(reportDateAndTime),
-    modifiedBy: reportingUsername,
+    modifiedAt: format.isoDateTime(modifiedDateAndTime),
+    modifiedBy: modifyingUsername,
     createdInNomis,
     lastModifiedInNomis: createdInNomis,
     duplicatedReportId: null,

--- a/server/data/testData/manageUsers.ts
+++ b/server/data/testData/manageUsers.ts
@@ -13,6 +13,9 @@ export function mockUser(username: string, name: string): User {
 /** The user who is performing actions during testing */
 export const mockSharedUser: User = mockUser('user1', 'John Smith')
 
+/** The user who is modifying reports during testing */
+export const mockSharedUser2: User = mockUser('user2', 'Mary Johnson')
+
 /** Same user as above returned from prison-specific endpoint that splits first names from surnames */
 export const mockPrisonUser: PrisonUser = {
   username: 'user1',

--- a/server/routes/reports/viewReport.ts
+++ b/server/routes/reports/viewReport.ts
@@ -55,7 +55,7 @@ export function viewReportRouter(): Router {
       const { permissions, allowedActions, reportConfig, reportUrl, questionProgress } = res.locals
       const { userType } = permissions
 
-      const usernames = [report.reportedBy]
+      const usernames = [report.reportedBy, report.modifiedBy]
       if (report.correctionRequests?.length) {
         usernames.push(...report.correctionRequests.map(correctionRequest => correctionRequest.correctionRequestedBy))
       }

--- a/server/routes/reports/viewReport.ts
+++ b/server/routes/reports/viewReport.ts
@@ -55,7 +55,10 @@ export function viewReportRouter(): Router {
       const { permissions, allowedActions, reportConfig, reportUrl, questionProgress } = res.locals
       const { userType } = permissions
 
-      const usernames = [report.reportedBy, report.modifiedBy]
+      const usernames = [report.reportedBy]
+      if (report.reportedBy !== report.modifiedBy) {
+        usernames.push(report.modifiedBy)
+      }
       if (report.correctionRequests?.length) {
         usernames.push(...report.correctionRequests.map(correctionRequest => correctionRequest.correctionRequestedBy))
       }

--- a/server/testutils/fakeClock.ts
+++ b/server/testutils/fakeClock.ts
@@ -3,3 +3,5 @@
  * 2023-12-05T12:34:56.000Z
  */
 export const now = new Date(2023, 11, 5, 12, 34, 56)
+
+export const dayLater = new Date(2023, 11, 6, 12, 34, 56)

--- a/server/views/pages/reports/view/index.njk
+++ b/server/views/pages/reports/view/index.njk
@@ -68,6 +68,9 @@
     <strong>Reported by:</strong>
     <span data-qa="report-reported-by">{{ usersLookup[report.reportedBy].name or report.reportedBy }} on {{ report.reportedAt | longDate }}</span>
     <br />
+    <strong>Last updated by:</strong>
+    <span data-qa="report-reported-by">{{ usersLookup[report.modifiedBy].name or report.modifiedBy }} on {{ report.modifiedAt | longDate }}</span>
+    <br />
     <strong>Status:</strong>
     <span data-qa="report-status">{{ statusesDescriptions[report.status] or report.status }}</span>
   </p>

--- a/server/views/pages/reports/view/index.njk
+++ b/server/views/pages/reports/view/index.njk
@@ -69,7 +69,7 @@
     <span data-qa="report-reported-by">{{ usersLookup[report.reportedBy].name or report.reportedBy }} on {{ report.reportedAt | longDate }}</span>
     <br />
     <strong>Last updated by:</strong>
-    <span data-qa="report-reported-by">{{ usersLookup[report.modifiedBy].name or report.modifiedBy }} on {{ report.modifiedAt | longDate }}</span>
+    <span data-qa="report-updated-by">{{ usersLookup[report.modifiedBy].name or report.modifiedBy }} on {{ report.modifiedAt | longDate }}</span>
     <br />
     <strong>Status:</strong>
     <span data-qa="report-status">{{ statusesDescriptions[report.status] or report.status }}</span>


### PR DESCRIPTION
Adding the entry at the top of the view report page to show who last made a change to the report and when. It was decided by Steve to leave the time off for now to keep in line with the existing reported by entry [IR-1175]