### PR TITLE
IR-1167: PECS reports

### DIFF
--- a/integration_tests/e2e/journeys/actionPecsReport.cy.ts
+++ b/integration_tests/e2e/journeys/actionPecsReport.cy.ts
@@ -1,0 +1,102 @@
+import type { ReportWithDetails } from '../../../server/data/incidentReportingApi'
+import { pecsNorth } from '../../../server/data/testData/prisonApi'
+import { mockDataWarden } from '../../../server/data/testData/users'
+import { now } from '../../../server/testutils/fakeClock'
+import Page from '../../pages/page'
+import { ReportPage } from '../../pages/reports/report'
+import { validReport } from './validReport'
+import { actionTestCase } from './actionReport'
+
+describe('Actioning reopened PECS reports', () => {
+  beforeEach(() => {
+    cy.clock(now)
+  })
+
+  context('a data warden viewing a report with status REOPENED', () => {
+    beforeEach(() => {
+      cy.resetBasicStubs({ user: mockDataWarden })
+      cy.task('stubPrisonApiMockPrison', pecsNorth)
+      cy.task('stubManageKnownUsers')
+      cy.signIn()
+    })
+
+    context('if it is valid (all requirements fulfilled)', () => {
+      const reportWithDetails: DatesAsStrings<ReportWithDetails> = {
+        ...validReport,
+        status: 'REOPENED',
+        title: 'Food or liquid refusual: Arnold A1111AA, Benjamin A2222BB (PECS North)',
+        location: 'NORTH',
+        correctionRequests: [],
+      }
+
+      beforeEach(() => {
+        cy.task('stubIncidentReportingApiGetReportWithDetailsById', { report: reportWithDetails })
+        cy.visit(`/reports/${reportWithDetails.id}`)
+      })
+
+      it('should see a list of actions', () => {
+        const reportPage = Page.verifyOnPage(ReportPage, reportWithDetails.reportReference, true)
+        reportPage.userActionsChoices.then(choices => {
+          const expectedChoices: typeof choices = [
+            { label: 'Close', value: 'CLOSE', checked: false },
+            { label: 'Mark as a duplicate', value: 'MARK_DUPLICATE', checked: false },
+            { label: 'Mark as not reportable', value: 'MARK_NOT_REPORTABLE', checked: false },
+          ]
+          expect(choices).to.deep.equal(expectedChoices)
+        })
+      })
+
+      it(`should be able to close it`, () => {
+        actionTestCase({
+          reportWithDetails,
+          reportInToDoWorkList: true,
+          actionLabel: 'Close',
+          userAction: 'CLOSE',
+          newStatus: 'CLOSED',
+          banner: 'Incident report 6544 is now closed',
+        })
+      })
+
+      it('should be able to mark it as a duplicate', () => {
+        const duplicatedReportId = '0198a59c-1111-2222-3333-444444444444'
+        cy.task('stubIncidentReportingApiGetReportByReference', {
+          report: {
+            ...reportWithDetails,
+            id: duplicatedReportId,
+            reportReference: '6543',
+          },
+        })
+        cy.task('stubIncidentReportingApiUpdateReport', {
+          request: { duplicatedReportId },
+          report: {
+            ...reportWithDetails,
+            duplicatedReportId,
+          },
+        })
+
+        actionTestCase({
+          reportWithDetails,
+          reportInToDoWorkList: true,
+          actionLabel: 'Mark as a duplicate',
+          userAction: 'MARK_DUPLICATE',
+          newStatus: 'DUPLICATE',
+          originalReportReference: '6543',
+          comment: 'Definitely same incident as 6543',
+          banner: 'Incident report 6544 is now set as a duplicate',
+        })
+      })
+
+      it('should be able to mark it as not reportable', () => {
+        actionTestCase({
+          reportWithDetails,
+          reportInToDoWorkList: true,
+          actionLabel: 'Mark as not reportable',
+          userAction: 'MARK_NOT_REPORTABLE',
+          newStatus: 'NOT_REPORTABLE',
+          comment: 'Severity of incident does not necessitate a report',
+          banner: 'Incident report 6544 is now set as non reportable',
+        })
+      })
+    })
+  })
+})

