### PR TITLE
CDPS-1906: Add both old and new DPS home pages to Content-Security-Policy `form-action` directive

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -17,6 +17,7 @@ OFFENDER_SEARCH_API_URL=http://localhost:9091/offenderSearchApi
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 
 DPS_URL=http://localhost:3000
+NEW_DPS_URL=http://localhost:3000
 
 API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,6 +15,7 @@ generic-service:
 
     INGRESS_URL: "https://incident-reporting-dev.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
+    NEW_DPS_URL: "https://dps-dev.prison.service.justice.gov.uk"
     SUPPORT_URL: "https://support-dev.hmpps.service.justice.gov.uk"
 
     COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,7 @@ generic-service:
 
     INGRESS_URL: "https://incident-reporting-preprod.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-preprod.prison.service.justice.gov.uk"
+    NEW_DPS_URL: "https://dps-preprod.prison.service.justice.gov.uk"
     SUPPORT_URL: "https://support-preprod.hmpps.service.justice.gov.uk"
 
     COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,6 +11,7 @@ generic-service:
 
     INGRESS_URL: "https://incident-reporting.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital.prison.service.justice.gov.uk"
+    NEW_DPS_URL: "https://dps.prison.service.justice.gov.uk"
     SUPPORT_URL: "https://support.hmpps.service.justice.gov.uk"
 
     COMPONENT_API_URL: "https://frontend-components.hmpps.service.justice.gov.uk"

--- a/local.env
+++ b/local.env
@@ -19,6 +19,7 @@ OFFENDER_SEARCH_API_URL=http://localhost:8083
 TOKEN_VERIFICATION_API_URL=http://unavailable.localhost
 
 DPS_URL=http://localhost:3000
+NEW_DPS_URL=http://localhost:3000
 SUPPORT_URL=http://localhost:3000
 
 API_CLIENT_ID=hmpps-incident-reporting

--- a/server/config.ts
+++ b/server/config.ts
@@ -141,6 +141,7 @@ export default {
   googleAnalyticsMeasurementId: get('GOOGLE_ANALYTICS_MEASUREMENT_ID', ''),
   ingressUrl: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   dpsUrl: get('DPS_URL', 'http://dps.local', requiredInProduction),
+  newDpsUrl: get('NEW_DPS_URL', 'http://dps.local', requiredInProduction),
   supportUrl: get('SUPPORT_URL', 'http://support.dps.local', requiredInProduction),
   feedbackUrl: get('FEEDBACK_URL', ''),
   sharepointUrl: get('SHAREPOINT_URL', ''),

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -18,6 +18,7 @@ export default function setUpWebSecurity(): Router {
 
   const authHost = new URL(config.apis.hmppsAuth.externalUrl).hostname
   const dpsHost = new URL(config.dpsUrl).hostname
+  const newDpsHost = new URL(config.newDpsUrl).hostname
   const frontendComponentsHost = new URL(config.apis.frontendComponents.url).hostname
 
   router.use(
@@ -49,7 +50,7 @@ export default function setUpWebSecurity(): Router {
             '*.google.co.uk',
           ],
           fontSrc: ["'self'", 'fonts.gstatic.com', frontendComponentsHost],
-          formAction: ["'self'", authHost, dpsHost],
+          formAction: ["'self'", authHost, dpsHost, newDpsHost],
           connectSrc: [
             "'self'",
             '*.google-analytics.com',


### PR DESCRIPTION
… so that prisoner search will once again work from the header. CDPS team moved the feature between services, but there are redirects involved so both domains are needed.