### PR TITLE
IR-1215 removals filter

### DIFF
--- a/assets/scss/page/_dashboard.scss
+++ b/assets/scss/page/_dashboard.scss
@@ -41,3 +41,7 @@
     margin-bottom: 0;
   }
 }
+
+.app-dashboard__removals-filter {
+  border-left-style: solid;
+}

--- a/assets/scss/page/_dashboard.scss
+++ b/assets/scss/page/_dashboard.scss
@@ -1,5 +1,6 @@
 .app-dashboard__search-box {
-  background-color: govuk-colour("light-grey");
+  background-color: #f3f2f1;
+  padding: 20px 20px 10px !important;
 
   .autocomplete__input {
     background-color: $govuk-body-background-colour;
@@ -42,6 +43,7 @@
   }
 }
 
-.app-dashboard__removals-filter {
-  border-left-style: solid;
+.app-dashboard__completed-status-filter {
+  border-right-style: solid;
+  border-bottom-width: 2px;
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -31,7 +31,7 @@ type DashboardFilters = {
   toDateInput?: string
   typeFamily?: TypeFamily
   incidentStatuses?: IncidentStatuses | IncidentStatuses[]
-  userActions?: ApiUserAction | ApiUserAction[]
+  latestUserActions?: ApiUserAction | ApiUserAction[] | 'REQUEST_REMOVAL'
 }
 
 type BannerTypes = 'information' | 'success' | 'error'

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -10,6 +10,7 @@ import type { PrisonApi } from '../../data/prisonApi'
 import type { Permissions, UserAction, ReportTransitions } from '../../middleware/permissions'
 import type { TypeFamily } from '../../reportConfiguration/constants'
 import { IncidentStatuses } from '../../routes/dashboard'
+import { ApiUserAction } from '../../middleware/permissions'
 
 export default {}
 
@@ -30,6 +31,7 @@ type DashboardFilters = {
   toDateInput?: string
   typeFamily?: TypeFamily
   incidentStatuses?: IncidentStatuses | IncidentStatuses[]
+  userActions?: ApiUserAction | ApiUserAction[]
 }
 
 type BannerTypes = 'information' | 'success' | 'error'

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -107,7 +107,7 @@ export type GetReportsParams = {
   reportedByUsername: string
   involvingStaffUsername: string
   involvingPrisonerNumber: string
-  latestUserAction: ApiUserAction
+  userAction: ApiUserAction | ApiUserAction[]
 } & PaginationSortingParams
 
 export type PaginationSortingParams = {
@@ -264,7 +264,7 @@ export class IncidentReportingApi extends RestClient {
       reportedByUsername,
       involvingStaffUsername,
       involvingPrisonerNumber,
-      latestUserAction,
+      userAction,
       page,
       size,
       sort,
@@ -281,7 +281,7 @@ export class IncidentReportingApi extends RestClient {
       reportedByUsername: null,
       involvingStaffUsername: null,
       involvingPrisonerNumber: null,
-      latestUserAction: null,
+      userAction: null,
       page: 0,
       size: defaultPageSize,
       sort: ['incidentDateAndTime,DESC'],
@@ -328,8 +328,8 @@ export class IncidentReportingApi extends RestClient {
     if (involvingPrisonerNumber) {
       query.involvingPrisonerNumber = involvingPrisonerNumber
     }
-    if (latestUserAction) {
-      query.latestUserAction = latestUserAction
+    if (userAction) {
+      query.userAction = userAction
     }
 
     const response = await this.get<DatesAsStrings<PaginatedBasicReports>>(

--- a/server/data/incidentReportingApi.ts
+++ b/server/data/incidentReportingApi.ts
@@ -78,6 +78,7 @@ export type ReportBasic = {
   createdInNomis: boolean
   lastModifiedInNomis: boolean
   duplicatedReportId: string | null
+  latestUserAction: ApiUserAction | null
 }
 
 export type ReportWithDetails = ReportBasic & {
@@ -106,6 +107,7 @@ export type GetReportsParams = {
   reportedByUsername: string
   involvingStaffUsername: string
   involvingPrisonerNumber: string
+  latestUserAction: ApiUserAction
 } & PaginationSortingParams
 
 export type PaginationSortingParams = {
@@ -262,6 +264,7 @@ export class IncidentReportingApi extends RestClient {
       reportedByUsername,
       involvingStaffUsername,
       involvingPrisonerNumber,
+      latestUserAction,
       page,
       size,
       sort,
@@ -278,6 +281,7 @@ export class IncidentReportingApi extends RestClient {
       reportedByUsername: null,
       involvingStaffUsername: null,
       involvingPrisonerNumber: null,
+      latestUserAction: null,
       page: 0,
       size: defaultPageSize,
       sort: ['incidentDateAndTime,DESC'],
@@ -323,6 +327,9 @@ export class IncidentReportingApi extends RestClient {
     }
     if (involvingPrisonerNumber) {
       query.involvingPrisonerNumber = involvingPrisonerNumber
+    }
+    if (latestUserAction) {
+      query.latestUserAction = latestUserAction
     }
 
     const response = await this.get<DatesAsStrings<PaginatedBasicReports>>(

--- a/server/data/testData/incidentReporting.ts
+++ b/server/data/testData/incidentReporting.ts
@@ -16,6 +16,7 @@ import type {
 } from '../incidentReportingApi'
 import { andrew, barry } from './offenderSearch'
 import { staffBarry, staffMary } from './prisonApi'
+import { ApiUserAction } from '../../middleware/permissions'
 
 interface MockReportConfig {
   reportReference: string
@@ -27,6 +28,7 @@ interface MockReportConfig {
   reportingUsername?: string
   modifyingUsername?: string
   modifiedDateAndTime?: Date
+  latestUserAction?: ApiUserAction | null
   withAddendums?: boolean
 }
 
@@ -45,6 +47,7 @@ export function mockReport({
   reportingUsername = 'user1',
   modifyingUsername = 'user1',
   modifiedDateAndTime = reportDateAndTime,
+  latestUserAction = null,
   withDetails = false,
   withAddendums = false,
 }: MockReportConfig & { withDetails?: boolean }): DatesAsStrings<ReportBasic | ReportWithDetails> {
@@ -70,6 +73,7 @@ export function mockReport({
     createdInNomis,
     lastModifiedInNomis: createdInNomis,
     duplicatedReportId: null,
+    latestUserAction,
   }
 
   if (withDetails) {

--- a/server/middleware/permissions/userActions.ts
+++ b/server/middleware/permissions/userActions.ts
@@ -28,13 +28,21 @@ export const userActions = [
 export type UserAction = (typeof userActions)[number]['code']
 
 /** IRS api has a different but overlapping set of values */
-export type ApiUserAction =
-  | Exclude<UserAction, 'VIEW' | 'EDIT' | 'REQUEST_REMOVAL'>
-  | 'REQUEST_DUPLICATE'
-  | 'REQUEST_NOT_REPORTABLE'
+export const apiUserActions = [
+  ...userActions.map(action => action.code).filter(action => !['VIEW', 'EDIT', 'REQUEST_REMOVAL'].includes(action)),
+  'REQUEST_DUPLICATE',
+  'REQUEST_NOT_REPORTABLE',
+]
+
+/** IRS api has a different but overlapping set of values */
+export type ApiUserAction = (typeof apiUserActions)[number]
 
 export const userActionMapping = Object.fromEntries(userActions.map(action => [action.code, action]))
 
 export function parseUserActionCode(code: unknown): code is UserAction {
+  return userActions.some(action => action.code === code)
+}
+
+export function parseApiUserActionCode(code: unknown): code is ApiUserAction {
   return userActions.some(action => action.code === code)
 }

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -20,12 +20,7 @@ import {
 import type { PaginatedBasicReports } from '../../data/incidentReportingApi'
 import { type Order, orderOptions } from '../../data/offenderSearchApi'
 import { pecsRegions } from '../../data/pecsRegions'
-import {
-  ApiUserAction,
-  apiUserActions,
-  isLocationActiveInService,
-  parseApiUserActionCode,
-} from '../../middleware/permissions'
+import { ApiUserAction, apiUserActions, isLocationActiveInService } from '../../middleware/permissions'
 import type { HeaderCell } from '../../utils/sortableTable'
 import format from '../../utils/format'
 import type { GovukErrorSummaryItem, GovukSelectItem } from '../../utils/govukFrontend'

--- a/server/views/pages/dashboard/statusFilters.njk
+++ b/server/views/pages/dashboard/statusFilters.njk
@@ -54,7 +54,7 @@
     }) }}
   </div>
 
-  <div class="govuk-grid-column-one-quarter">
+  <div class="app-dashboard__completed-status-filter govuk-grid-column-one-quarter">
     {{ statusFilters({
       id: "completed",
       legendText: "Completed status",
@@ -63,7 +63,7 @@
     }) }}
   </div>
 
-  <div class="app-dashboard__removals-filter govuk-grid-column-one-quarter">
+  <div class="govuk-grid-column-one-quarter">
     {{ govukCheckboxes({
       classes: "govuk-checkboxes--small",
       name: "userActions",

--- a/server/views/pages/dashboard/statusFilters.njk
+++ b/server/views/pages/dashboard/statusFilters.njk
@@ -35,7 +35,7 @@
 {% endmacro %}
 
 <div id="incidentStatuses" class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-quarter">
     {{ statusFilters({
       id: "toDo",
       legendText: "Reporting status",
@@ -45,7 +45,7 @@
     }) }}
   </div>
 
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-quarter">
     {{ statusFilters({
       id: "submitted",
       legendText: "Reviewing status",
@@ -54,12 +54,34 @@
     }) }}
   </div>
 
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-quarter">
     {{ statusFilters({
       id: "completed",
       legendText: "Completed status",
       workListMapping: workListMapping,
       statusesDescriptions: statusesDescriptions
+    }) }}
+  </div>
+
+  <div class="app-dashboard__removals-filter govuk-grid-column-one-quarter">
+    {{ govukCheckboxes({
+      classes: "govuk-checkboxes--small",
+      name: "userActions",
+      attributes: {
+        id: "userActions"
+      },
+      formGroup: {
+        classes: "govuk-form-group--error" if not params.showErrors and error else ""
+      },
+      fieldset: {
+        legend: {
+          text: "Request to remove report",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      idPrefix: id + "-item",
+      items: [{value: "REQUEST_DUPLICATE", text: "Removal requests"}] | govukMultipleCheckedItems(formValues.userActions),
+      errorMessage: params.showErrors and error
     }) }}
   </div>
 </div>

--- a/server/views/pages/dashboard/statusFilters.njk
+++ b/server/views/pages/dashboard/statusFilters.njk
@@ -66,12 +66,9 @@
   <div class="govuk-grid-column-one-quarter">
     {{ govukCheckboxes({
       classes: "govuk-checkboxes--small",
-      name: "userActions",
+      name: "latestUserActions",
       attributes: {
-        id: "userActions"
-      },
-      formGroup: {
-        classes: "govuk-form-group--error" if not params.showErrors and error else ""
+        id: "latestUserActions"
       },
       fieldset: {
         legend: {
@@ -79,9 +76,9 @@
           classes: "govuk-fieldset__legend--s"
         }
       },
-      idPrefix: id + "-item",
-      items: [{value: "REQUEST_DUPLICATE", text: "Removal requests"}] | govukMultipleCheckedItems(formValues.userActions),
-      errorMessage: params.showErrors and error
+      idPrefix: "latestUserAction-item",
+      items: [{value: "REQUEST_REMOVAL", text: "Removal requests"}] | govukMultipleCheckedItems(formValues.latestUserActions),
+      errorMessage: errors | findFieldInGovukErrorSummary("latestUserActions")
     }) }}
   </div>
 </div>


### PR DESCRIPTION
Adding new filter to enable DWs to filter for removal requests. 

Work done:

- Updated API call and associated types to filter for removal requests via `lastUserAction` parameter
- Updated basic report type to include new variable `lastUserAction`
- Added filter with validation on to the dashboard. 

No tests have been added for this yet. 

No unit tests have been broken, integration tests are now broken. 