--- a/integration_tests/e2e/journeys/actionPrisonReport.cy.ts
+++ b/integration_tests/e2e/journeys/actionPrisonReport.cy.ts
@@ -1,17 +1,11 @@
-import {
-  RelatedObjectUrlSlug,
-  type AddCorrectionRequestRequest,
-  type ReportWithDetails,
-} from '../../../server/data/incidentReportingApi'
+import type { ReportWithDetails } from '../../../server/data/incidentReportingApi'
 import { moorland } from '../../../server/data/testData/prisonApi'
 import { mockDataWarden } from '../../../server/data/testData/users'
-import type { ApiUserAction, UserAction } from '../../../server/middleware/permissions'
-import type { Status } from '../../../server/reportConfiguration/constants'
 import { now } from '../../../server/testutils/fakeClock'
 import Page from '../../pages/page'
-import { DashboardPage } from '../../pages/dashboard'
 import { ReportPage } from '../../pages/reports/report'
 import { validReport } from './validReport'
+import { actionTestCase } from './actionReport'
 
 describe('Actioning submitted prison reports', () => {
   beforeEach(() => {
@@ -245,67 +239,3 @@ describe('Actioning submitted prison reports', () => {
     })
   })
 })
-
-function actionTestCase({
-  reportWithDetails,
-  actionLabel,
-  userAction,
-  newStatus,
-  comment,
-  commentSentToApi,
-  originalReportReference,
-  originalReportReferenceSentToApi,
-  banner,
-}: {
-  reportWithDetails: DatesAsStrings<ReportWithDetails>
-  actionLabel: string
-  userAction: ApiUserAction & UserAction
-  newStatus: Status
-  /** Comment entered by user */
-  comment?: string
-  /** Comment sent to api if different from that entered by user */
-  commentSentToApi?: string
-  /** Reference entered by user */
-  originalReportReference?: string
-  /** Reference sent to api if different from that entered by user */
-  originalReportReferenceSentToApi?: string
-  banner: string
-}) {
-  const reportPage = Page.verifyOnPage(ReportPage, reportWithDetails.reportReference)
-  reportPage.selectAction(actionLabel)
-  if (originalReportReference) {
-    reportPage.enterOriginalReportReference(originalReportReference)
-  }
-  if (comment) {
-    reportPage.enterComment(userAction, comment)
-  }
-
-  const correctionRequestPayload: AddCorrectionRequestRequest = {
-    userType: 'DATA_WARDEN',
-    userAction,
-    descriptionOfChange: commentSentToApi ?? comment,
-  }
-  if (originalReportReferenceSentToApi ?? originalReportReference) {
-    correctionRequestPayload.originalReportReference = originalReportReferenceSentToApi ?? originalReportReference
-  }
-  cy.task('stubIncidentReportingApiCreateRelatedObject', {
-    urlSlug: RelatedObjectUrlSlug.correctionRequests,
-    reportId: reportWithDetails.id,
-    request: correctionRequestPayload,
-    response: reportWithDetails.correctionRequests, // technically, missing new comment
-  })
-  cy.task('stubIncidentReportingApiChangeReportStatus', {
-    request: { newStatus },
-    report: {
-      ...reportWithDetails,
-      status: newStatus,
-    },
-  })
-
-  cy.task('stubIncidentReportingApiGetReports') // for empty dashboard page
-
-  reportPage.continueButton.click()
-
-  const dashboardPage = Page.verifyOnPage(DashboardPage)
-  dashboardPage.checkNotificationBannerContent(banner)
-}

