### PR TITLE
IR-1647: Allow incident type to override 'Date of incident' field label & R-1648: Hide time field for incident types where time is not relevant 

### DIFF
--- a/server/reportConfiguration/constants/types.ts
+++ b/server/reportConfiguration/constants/types.ts
@@ -359,7 +359,7 @@ export const incidentTypeHints: { [K in Type]?: Record<string, string> } = {
  * When set, the time field is hidden and this value is submitted to the API automatically.
  */
 export const incidentTypeDefaultTimes: Partial<Record<Type, string>> = {
-  UNLAWFUL_DETENTION_1: '23:59',
+  UNLAWFUL_DETENTION_1: '00:00',
 }
 
 /**

--- a/server/reportConfiguration/constants/types.ts
+++ b/server/reportConfiguration/constants/types.ts
@@ -351,8 +351,15 @@ export const incidentTypeHints: { [K in Type]?: Record<string, string> } = {
   },
   UNLAWFUL_DETENTION_1: {
     incidentDate: 'The date the person was meant to be released - for example, 17/5/2024',
-    incidentTime: "For example, 09 08. If you're unsure, enter 23 59",
   },
+}
+
+/**
+ * Default times (HH:MM) for incident types where time input is not shown to the user.
+ * When set, the time field is hidden and this value is submitted to the API automatically.
+ */
+export const incidentTypeDefaultTimes: Partial<Record<Type, string>> = {
+  UNLAWFUL_DETENTION_1: '23:59',
 }
 
 /**

--- a/server/reportConfiguration/constants/types.ts
+++ b/server/reportConfiguration/constants/types.ts
@@ -355,11 +355,12 @@ export const incidentTypeHints: { [K in Type]?: Record<string, string> } = {
 }
 
 /**
- * Default times (HH:MM) for incident types where time input is not shown to the user.
- * When set, the time field is hidden and this value is submitted to the API automatically.
+ * Override map for incident types where the time of incident is irrelevant.
+ * When set to false, the time field is hidden and 00:00 is submitted to the API automatically.
+ * Defaults to true (time required) for all types not listed here.
  */
-export const incidentTypeDefaultTimes: Partial<Record<Type, string>> = {
-  UNLAWFUL_DETENTION_1: '00:00',
+export const incidentTypeRequiresTime: Partial<Record<Type, boolean>> = {
+  UNLAWFUL_DETENTION_1: false,
 }
 
 /**

--- a/server/reportConfiguration/constants/types.ts
+++ b/server/reportConfiguration/constants/types.ts
@@ -350,7 +350,7 @@ export const incidentTypeHints: { [K in Type]?: Record<string, string> } = {
     incidentDate: 'This should be the date the person was released - for example, 17/5/2024',
   },
   UNLAWFUL_DETENTION_1: {
-    incidentDate: 'The date the person was meant to be released - for example, 17/5/2024',
+    incidentDate: 'For example, 17/5/2024',
     incidentTime: "For example, 09 08. If you're unsure, enter 23 59",
   },
 }
@@ -361,7 +361,7 @@ export const incidentTypeLabels: { [K in Type]?: Record<string, string> } = {
     incidentDate: 'Date of release',
   },
   UNLAWFUL_DETENTION_1: {
-    incidentDate: 'Date meant for release',
+    incidentDate: 'Date the person should have been released',
   },
 }
 

--- a/server/reportConfiguration/constants/types.ts
+++ b/server/reportConfiguration/constants/types.ts
@@ -355,6 +355,16 @@ export const incidentTypeHints: { [K in Type]?: Record<string, string> } = {
   },
 }
 
+/** Overrides for form field labels for incident types */
+export const incidentTypeLabels: { [K in Type]?: Record<string, string> } = {
+  RELEASE_IN_ERROR_1: {
+    incidentDate: 'Date of release',
+  },
+  UNLAWFUL_DETENTION_1: {
+    incidentDate: 'Date meant for release',
+  },
+}
+
 /**
  * NOMIS codes for Types of reportable incidents
  * @deprecated

--- a/server/routes/reports/details/incidentDateAndTimeController.ts
+++ b/server/routes/reports/details/incidentDateAndTimeController.ts
@@ -10,7 +10,7 @@ import {
   hoursFieldName,
   minutesFieldName,
 } from './incidentDateAndTimeFields'
-import { incidentTypeDefaultTimes, incidentTypeHints, Type } from '../../../reportConfiguration/constants'
+import { incidentTypeHints, incidentTypeRequiresTime, Type } from '../../../reportConfiguration/constants'
 
 type IncidentDateAndTimeControllerValues = IncidentDateAndTimeValues & { type?: Type }
 /**
@@ -42,11 +42,11 @@ export abstract class BaseIncidentDateAndTimeController<
       req.form.options.fields.incidentTime.hint = incidentTypeHints[reportType].incidentTime
     }
 
-    const defaultTime = incidentTypeDefaultTimes[reportType]
-    if (defaultTime) {
+    const timeRequired = incidentTypeRequiresTime[reportType] ?? true
+    if (!timeRequired) {
       req.form.options.fields.incidentTime.component = 'hidden'
       req.form.options.fields.incidentTime.validate = []
-      res.locals.defaultIncidentTime = defaultTime
+      res.locals.incidentTimeRequired = false
     }
 
     next()
@@ -64,11 +64,11 @@ export abstract class BaseIncidentDateAndTimeController<
       }
 
       const reportType: Type = (req.sessionModel.get('type') as Type) ?? res.locals.report?.type
-      const defaultTime = incidentTypeDefaultTimes[reportType]
+      const timeRequired = incidentTypeRequiresTime[reportType] ?? true
 
-      if (defaultTime) {
+      if (!timeRequired) {
         // eslint-disable-next-line no-param-reassign
-        values.incidentTime = defaultTime as V['incidentTime']
+        values.incidentTime = '00:00' as V['incidentTime']
       } else {
         const errorValues = req.sessionModel.get('errorValues')
         const incidentTimeValue = errorValues?.incidentTime ?? values?.incidentTime
@@ -91,10 +91,10 @@ export abstract class BaseIncidentDateAndTimeController<
     next: express.NextFunction,
   ): void {
     const reportType: Type = (req.sessionModel.get('type') as Type) ?? res.locals.report?.type
-    const defaultTime = incidentTypeDefaultTimes[reportType]
+    const timeRequired = incidentTypeRequiresTime[reportType] ?? true
 
-    if (defaultTime) {
-      req.form.values.incidentTime = defaultTime as V['incidentTime']
+    if (!timeRequired) {
+      req.form.values.incidentTime = '00:00' as V['incidentTime']
     } else {
       const hours = req.form.values[hoursFieldName]
       const minutes = req.form.values[minutesFieldName]
@@ -114,7 +114,7 @@ export abstract class BaseIncidentDateAndTimeController<
   ): void {
     // if (and only if) incidentDate and incidentTime are valid, ensure that the combined date & time is in the past
     const { incidentDate, incidentTime } = req.form.values
-    const usingDefaultTime = Boolean(res.locals.defaultIncidentTime)
+    const timeRequired = res.locals.incidentTimeRequired ?? true
     try {
       const incidentDateAndTime = this.buildIncidentDateAndTime(incidentDate, incidentTime)
       const now = new Date()
@@ -127,8 +127,8 @@ export abstract class BaseIncidentDateAndTimeController<
           next({ incidentDate: error })
           return
         }
-        // Skip the time-in-future error when the time is a type-level default, not user-entered
-        if (!usingDefaultTime) {
+        // Skip the time-in-future error when the time field is not shown to the user
+        if (timeRequired) {
           const error = new this.Error('incidentTime', {
             field: hoursFieldName,
             key: 'incidentTime',

--- a/server/routes/reports/details/incidentDateAndTimeController.ts
+++ b/server/routes/reports/details/incidentDateAndTimeController.ts
@@ -10,7 +10,7 @@ import {
   hoursFieldName,
   minutesFieldName,
 } from './incidentDateAndTimeFields'
-import { incidentTypeHints, Type } from '../../../reportConfiguration/constants'
+import { incidentTypeHints, incidentTypeLabels, Type } from '../../../reportConfiguration/constants'
 
 type IncidentDateAndTimeControllerValues = IncidentDateAndTimeValues & { type?: Type }
 /**
@@ -22,12 +22,12 @@ export abstract class BaseIncidentDateAndTimeController<
   V extends IncidentDateAndTimeControllerValues,
 > extends BaseController<V, IncidentDateAndTimeFieldNames> {
   middlewareLocals(): void {
-    this.use(this.customiseIncidentDateHint)
+    this.use(this.customiseIncidentDateFields)
     super.middlewareLocals()
   }
 
-  /** Rewrite hint text for incident date if required */
-  private customiseIncidentDateHint(
+  /** Rewrite hint text and labels for incident date/time fields if configured for this type */
+  private customiseIncidentDateFields(
     req: FormWizard.Request<V, IncidentDateAndTimeFieldNames>,
     res: express.Response,
     next: express.NextFunction,
@@ -40,6 +40,10 @@ export abstract class BaseIncidentDateAndTimeController<
 
     if (incidentTypeHints[reportType]?.incidentTime) {
       req.form.options.fields.incidentTime.hint = incidentTypeHints[reportType].incidentTime
+    }
+
+    if (incidentTypeLabels[reportType]?.incidentDate) {
+      req.form.options.fields.incidentDate.label = incidentTypeLabels[reportType].incidentDate
     }
 
     next()

--- a/server/routes/reports/details/incidentDateAndTimeController.ts
+++ b/server/routes/reports/details/incidentDateAndTimeController.ts
@@ -10,7 +10,7 @@ import {
   hoursFieldName,
   minutesFieldName,
 } from './incidentDateAndTimeFields'
-import { incidentTypeHints, Type } from '../../../reportConfiguration/constants'
+import { incidentTypeDefaultTimes, incidentTypeHints, Type } from '../../../reportConfiguration/constants'
 
 type IncidentDateAndTimeControllerValues = IncidentDateAndTimeValues & { type?: Type }
 /**
@@ -22,12 +22,12 @@ export abstract class BaseIncidentDateAndTimeController<
   V extends IncidentDateAndTimeControllerValues,
 > extends BaseController<V, IncidentDateAndTimeFieldNames> {
   middlewareLocals(): void {
-    this.use(this.customiseIncidentDateHint)
+    this.use(this.customiseIncidentDateFields)
     super.middlewareLocals()
   }
 
-  /** Rewrite hint text for incident date if required */
-  private customiseIncidentDateHint(
+  /** Rewrite hint text and hide time field for incident date/time if configured for this type */
+  private customiseIncidentDateFields(
     req: FormWizard.Request<V, IncidentDateAndTimeFieldNames>,
     res: express.Response,
     next: express.NextFunction,
@@ -40,6 +40,13 @@ export abstract class BaseIncidentDateAndTimeController<
 
     if (incidentTypeHints[reportType]?.incidentTime) {
       req.form.options.fields.incidentTime.hint = incidentTypeHints[reportType].incidentTime
+    }
+
+    const defaultTime = incidentTypeDefaultTimes[reportType]
+    if (defaultTime) {
+      req.form.options.fields.incidentTime.component = 'hidden'
+      req.form.options.fields.incidentTime.validate = []
+      res.locals.defaultIncidentTime = defaultTime
     }
 
     next()
@@ -56,14 +63,22 @@ export abstract class BaseIncidentDateAndTimeController<
         return
       }
 
-      const errorValues = req.sessionModel.get('errorValues')
-      const incidentTimeValue = errorValues?.incidentTime ?? values?.incidentTime
-      if (incidentTimeValue) {
-        const [hours, minutes] = incidentTimeValue.split(':')
+      const reportType: Type = (req.sessionModel.get('type') as Type) ?? res.locals.report?.type
+      const defaultTime = incidentTypeDefaultTimes[reportType]
+
+      if (defaultTime) {
         // eslint-disable-next-line no-param-reassign
-        values[hoursFieldName] = hours
-        // eslint-disable-next-line no-param-reassign
-        values[minutesFieldName] = minutes
+        values.incidentTime = defaultTime as V['incidentTime']
+      } else {
+        const errorValues = req.sessionModel.get('errorValues')
+        const incidentTimeValue = errorValues?.incidentTime ?? values?.incidentTime
+        if (incidentTimeValue) {
+          const [hours, minutes] = incidentTimeValue.split(':')
+          // eslint-disable-next-line no-param-reassign
+          values[hoursFieldName] = hours
+          // eslint-disable-next-line no-param-reassign
+          values[minutesFieldName] = minutes
+        }
       }
 
       callback(null, values)
@@ -75,11 +90,18 @@ export abstract class BaseIncidentDateAndTimeController<
     res: express.Response,
     next: express.NextFunction,
   ): void {
-    const hours = req.form.values[hoursFieldName]
-    const minutes = req.form.values[minutesFieldName]
-    const digits = /^\d{1,2}$/
-    if (digits.test(hours) && digits.test(minutes)) {
-      req.form.values.incidentTime = `${hours.padStart(2, '0')}:${minutes.padStart(2, '0')}`
+    const reportType: Type = (req.sessionModel.get('type') as Type) ?? res.locals.report?.type
+    const defaultTime = incidentTypeDefaultTimes[reportType]
+
+    if (defaultTime) {
+      req.form.values.incidentTime = defaultTime as V['incidentTime']
+    } else {
+      const hours = req.form.values[hoursFieldName]
+      const minutes = req.form.values[minutesFieldName]
+      const digits = /^\d{1,2}$/
+      if (digits.test(hours) && digits.test(minutes)) {
+        req.form.values.incidentTime = `${hours.padStart(2, '0')}:${minutes.padStart(2, '0')}`
+      }
     }
 
     super.process(req, res, next)
@@ -92,6 +114,7 @@ export abstract class BaseIncidentDateAndTimeController<
   ): void {
     // if (and only if) incidentDate and incidentTime are valid, ensure that the combined date & time is in the past
     const { incidentDate, incidentTime } = req.form.values
+    const usingDefaultTime = Boolean(res.locals.defaultIncidentTime)
     try {
       const incidentDateAndTime = this.buildIncidentDateAndTime(incidentDate, incidentTime)
       const now = new Date()
@@ -104,13 +127,16 @@ export abstract class BaseIncidentDateAndTimeController<
           next({ incidentDate: error })
           return
         }
-        const error = new this.Error('incidentTime', {
-          field: hoursFieldName,
-          key: 'incidentTime',
-          message: 'Time of the incident must be in the past',
-        })
-        next({ incidentTime: error })
-        return
+        // Skip the time-in-future error when the time is a type-level default, not user-entered
+        if (!usingDefaultTime) {
+          const error = new this.Error('incidentTime', {
+            field: hoursFieldName,
+            key: 'incidentTime',
+            message: 'Time of the incident must be in the past',
+          })
+          next({ incidentTime: error })
+          return
+        }
       }
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {

--- a/server/routes/reports/details/incidentDateAndTimeController.ts
+++ b/server/routes/reports/details/incidentDateAndTimeController.ts
@@ -22,12 +22,12 @@ export abstract class BaseIncidentDateAndTimeController<
   V extends IncidentDateAndTimeControllerValues,
 > extends BaseController<V, IncidentDateAndTimeFieldNames> {
   middlewareLocals(): void {
-    this.use(this.customiseIncidentDateFields)
+    this.use(this.customiseIncidentDateAndTimeFields)
     super.middlewareLocals()
   }
 
   /** Rewrite hint text and hide time field for incident date/time if configured for this type */
-  private customiseIncidentDateFields(
+  private customiseIncidentDateAndTimeFields(
     req: FormWizard.Request<V, IncidentDateAndTimeFieldNames>,
     res: express.Response,
     next: express.NextFunction,

--- a/server/routes/reports/details/updateIncidentDateAndTime.test.ts
+++ b/server/routes/reports/details/updateIncidentDateAndTime.test.ts
@@ -101,6 +101,57 @@ describe('Updating report incident date and time', () => {
       })
   })
 
+  describe('Incident types with a default time (time field hidden)', () => {
+    beforeEach(() => {
+      reportBasic.type = 'UNLAWFUL_DETENTION_1' as Type
+    })
+
+    afterAll(() => {
+      reportBasic.type = 'DISORDER_2' as Type
+    })
+
+    it('should hide the time field and render it as a hidden input with the default value', () => {
+      return agent
+        .get(updateIncidentDateAndTimeUrl)
+        .expect(200)
+        .expect(res => {
+          expect(res.text).not.toContain('Time of incident')
+          expect(res.text).toContain('name="incidentTime" value="23:59"')
+        })
+    })
+
+    it('should submit the default time to the API when no time fields are provided by the user', () => {
+      const expectedDateAndTime = new Date('2024-10-21T23:59:00+01:00')
+      incidentReportingApi.updateReport.mockResolvedValueOnce(reportBasic)
+
+      return agent
+        .post(updateIncidentDateAndTimeUrl)
+        .send({ incidentDate: '21/10/2024', incidentTime: '23:59' })
+        .redirects(0)
+        .expect(302)
+        .expect(() => {
+          expect(incidentReportingApi.updateReport).toHaveBeenCalledWith(reportBasic.id, {
+            incidentDateAndTime: expectedDateAndTime,
+          })
+          mockHandleReportEdit.expectCalled()
+        })
+    })
+
+    it('should not show a time-in-future error when today is selected (default time may be in future)', () => {
+      const today = format.shortDate(new Date())
+      incidentReportingApi.updateReport.mockResolvedValueOnce(reportBasic)
+
+      return agent
+        .post(updateIncidentDateAndTimeUrl)
+        .send({ incidentDate: today, incidentTime: '23:59' })
+        .redirects(0)
+        .expect(302)
+        .expect(res => {
+          expect(res.header.location).toEqual(`/reports/${reportBasic.id}`)
+        })
+    })
+  })
+
   it('should display form prefilled with existing incident date and time', () => {
     return agent
       .get(updateIncidentDateAndTimeUrl)

--- a/server/routes/reports/details/updateIncidentDateAndTime.test.ts
+++ b/server/routes/reports/details/updateIncidentDateAndTime.test.ts
@@ -101,7 +101,7 @@ describe('Updating report incident date and time', () => {
       })
   })
 
-  describe('Incident types with a default time (time field hidden)', () => {
+  describe('Incident types where time is not required (time field hidden)', () => {
     beforeEach(() => {
       reportBasic.type = 'UNLAWFUL_DETENTION_1' as Type
     })
@@ -110,7 +110,7 @@ describe('Updating report incident date and time', () => {
       reportBasic.type = 'DISORDER_2' as Type
     })
 
-    it('should hide the time field and render it as a hidden input with the default value', () => {
+    it('should hide the time field and render it as a hidden input with 00:00', () => {
       return agent
         .get(updateIncidentDateAndTimeUrl)
         .expect(200)
@@ -120,7 +120,7 @@ describe('Updating report incident date and time', () => {
         })
     })
 
-    it('should submit the default time to the API when no time fields are provided by the user', () => {
+    it('should submit 00:00 to the API when the time field is not shown', () => {
       const expectedDateAndTime = new Date('2024-10-21T00:00:00+01:00')
       incidentReportingApi.updateReport.mockResolvedValueOnce(reportBasic)
 
@@ -137,7 +137,7 @@ describe('Updating report incident date and time', () => {
         })
     })
 
-    it('should not show a time-in-future error when today is selected (default time may be in future)', () => {
+    it('should not show a time-in-future error when today is selected (00:00 may be in future)', () => {
       const today = format.shortDate(new Date())
       incidentReportingApi.updateReport.mockResolvedValueOnce(reportBasic)
 

--- a/server/routes/reports/details/updateIncidentDateAndTime.test.ts
+++ b/server/routes/reports/details/updateIncidentDateAndTime.test.ts
@@ -101,6 +101,45 @@ describe('Updating report incident date and time', () => {
       })
   })
 
+  it.each([
+    { incidentType: 'FIND_6' },
+    { incidentType: 'ASSAULT_5' },
+    { incidentType: 'ATTEMPTED_ESCAPE_FROM_PRISON_1' },
+    { incidentType: 'DRONE_SIGHTING_3' },
+  ])('should show default label for incident type - $incidentType', ({ incidentType }) => {
+    reportBasic.type = incidentType as Type
+    return agent
+      .get(updateIncidentDateAndTimeUrl)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Date of incident')
+        expect(res.text).not.toContain('Date of release')
+        expect(res.text).not.toContain('Date meant for release')
+      })
+  })
+
+  it('should show bespoke label for release in error', () => {
+    reportBasic.type = 'RELEASE_IN_ERROR_1' as Type
+    return agent
+      .get(updateIncidentDateAndTimeUrl)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Date of release')
+        expect(res.text).not.toContain('Date of incident')
+      })
+  })
+
+  it('should show bespoke label for unlawful detention', () => {
+    reportBasic.type = 'UNLAWFUL_DETENTION_1' as Type
+    return agent
+      .get(updateIncidentDateAndTimeUrl)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Date meant for release')
+        expect(res.text).not.toContain('Date of incident')
+      })
+  })
+
   it('should display form prefilled with existing incident date and time', () => {
     return agent
       .get(updateIncidentDateAndTimeUrl)

--- a/server/routes/reports/details/updateIncidentDateAndTime.test.ts
+++ b/server/routes/reports/details/updateIncidentDateAndTime.test.ts
@@ -97,7 +97,7 @@ describe('Updating report incident date and time', () => {
       .get(updateIncidentDateAndTimeUrl)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('This should be the date the person was released - for example, 17/5/2024')
+        expect(res.text).toContain('For example, 17/5/2024')
       })
   })
 
@@ -124,7 +124,7 @@ describe('Updating report incident date and time', () => {
       .get(updateIncidentDateAndTimeUrl)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Date of release')
+        expect(res.text).toContain('Date the person was released')
         expect(res.text).not.toContain('Date of incident')
       })
   })
@@ -135,7 +135,7 @@ describe('Updating report incident date and time', () => {
       .get(updateIncidentDateAndTimeUrl)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Date meant for release')
+        expect(res.text).toContain('Date the person should have been released')
         expect(res.text).not.toContain('Date of incident')
       })
   })

--- a/server/routes/reports/details/updateIncidentDateAndTime.test.ts
+++ b/server/routes/reports/details/updateIncidentDateAndTime.test.ts
@@ -116,17 +116,17 @@ describe('Updating report incident date and time', () => {
         .expect(200)
         .expect(res => {
           expect(res.text).not.toContain('Time of incident')
-          expect(res.text).toContain('name="incidentTime" value="23:59"')
+          expect(res.text).toContain('name="incidentTime" value="00:00"')
         })
     })
 
     it('should submit the default time to the API when no time fields are provided by the user', () => {
-      const expectedDateAndTime = new Date('2024-10-21T23:59:00+01:00')
+      const expectedDateAndTime = new Date('2024-10-21T00:00:00+01:00')
       incidentReportingApi.updateReport.mockResolvedValueOnce(reportBasic)
 
       return agent
         .post(updateIncidentDateAndTimeUrl)
-        .send({ incidentDate: '21/10/2024', incidentTime: '23:59' })
+        .send({ incidentDate: '21/10/2024', incidentTime: '00:00' })
         .redirects(0)
         .expect(302)
         .expect(() => {
@@ -143,7 +143,7 @@ describe('Updating report incident date and time', () => {
 
       return agent
         .post(updateIncidentDateAndTimeUrl)
-        .send({ incidentDate: today, incidentTime: '23:59' })
+        .send({ incidentDate: today, incidentTime: '00:00' })
         .redirects(0)
         .expect(302)
         .expect(res => {


### PR DESCRIPTION
## What

Introduces a configurable label override for the `incidentDate` field so that individual incident types can replace the default "Date of incident" heading with something more semantically accurate.

<img width="1029" height="760" alt="Screenshot 2026-05-27 at 11 59 16" src="https://github.com/user-attachments/assets/cac49f5c-5858-495e-8f82-34bbbe2b1831" />



## Why

For some incident types the hint text was already customised to describe a different date (e.g. the intended release date for unlawful detention, or the actual release date for release in error), but the field label remained "Date of incident". This was misleading — the label is the prominent heading the user reads first, so it should match the meaning of the date being collected.

## How

A new `incidentTypeLabels` map has been added to `server/reportConfiguration/constants/types.ts`, parallel to the existing `incidentTypeHints` map. It follows the same `{ [K in Type]?: Record<string, string> }` shape.

The middleware method `customiseIncidentDateHint` in `BaseIncidentDateAndTimeController` has been renamed to `customiseIncidentDateFields` and extended to apply any label override from `incidentTypeLabels` via `req.form.options.fields.incidentDate.label`. This works automatically for both the create and edit flows since both use the same base controller.

Initial overrides:
- `RELEASE_IN_ERROR_1` → **"Date of release"**
- `UNLAWFUL_DETENTION_1` → **"Date meant for release"**

Adding further overrides in future only requires a new entry in `incidentTypeLabels` — no controller changes needed.

## Tests

Added to `updateIncidentDateAndTime.test.ts`:
- Parameterised test confirming regular incident types still show the default "Date of incident" label
- Test confirming `RELEASE_IN_ERROR_1` shows "Date of release" and not the default
- Test confirming `UNLAWFUL_DETENTION_1` shows "Date meant for release" and not the default

## Test plan
- [ ] Run unit tests: `npm test`
- [ ] Run type-check: `npm run typecheck`
- [ ] Manually verify the label change on the create report flow for UNLAWFUL_DETENTION_1 and RELEASE_IN_ERROR_1
- [ ] Verify other incident types still show "Date of incident"

## Summary

- Adds `incidentTypeDefaultTimes` config map in `types.ts` (same pattern as existing `incidentTypeHints`). When a type has an entry, its time-of-incident field is hidden from the user and the configured value is submitted to the API automatically.
- `UNLAWFUL_DETENTION_1` defaults to `00:00` (time of occurrence is not meaningful for this type).
- Removed the `incidentTime` hint for `UNLAWFUL_DETENTION_1` since the field is no longer shown.
- Controller changes in `BaseIncidentDateAndTimeController` cover `middlewareLocals` (hides field, sets default in `res.locals`), `getValues`, `process`, and `validate` (skips "time must be in the past" error for type-level defaults).


## Test plan

- [ ] New `describe` block in `updateIncidentDateAndTime.test.ts` verifies hidden field rendering, API submission with default time, and exemption from the future-time error
- [ ] `afterAll` reset in the new describe block prevents `reportBasic.type` mutation from bleeding into subsequent tests
- [ ] All 2595 unit tests pass (`npm test`)
- [ ] Manually verify: load a report with type `UNLAWFUL_DETENTION_1` and navigate to update-date-and-time — time field should be absent, hidden input `name="incidentTime" value="00:00"` should be present, and submitting should call the API with `00:00` as the time component
