### PR TITLE
IR-1202 Refactor `getPrison` to `getAgency` and enhance formatting options

### DIFF
--- a/server/data/prisonApi.ts
+++ b/server/data/prisonApi.ts
@@ -142,14 +142,18 @@ export class PrisonApi extends RestClient {
     })
   }
 
-  // TODO: rename method to reflect that it could be more than just a prison
   /** Look up agency details (can be a prison, a PECS region, etc) */
-  async getPrison(prisonId: string, activeOnly = true, agencyType?: AgencyType): Promise<Agency | null> {
+  async getAgency(
+    agencyId: string,
+    activeOnly = true,
+    agencyType?: AgencyType,
+    skipFormatLocation?: boolean,
+  ): Promise<Agency | null> {
     try {
       return await this.get<Agency>(
         {
-          path: `/api/agencies/${encodeURIComponent(prisonId)}`,
-          query: { activeOnly: activeOnly.toString(), agencyType },
+          path: `/api/agencies/${encodeURIComponent(agencyId)}`,
+          query: { activeOnly: activeOnly.toString(), agencyType, skipFormatLocation },
         },
         asSystem(),
       )

--- a/server/routes/reports/actions/actionPecsReport.test.ts
+++ b/server/routes/reports/actions/actionPecsReport.test.ts
@@ -64,7 +64,7 @@ beforeEach(() => {
     [mockSharedUser.username]: mockSharedUser,
   })
 
-  prisonApi.getPrison.mockImplementation(locationCode =>
+  prisonApi.getAgency.mockImplementation(locationCode =>
     Promise.resolve(
       {
         NORTH: pecsNorth,
@@ -519,15 +519,15 @@ describe('Actioning PECS reports', () => {
                 expect(incidentReportingApi.getReportByReference).not.toHaveBeenCalled()
               }
               if (updatesTitle) {
-                expect(prisonApi.getPrison).toHaveBeenCalledTimes(2)
-                expect(prisonApi.getPrison).toHaveBeenNthCalledWith(1, 'NORTH', false) // to display report location
-                expect(prisonApi.getPrison).toHaveBeenNthCalledWith(2, 'NORTH', false) // to regenerate title
+                expect(prisonApi.getAgency).toHaveBeenCalledTimes(2)
+                expect(prisonApi.getAgency).toHaveBeenNthCalledWith(1, 'NORTH', false, 'PECS', true) // to display report location
+                expect(prisonApi.getAgency).toHaveBeenNthCalledWith(2, 'NORTH', false, 'PECS', true) // to regenerate title
                 expect(incidentReportingApi.updateReport).toHaveBeenCalledWith(mockedReport.id, {
                   title: 'Assault: Arnold A1111AA, Benjamin A2222BB (PECS North)',
                 })
               } else {
-                expect(prisonApi.getPrison).toHaveBeenCalledTimes(1)
-                expect(prisonApi.getPrison).toHaveBeenCalledWith('NORTH', false) // to display report location
+                expect(prisonApi.getAgency).toHaveBeenCalledTimes(1)
+                expect(prisonApi.getAgency).toHaveBeenCalledWith('NORTH', false, 'PECS', true) // to display report location
                 if (userAction === 'MARK_DUPLICATE') {
                   expect(incidentReportingApi.updateReport).toHaveBeenCalledWith(mockedReport.id, {
                     duplicatedReportId: mockedOriginalReport.id,

--- a/server/routes/reports/actions/actionPrisonReport.test.ts
+++ b/server/routes/reports/actions/actionPrisonReport.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
     [mockSharedUser.username]: mockSharedUser,
   })
 
-  prisonApi.getPrison.mockImplementation(locationCode =>
+  prisonApi.getAgency.mockImplementation(locationCode =>
     Promise.resolve(
       {
         LEI: leeds,
@@ -980,15 +980,15 @@ describe('Actioning prison reports', () => {
                 expect(incidentReportingApi.getReportByReference).not.toHaveBeenCalled()
               }
               if (updatesTitle) {
-                expect(prisonApi.getPrison).toHaveBeenCalledTimes(2)
-                expect(prisonApi.getPrison).toHaveBeenNthCalledWith(1, 'MDI', false) // to display report location
-                expect(prisonApi.getPrison).toHaveBeenNthCalledWith(2, 'MDI', false) // to regenerate title
+                expect(prisonApi.getAgency).toHaveBeenCalledTimes(2)
+                expect(prisonApi.getAgency).toHaveBeenNthCalledWith(1, 'MDI', false, 'INST', false) // to display report location
+                expect(prisonApi.getAgency).toHaveBeenNthCalledWith(2, 'MDI', false, 'INST', false) // to regenerate title
                 expect(incidentReportingApi.updateReport).toHaveBeenCalledWith(mockedReport.id, {
                   title: 'Assault: Arnold A1111AA, Benjamin A2222BB (Moorland (HMP & YOI))',
                 })
               } else {
-                expect(prisonApi.getPrison).toHaveBeenCalledTimes(1)
-                expect(prisonApi.getPrison).toHaveBeenCalledWith('MDI', false) // to display report location
+                expect(prisonApi.getAgency).toHaveBeenCalledTimes(1)
+                expect(prisonApi.getAgency).toHaveBeenCalledWith('MDI', false, 'INST', false) // to display report location
                 if (userAction === 'MARK_DUPLICATE') {
                   expect(incidentReportingApi.updateReport).toHaveBeenCalledWith(mockedReport.id, {
                     duplicatedReportId: mockedOriginalReport.id,

--- a/server/routes/reports/details/changeType.test.ts
+++ b/server/routes/reports/details/changeType.test.ts
@@ -23,7 +23,7 @@ let agent: Agent
 
 beforeEach(() => {
   agent = request.agent(appWithAllRoutes())
-  prisonApi.getPrison.mockResolvedValueOnce(moorland)
+  prisonApi.getAgency.mockResolvedValueOnce(moorland)
 })
 
 afterEach(() => {

--- a/server/routes/reports/prisoners/involvement/add.test.ts
+++ b/server/routes/reports/prisoners/involvement/add.test.ts
@@ -49,7 +49,7 @@ beforeEach(() => {
 
   mockHandleReportEdit.withoutSideEffect()
   offenderSearchApi.getPrisoner.mockResolvedValueOnce(andrew)
-  prisonApi.getPrison.mockResolvedValueOnce(moorland)
+  prisonApi.getAgency.mockResolvedValueOnce(moorland)
 })
 
 afterEach(() => {

--- a/server/routes/reports/prisoners/involvement/edit.test.ts
+++ b/server/routes/reports/prisoners/involvement/edit.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
   app = appWithAllRoutes()
 
   mockHandleReportEdit.withoutSideEffect()
-  prisonApi.getPrison.mockResolvedValueOnce(moorland)
+  prisonApi.getAgency.mockResolvedValueOnce(moorland)
 })
 
 afterEach(() => {

--- a/server/routes/reports/prisoners/remove/index.test.ts
+++ b/server/routes/reports/prisoners/remove/index.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
   app = appWithAllRoutes()
 
   mockHandleReportEdit.withoutSideEffect()
-  prisonApi.getPrison.mockResolvedValueOnce(moorland)
+  prisonApi.getAgency.mockResolvedValueOnce(moorland)
 })
 
 afterEach(() => {

--- a/server/routes/reports/viewReport.test.ts
+++ b/server/routes/reports/viewReport.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
     [mockSharedUser.username]: mockSharedUser,
   })
 
-  prisonApi.getPrison.mockImplementation(locationCode =>
+  prisonApi.getAgency.mockImplementation(locationCode =>
     Promise.resolve(
       {
         LEI: leeds,

--- a/server/routes/reports/viewReport.ts
+++ b/server/routes/reports/viewReport.ts
@@ -5,23 +5,23 @@ import logger from '../../../logger'
 import { updateReportTitle } from '../../services/reportTitle'
 import {
   aboutTheType,
+  dwNotReviewed,
   prisonerInvolvementOutcomesDescriptions,
   prisonerInvolvementRolesDescriptions,
   staffInvolvementRolesDescriptions,
   statusesDescriptions,
   typesDescriptions,
-  dwNotReviewed,
   workListMapping,
 } from '../../reportConfiguration/constants'
 import { correctPecsReportStatus } from '../../middleware/correctPecsReportStatus'
 import {
-  logoutUnless,
-  hasPermissionTo,
-  parseUserActionCode,
-  userActionMapping,
-  type ApiUserType,
   type ApiUserAction,
+  type ApiUserType,
+  hasPermissionTo,
+  logoutUnless,
+  parseUserActionCode,
   type UserAction,
+  userActionMapping,
 } from '../../middleware/permissions'
 import { populateReport } from '../../middleware/populateReport'
 import { populateReportConfiguration } from '../../middleware/populateReportConfiguration'
@@ -32,6 +32,7 @@ import type { GovukErrorSummaryItem } from '../../utils/govukFrontend'
 import { correctionRequestActionLabels } from './actions/correctionRequestLabels'
 import { placeholderForCorrectionRequest } from './actions/correctionRequestPlaceholder'
 import { findRequestDuplicate } from './actions/findRequestDuplicate'
+import { AgencyType } from '../../data/prisonApi'
 
 export function viewReportRouter(): Router {
   const router = Router({ mergeParams: true })
@@ -69,7 +70,9 @@ export function viewReportRouter(): Router {
       }
       const [usersLookup, locationDescription] = await Promise.all([
         userService.getUsers(res.locals.systemToken, usernames),
-        prisonApi.getPrison(report.location, false).then(agency => agency?.description || report.location),
+        prisonApi
+          .getAgency(report.location, false, isPecsReport ? AgencyType.PECS : AgencyType.INST, isPecsReport)
+          .then(agency => agency?.description || report.location),
       ])
 
       const questionProgressSteps = Array.from(questionProgress)

--- a/server/services/reportTitle.ts
+++ b/server/services/reportTitle.ts
@@ -5,6 +5,8 @@ import type { ReportWithDetails } from '../data/incidentReportingApi'
 import { reportHasDetails } from '../data/incidentReportingApiUtils'
 import { getTypeDetails, type Type } from '../reportConfiguration/constants'
 import { convertToTitleCase } from '../utils/utils'
+import { isPecsRegionCode } from '../data/pecsRegions'
+import { AgencyType } from '../data/prisonApi'
 
 // NB: Report titles are never displayed in this service, but they are saved for downstream services’ compatibility
 
@@ -38,8 +40,10 @@ export async function updateReportTitle(res: express.Response): Promise<void> {
     throw new Error('implementation error: regenerateTitleForReport should only be used on report with details')
   }
 
+  const isPecsReport = isPecsRegionCode(report.location)
+
   const locationDescription = await prisonApi
-    .getPrison(report.location, false)
+    .getAgency(report.location, false, isPecsReport ? AgencyType.PECS : AgencyType.INST, isPecsReport)
     .then(prison => prison?.description || report.location)
     // fall back to code
     .catch(() => report.location)


### PR DESCRIPTION
```
### Description

This pull request refactors the `getPrison` function to `getAgency` in `prisonApi`. Additionally, it introduces an option to skip formatting for increased flexibility.

### Checklist

- [ ] Appropriate unit tests are added or updated
- [ ] Changes are backward-compatible
```