--- a/integration_tests/e2e/journeys/actionReport.ts
+++ b/integration_tests/e2e/journeys/actionReport.ts
@@ -1,0 +1,82 @@
+import {
+  RelatedObjectUrlSlug,
+  type AddCorrectionRequestRequest,
+  type ReportWithDetails,
+} from '../../../server/data/incidentReportingApi'
+import type { ApiUserAction, UserAction } from '../../../server/middleware/permissions'
+import type { Status } from '../../../server/reportConfiguration/constants'
+import Page from '../../pages/page'
+import { ReportPage } from '../../pages/reports/report'
+import { DashboardPage } from '../../pages/dashboard'
+
+export function actionTestCase({
+  reportWithDetails,
+  reportInToDoWorkList = false,
+  actionLabel,
+  userAction,
+  newStatus,
+  comment,
+  commentSentToApi,
+  originalReportReference,
+  originalReportReferenceSentToApi,
+  banner,
+}: {
+  reportWithDetails: DatesAsStrings<ReportWithDetails>
+  reportInToDoWorkList?: boolean
+  actionLabel: string
+  userAction: ApiUserAction & UserAction
+  newStatus: Status
+  /** Comment entered by user */
+  comment?: string
+  /** Comment sent to api if different from that entered by user */
+  commentSentToApi?: string
+  /** Reference entered by user */
+  originalReportReference?: string
+  /** Reference sent to api if different from that entered by user */
+  originalReportReferenceSentToApi?: string
+  banner: string
+}) {
+  const reportPage = Page.verifyOnPage(ReportPage, reportWithDetails.reportReference, reportInToDoWorkList)
+  reportPage.selectAction(actionLabel)
+  if (originalReportReference) {
+    reportPage.enterOriginalReportReference(originalReportReference)
+  }
+  if (comment) {
+    reportPage.enterComment(userAction, comment)
+  }
+
+  if (reportInToDoWorkList) {
+    cy.task('stubIncidentReportingApiUpdateReport', {
+      request: { title: reportWithDetails.title },
+      report: reportWithDetails,
+    })
+  }
+  const correctionRequestPayload: AddCorrectionRequestRequest = {
+    userType: 'DATA_WARDEN',
+    userAction,
+    descriptionOfChange: commentSentToApi ?? comment,
+  }
+  if (originalReportReferenceSentToApi ?? originalReportReference) {
+    correctionRequestPayload.originalReportReference = originalReportReferenceSentToApi ?? originalReportReference
+  }
+  cy.task('stubIncidentReportingApiCreateRelatedObject', {
+    urlSlug: RelatedObjectUrlSlug.correctionRequests,
+    reportId: reportWithDetails.id,
+    request: correctionRequestPayload,
+    response: reportWithDetails.correctionRequests, // technically, missing new comment
+  })
+  cy.task('stubIncidentReportingApiChangeReportStatus', {
+    request: { newStatus },
+    report: {
+      ...reportWithDetails,
+      status: newStatus,
+    },
+  })
+
+  cy.task('stubIncidentReportingApiGetReports') // for empty dashboard page
+
+  reportPage.continueButton.click()
+
+  const dashboardPage = Page.verifyOnPage(DashboardPage)
+  dashboardPage.checkNotificationBannerContent(banner)
+}

--- a/integration_tests/e2e/journeys/actionSubmittedReport.cy.ts
+++ b/integration_tests/e2e/journeys/actionSubmittedReport.cy.ts
@@ -13,7 +13,7 @@ import { DashboardPage } from '../../pages/dashboard'
 import { ReportPage } from '../../pages/reports/report'
 import { validReport } from './validReport'
 
-describe('Actioning submitted reports', () => {
+describe('Actioning submitted prison reports', () => {
   beforeEach(() => {
     cy.clock(now)
   })

--- a/integration_tests/e2e/journeys/createCompleteReport.cy.ts
+++ b/integration_tests/e2e/journeys/createCompleteReport.cy.ts
@@ -526,7 +526,7 @@ for (const { scenario, user, reportType } of scenarios) {
         report: reportWithDetails,
       })
       cy.task('stubIncidentReportingApiGetReports')
-      reportPage.submitButtons.contains('Close').click()
+      reportPage.submitButtons.contains('Close report').click()
 
       const dashboardPage = Page.verifyOnPage(DashboardPage)
       dashboardPage.checkNotificationBannerContent(`Incident report ${reportWithDetails.reportReference} is now closed`)

--- a/server/middleware/correctPecsReportStatus.test.ts
+++ b/server/middleware/correctPecsReportStatus.test.ts
@@ -1,0 +1,96 @@
+import type { Express, NextFunction, Request, Response } from 'express'
+
+import { convertReportDates } from '../data/incidentReportingApiUtils'
+import { mockReport } from '../data/testData/incidentReporting'
+import { mockPecsRegions } from '../data/testData/pecsRegions'
+import { mockDataWarden, mockReportingOfficer } from '../data/testData/users'
+import { now } from '../testutils/fakeClock'
+import type { Status } from '../reportConfiguration/constants'
+import { Permissions } from './permissions'
+import { correctPecsReportStatus } from './correctPecsReportStatus'
+
+describe('Middleware to auto-correct PECS report statuses', () => {
+  const report = convertReportDates(mockReport({ reportReference: '6543', reportDateAndTime: now }))
+
+  beforeAll(() => {
+    mockPecsRegions()
+  })
+
+  function makeMockRequest(
+    user: Express.User,
+    reportLocation: string,
+    status: Status,
+  ): { req: Request; res: Response; next: NextFunction } {
+    return {
+      req: { originalUrl: '/some/path' } as unknown as Request,
+      res: {
+        locals: {
+          apis: { incidentReportingApi: { changeReportStatus: jest.fn() } },
+          permissions: new Permissions(user),
+          report: { ...report, location: reportLocation, status },
+        },
+        redirect: jest.fn(),
+      } as unknown as Response,
+      next: jest.fn(),
+    }
+  }
+
+  it('should ignore prison reports', async () => {
+    const { req, res, next } = makeMockRequest(mockDataWarden, 'MDI', 'AWAITING_REVIEW')
+    await correctPecsReportStatus()(req, res, next)
+
+    expect(res.locals.apis.incidentReportingApi.changeReportStatus).not.toHaveBeenCalled()
+    expect(res.redirect).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it('should ignore PECS reports if user is not a data warden', async () => {
+    const { req, res, next } = makeMockRequest(mockReportingOfficer, 'NORTH', 'AWAITING_REVIEW')
+    await correctPecsReportStatus()(req, res, next)
+
+    expect(res.locals.apis.incidentReportingApi.changeReportStatus).not.toHaveBeenCalled()
+    expect(res.redirect).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it.each(['DRAFT', 'CLOSED', 'DUPLICATE', 'NOT_REPORTABLE', 'REOPENED'] as const)(
+    'should ignore a %s PECS report since status does not need correction',
+    async status => {
+      const { req, res, next } = makeMockRequest(mockDataWarden, 'NORTH', status)
+      await correctPecsReportStatus()(req, res, next)
+
+      expect(res.locals.apis.incidentReportingApi.changeReportStatus).not.toHaveBeenCalled()
+      expect(res.redirect).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalledWith()
+    },
+  )
+
+  it.each([
+    { status: 'AWAITING_REVIEW', correctedTo: 'DRAFT' },
+    { status: 'UPDATED', correctedTo: 'REOPENED' },
+    { status: 'ON_HOLD', correctedTo: 'REOPENED' },
+    { status: 'NEEDS_UPDATING', correctedTo: 'REOPENED' },
+    { status: 'WAS_CLOSED', correctedTo: 'REOPENED' },
+  ] as const)('should correct a $status PECS report to $correctedTo', async ({ status, correctedTo }) => {
+    const { req, res, next } = makeMockRequest(mockDataWarden, 'NORTH', status)
+    await correctPecsReportStatus()(req, res, next)
+
+    expect(res.locals.apis.incidentReportingApi.changeReportStatus).toHaveBeenCalledWith(report.id, {
+      newStatus: correctedTo,
+    })
+    expect(res.redirect).toHaveBeenCalledWith('/some/path')
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it.each(['report', 'permissions'] as const)('should fail if %s local is not supplied', async property => {
+    const { req, res, next } = makeMockRequest(mockDataWarden, 'NORTH', 'AWAITING_REVIEW')
+    delete res.locals[property]
+    await correctPecsReportStatus()(req, res, next)
+
+    expect(res.locals.apis.incidentReportingApi.changeReportStatus).not.toHaveBeenCalled()
+    expect(res.redirect).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('correctPecsReportStatus() requires'), status: 501 }),
+    )
+  })
+})

--- a/server/middleware/correctPecsReportStatus.ts
+++ b/server/middleware/correctPecsReportStatus.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from 'express'
 import { NotImplemented } from 'http-errors'
 
 import { isPecsRegionCode } from '../data/pecsRegions'
-import type { Status } from '../reportConfiguration/constants'
+import { type Status, statuses } from '../reportConfiguration/constants'
 
 /**
  * When a PECS report is accessed by a data warden, and it is found to be in an unexpected status,
@@ -42,3 +42,10 @@ export const pecsStatusCorrections: Partial<Record<Status, Status>> = {
   NEEDS_UPDATING: 'REOPENED',
   WAS_CLOSED: 'REOPENED',
 }
+
+/**
+ * Statuses that are expected for PECS reports
+ */
+export const possiblePecsStatuses = statuses
+  .map(({ code: status }) => status)
+  .filter(status => !(status in pecsStatusCorrections))

--- a/server/middleware/correctPecsReportStatus.ts
+++ b/server/middleware/correctPecsReportStatus.ts
@@ -1,0 +1,44 @@
+import type { RequestHandler } from 'express'
+import { NotImplemented } from 'http-errors'
+
+import { isPecsRegionCode } from '../data/pecsRegions'
+import type { Status } from '../reportConfiguration/constants'
+
+/**
+ * When a PECS report is accessed by a data warden, and it is found to be in an unexpected status,
+ * automatically move it to the most sensible one and redirect to refresh.
+ */
+export function correctPecsReportStatus(): RequestHandler {
+  return async (req, res, next): Promise<void> => {
+    const { report, permissions } = res.locals
+    if (!report) {
+      next(new NotImplemented('correctPecsReportStatus() requires res.locals.report'))
+      return
+    }
+    if (!permissions) {
+      next(new NotImplemented('correctPecsReportStatus() requires permissions middleware'))
+      return
+    }
+
+    if (permissions.isDataWarden && isPecsRegionCode(report.location) && report.status in pecsStatusCorrections) {
+      await res.locals.apis.incidentReportingApi.changeReportStatus(report.id, {
+        newStatus: pecsStatusCorrections[report.status],
+      })
+      res.redirect(req.originalUrl) // NB: req.url is not right for some reason
+      return
+    }
+
+    next()
+  }
+}
+
+/**
+ * Which statuses should be corrected if such a PECS report is found?
+ */
+export const pecsStatusCorrections: Partial<Record<Status, Status>> = {
+  AWAITING_REVIEW: 'DRAFT',
+  UPDATED: 'REOPENED',
+  ON_HOLD: 'REOPENED',
+  NEEDS_UPDATING: 'REOPENED',
+  WAS_CLOSED: 'REOPENED',
+}

--- a/server/middleware/permissions/statusTransitions.ts
+++ b/server/middleware/permissions/statusTransitions.ts
@@ -325,6 +325,10 @@ export const pecsReportTransitions: Transitions = {
         mustBeValid: true,
         successBanner: 'Incident report $reportReference is now closed',
       },
+      // it would be logical to also allow MARK_DUPLICATE & MARK_NOT_REPORTABLE
+      // and this is what the stakeholders signed off,
+      // but UCD decided that those should only be possible after first reopening
+      // since data wardens are unlikely to even start creating a duplicate or not reportable report by accident.
     },
     CLOSED: {
       RECALL: { newStatus: 'REOPENED', label: 'Reopen and change report' },

--- a/server/middleware/populatePrisoner.ts
+++ b/server/middleware/populatePrisoner.ts
@@ -1,10 +1,10 @@
-import type { NextFunction, Request, Response } from 'express'
+import type { RequestHandler } from 'express'
 import { NotImplemented } from 'http-errors'
 
 import logger from '../../logger'
 
-export function populatePrisoner() {
-  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+export function populatePrisoner(): RequestHandler {
+  return async (req, res, next): Promise<void> => {
     const { prisonerNumber } = req.params
     if (!prisonerNumber) {
       next(new NotImplemented('populatePrisoner() requires req.params.prisonerNumber'))

--- a/server/middleware/populateReport.ts
+++ b/server/middleware/populateReport.ts
@@ -1,4 +1,4 @@
-import type { NextFunction, Request, Response } from 'express'
+import type { RequestHandler } from 'express'
 import { NotImplemented } from 'http-errors'
 
 import logger from '../../logger'
@@ -6,8 +6,8 @@ import logger from '../../logger'
 /**
  * Loads a report by id from `req.params.reportId`
  */
-export function populateReport(withDetails: boolean) {
-  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+export function populateReport(withDetails: boolean): RequestHandler {
+  return async (req, res, next): Promise<void> => {
     const { reportId } = req.params
     const { permissions } = res.locals
     if (!reportId) {

--- a/server/middleware/populateReportConfiguration.ts
+++ b/server/middleware/populateReportConfiguration.ts
@@ -1,4 +1,4 @@
-import type { NextFunction, Request, Response } from 'express'
+import type { RequestHandler } from 'express'
 import { NotImplemented } from 'http-errors'
 
 import logger from '../../logger'
@@ -11,8 +11,8 @@ import { QuestionProgress } from '../data/incidentTypeConfiguration/questionProg
  * Loads report configuration for a report in `res.locals.report`.
  * Must come after populateReport() middleware.
  */
-export function populateReportConfiguration(generateQuestionSteps = true) {
-  return async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+export function populateReportConfiguration(generateQuestionSteps = true): RequestHandler {
+  return async (_req, res, next): Promise<void> => {
     const { report } = res.locals
     if (!report) {
       // expect to always be used after populateReport() middleware

--- a/server/middleware/populateStaffMember.ts
+++ b/server/middleware/populateStaffMember.ts
@@ -1,4 +1,4 @@
-import type { NextFunction, Request, Response } from 'express'
+import type { RequestHandler } from 'express'
 import { NotImplemented } from 'http-errors'
 
 import logger from '../../logger'
@@ -7,8 +7,8 @@ import ManageUsersApiClient from '../data/manageUsersApiClient'
 /**
  * Loads a staff member by username from `req.params.username`
  */
-export function populateStaffMember() {
-  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+export function populateStaffMember(): RequestHandler {
+  return async (req, res, next): Promise<void> => {
     const { username } = req.params
     if (!username) {
       next(new NotImplemented('populateStaffMember() requires req.params.username'))

--- a/server/middleware/redirectOnReportStatus.ts
+++ b/server/middleware/redirectOnReportStatus.ts
@@ -1,4 +1,4 @@
-import type { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { RequestHandler } from 'express'
 import { NotImplemented } from 'http-errors'
 
 import logger from '../../logger'
@@ -9,7 +9,7 @@ export function redirectIfStatusNot(...statuses: Status[]): RequestHandler {
     throw new NotImplemented('redirectIfStatusNot() requires at least one status')
   }
 
-  return (_req: Request, res: Response, next: NextFunction): void => {
+  return (_req, res, next): void => {
     const { report } = res.locals
     if (!report) {
       // expect to always be used after populateReport() middleware

--- a/server/middleware/updateActiveAgencies.ts
+++ b/server/middleware/updateActiveAgencies.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import type { RequestHandler } from 'express'
 
 import { PrisonApi } from '../data/prisonApi'
 import { type Services } from '../services'
@@ -20,7 +20,7 @@ export const activeAgenciesCache: Cache<typeof ACTIVE_AGENCIES_CACHE_UPDATED> = 
  * `activeAgencies` changes)
  */
 export default function updateActiveAgencies({ hmppsAuthClient, applicationInfo }: Services): RequestHandler {
-  return async (_req: Request, _res: Response, next: NextFunction) => {
+  return async (_req, _res, next) => {
     // check if activeAgencies cache is fresh enough
     const activeAgenciesCacheExpired = !activeAgenciesCache.get()
     if (activeAgenciesCacheExpired) {

--- a/server/routes/reports/actions/actionPecsReport.test.ts
+++ b/server/routes/reports/actions/actionPecsReport.test.ts
@@ -6,6 +6,7 @@ import { appWithAllRoutes } from '../../testutils/appSetup'
 import { now } from '../../../testutils/fakeClock'
 import UserService from '../../../services/userService'
 import { type Status, statuses } from '../../../reportConfiguration/constants'
+import * as correctPecsReportStatus from '../../../middleware/correctPecsReportStatus'
 import { type UserAction, userActions } from '../../../middleware/permissions'
 import {
   IncidentReportingApi,
@@ -29,6 +30,7 @@ import { rolePecs } from '../../../data/constants'
 jest.mock('../../../data/incidentReportingApi')
 jest.mock('../../../data/prisonApi')
 jest.mock('../../../data/reportValidity')
+jest.mock('../../../middleware/correctPecsReportStatus')
 jest.mock('../../../services/userService')
 jest.mock('./correctionRequestPlaceholder')
 
@@ -43,6 +45,9 @@ const userService = UserService.prototype as jest.Mocked<UserService>
 const prisonApi = PrisonApi.prototype as jest.Mocked<PrisonApi>
 
 const { validateReport } = reportValidity as jest.Mocked<typeof import('../../../data/reportValidity')>
+const { correctPecsReportStatus: mockCorrectPecsReportStatus } = correctPecsReportStatus as jest.Mocked<
+  typeof import('../../../middleware/correctPecsReportStatus')
+>
 const { placeholderForCorrectionRequest } = correctionRequestPlaceholder as jest.Mocked<
   typeof import('./correctionRequestPlaceholder')
 >
@@ -68,6 +73,10 @@ beforeEach(() => {
     ),
   )
 
+  mockCorrectPecsReportStatus.mockImplementationOnce(() => (_req, _res, next) => {
+    // turn off all status corrections
+    next()
+  })
   placeholderForCorrectionRequest.mockReturnValue('PLACEHOLDER')
 })
 

--- a/server/routes/reports/viewReport.ts
+++ b/server/routes/reports/viewReport.ts
@@ -13,6 +13,7 @@ import {
   dwNotReviewed,
   workListMapping,
 } from '../../reportConfiguration/constants'
+import { correctPecsReportStatus } from '../../middleware/correctPecsReportStatus'
 import {
   logoutUnless,
   hasPermissionTo,
@@ -46,6 +47,7 @@ export function viewReportRouter(): Router {
     },
     populateReport(true),
     logoutUnless(hasPermissionTo('VIEW')),
+    correctPecsReportStatus(),
     populateReportConfiguration(true),
     async (req, res) => {
       const { incidentReportingApi, prisonApi, userService } = res.locals.apis


### PR DESCRIPTION
NB: the diffs are much more manageable if looking commit-by-commit, ignoring whitespace

- test PECS report actions
- add middleware that corrects unexpected PECS report statuses (when viewed by data wardens)