### PR TITLE
IR-1651: Auto-skip radio/checkbox when question has only one active answer

### DIFF
--- a/server/@types/hmpo-form-wizard/application-extensions.d.ts
+++ b/server/@types/hmpo-form-wizard/application-extensions.d.ts
@@ -17,6 +17,8 @@ declare module 'hmpo-form-wizard' {
         | 'govukTextarea'
         | 'mojDatePicker'
         | 'appTime'
+      /** True when this field has only one active answer and is auto-selected (rendered as a hidden input) */
+      singleAnswer?: boolean
     }
 
     interface FieldItem {

--- a/server/data/incidentTypeConfiguration/formWizard.test.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.test.ts
@@ -12,8 +12,29 @@ const testConfig: IncidentTypeConfiguration = {
   incidentType: 'MISCELLANEOUS_1',
   active: true,
   prisonerRoles: [],
-  startingQuestionCode: 'qanimals',
+  startingQuestionCode: 'qsingledate',
   questions: {
+    // Single-answer question with a mandatory date (and a hint via commentLabel)
+    qsingledate: {
+      code: 'qsingledate',
+      question: 'WHEN WAS THE EVENT',
+      label: 'When was the event?',
+      active: true,
+      multipleAnswers: false,
+      answers: [
+        {
+          code: 'qsingledate-a1',
+          response: 'DATE ONLY',
+          label: 'Enter date',
+          active: true,
+          dateMandatory: true,
+          commentRequested: false,
+          commentMandatory: false,
+          commentLabel: 'For example, 17/5/2026',
+          nextQuestionCode: 'qanimals',
+        },
+      ],
+    },
     qanimals: {
       code: 'qanimals',
       question: 'WHICH ANIMALS DO YOU LIKE',
@@ -185,12 +206,14 @@ describe.each([
         reset: true,
         resetJourney: true,
         skip: true,
-        next: 'qanimals',
+        next: 'qsingledate',
         controller: EmptyController,
       },
-      '/qanimals': {
+      // Single-answer qsingledate is merged with the following non-branching qanimals step.
+      // qanimals is always reached only via qsingledate (single parent), so they are grouped.
+      '/qsingledate': {
         controller: QuestionsController,
-        fields: ['qanimals'],
+        fields: ['qsingledate', 'qsingledate-qsingledate-a1-date', 'qanimals'],
         next: [
           {
             field: 'qanimals',
@@ -269,6 +292,37 @@ describe('generateFields()', () => {
     const fields = generateFields(testConfig)
 
     expect(fields).toEqual({
+      // Single-answer question: hidden field + date sub-field with hint from commentLabel
+      qsingledate: {
+        name: 'qsingledate',
+        label: 'When was the event?',
+        validate: [],
+        multiple: false,
+        component: 'hidden',
+        singleAnswer: true,
+        default: 'DATE ONLY',
+        items: [
+          {
+            value: 'DATE ONLY',
+            label: 'Enter date',
+            hint: undefined,
+            dateRequired: true,
+            commentRequired: false,
+          },
+        ],
+      },
+      'qsingledate-qsingledate-a1-date': {
+        name: 'qsingledate-qsingledate-a1-date',
+        label: 'Date',
+        visuallyHiddenText: 'for Enter date',
+        hint: 'For example, 17/5/2026',
+        component: 'mojDatePicker',
+        validate: ['required', 'ukDate'],
+        dependent: {
+          field: 'qsingledate',
+          value: 'DATE ONLY',
+        },
+      },
       qanimals: {
         name: 'qanimals',
         label: 'Which animals do you like?',
@@ -402,6 +456,209 @@ describe('generateFields()', () => {
         ],
       },
     })
+  })
+})
+
+describe('generateFields() for single-answer questions', () => {
+  const singleAnswerConfig: IncidentTypeConfiguration = {
+    incidentType: 'MISCELLANEOUS_1',
+    active: true,
+    prisonerRoles: [],
+    startingQuestionCode: 'qdateonly',
+    questions: {
+      qdateonly: {
+        code: 'qdateonly',
+        question: 'WHEN WAS THE DATE',
+        label: 'When was the date?',
+        active: true,
+        multipleAnswers: false,
+        answers: [
+          {
+            code: 'qdateonly-a1',
+            response: 'DATE_RESPONSE',
+            label: 'Enter date',
+            active: true,
+            dateMandatory: true,
+            commentRequested: false,
+            commentMandatory: false,
+            commentLabel: 'For example, 17/5/2026',
+            nextQuestionCode: 'qcommentonly',
+          },
+        ],
+      },
+      qcommentonly: {
+        code: 'qcommentonly',
+        question: 'ENTER A COMMENT',
+        label: 'Enter a comment',
+        active: true,
+        multipleAnswers: false,
+        answers: [
+          {
+            code: 'qcommentonly-a1',
+            response: 'COMMENT_RESPONSE',
+            label: 'Enter details',
+            active: true,
+            dateMandatory: false,
+            commentRequested: true,
+            commentMandatory: true,
+            commentLabel: 'Provide your comment here',
+            nextQuestionCode: 'qdatepluscomment',
+          },
+        ],
+      },
+      qdatepluscomment: {
+        code: 'qdatepluscomment',
+        question: 'DATE AND COMMENT',
+        label: 'Date and comment',
+        active: true,
+        multipleAnswers: false,
+        answers: [
+          {
+            code: 'qdatepluscomment-a1',
+            response: 'DATE_AND_COMMENT_RESPONSE',
+            label: 'Enter date and comment',
+            active: true,
+            dateMandatory: true,
+            commentRequested: true,
+            commentMandatory: true,
+            commentLabel: 'Describe the event',
+            nextQuestionCode: null,
+          },
+        ],
+      },
+      qnone: {
+        code: 'qnone',
+        question: 'NO DATE OR COMMENT',
+        label: 'No date or comment',
+        active: true,
+        multipleAnswers: false,
+        answers: [
+          {
+            code: 'qnone-a1',
+            response: 'NONE_RESPONSE',
+            label: 'Auto answer',
+            active: true,
+            dateMandatory: false,
+            commentRequested: false,
+            commentMandatory: false,
+            nextQuestionCode: null,
+          },
+        ],
+      },
+    },
+  }
+
+  it('single-answer with date only: hidden field + date sub-field with commentLabel as hint', () => {
+    const fields = generateFields(singleAnswerConfig)
+
+    expect(fields.qdateonly).toEqual({
+      name: 'qdateonly',
+      label: 'When was the date?',
+      validate: [],
+      multiple: false,
+      component: 'hidden',
+      singleAnswer: true,
+      default: 'DATE_RESPONSE',
+      items: [
+        { value: 'DATE_RESPONSE', label: 'Enter date', hint: undefined, dateRequired: true, commentRequired: false },
+      ],
+    })
+
+    expect(fields['qdateonly-qdateonly-a1-date']).toEqual({
+      name: 'qdateonly-qdateonly-a1-date',
+      label: 'Date',
+      visuallyHiddenText: 'for Enter date',
+      hint: 'For example, 17/5/2026',
+      component: 'mojDatePicker',
+      validate: ['required', 'ukDate'],
+      dependent: { field: 'qdateonly', value: 'DATE_RESPONSE' },
+    })
+  })
+
+  it('single-answer with comment only: hidden field + comment sub-field', () => {
+    const fields = generateFields(singleAnswerConfig)
+
+    expect(fields.qcommentonly).toEqual({
+      name: 'qcommentonly',
+      label: 'Enter a comment',
+      validate: [],
+      multiple: false,
+      component: 'hidden',
+      singleAnswer: true,
+      default: 'COMMENT_RESPONSE',
+      items: [
+        {
+          value: 'COMMENT_RESPONSE',
+          label: 'Enter details',
+          hint: undefined,
+          dateRequired: false,
+          commentRequired: true,
+        },
+      ],
+    })
+
+    expect(fields['qcommentonly-qcommentonly-a1-comment']).toEqual({
+      name: 'qcommentonly-qcommentonly-a1-comment',
+      label: 'Provide your comment here',
+      visuallyHiddenText: 'for Enter details',
+      component: 'govukInput',
+      validate: ['required'],
+      dependent: { field: 'qcommentonly', value: 'COMMENT_RESPONSE' },
+    })
+
+    // No date sub-field generated
+    expect(fields['qcommentonly-qcommentonly-a1-date']).toBeUndefined()
+  })
+
+  it('single-answer with date + comment: commentLabel is the comment label (not the date hint)', () => {
+    const fields = generateFields(singleAnswerConfig)
+
+    expect(fields.qdatepluscomment).toMatchObject({
+      component: 'hidden',
+      singleAnswer: true,
+      default: 'DATE_AND_COMMENT_RESPONSE',
+    })
+
+    // Date field has no hint (commentLabel belongs to the comment field, not the date)
+    expect(fields['qdatepluscomment-qdatepluscomment-a1-date']).toEqual({
+      name: 'qdatepluscomment-qdatepluscomment-a1-date',
+      label: 'Date',
+      visuallyHiddenText: 'for Enter date and comment',
+      hint: undefined,
+      component: 'mojDatePicker',
+      validate: ['required', 'ukDate'],
+      dependent: { field: 'qdatepluscomment', value: 'DATE_AND_COMMENT_RESPONSE' },
+    })
+
+    // Comment field uses commentLabel as its label
+    expect(fields['qdatepluscomment-qdatepluscomment-a1-comment']).toEqual({
+      name: 'qdatepluscomment-qdatepluscomment-a1-comment',
+      label: 'Describe the event',
+      visuallyHiddenText: 'for Enter date and comment',
+      component: 'govukInput',
+      validate: ['required'],
+      dependent: { field: 'qdatepluscomment', value: 'DATE_AND_COMMENT_RESPONSE' },
+    })
+  })
+
+  it('single-answer with no date or comment: hidden field only, no sub-fields', () => {
+    const fields = generateFields(singleAnswerConfig)
+
+    expect(fields.qnone).toEqual({
+      name: 'qnone',
+      label: 'No date or comment',
+      validate: [],
+      multiple: false,
+      component: 'hidden',
+      singleAnswer: true,
+      default: 'NONE_RESPONSE',
+      items: [
+        { value: 'NONE_RESPONSE', label: 'Auto answer', hint: undefined, dateRequired: false, commentRequired: false },
+      ],
+    })
+
+    expect(fields['qnone-qnone-a1-date']).toBeUndefined()
+    expect(fields['qnone-qnone-a1-comment']).toBeUndefined()
   })
 })
 

--- a/server/data/incidentTypeConfiguration/formWizard.test.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.test.ts
@@ -712,7 +712,7 @@ describe('generateFields() for single-answer questions', () => {
     })
   })
 
-  it('single-answer comment with no commentLabel: comment sub-field has no visible label', () => {
+  it('single-answer comment with no commentLabel: answer label is used instead (e.g. "Specify location")', () => {
     const fields = generateFields(singleAnswerConfig)
 
     // Hidden field is unaffected
@@ -722,10 +722,10 @@ describe('generateFields() for single-answer questions', () => {
       default: 'COMMENT_RESPONSE',
     })
 
-    // Comment sub-field: label is undefined because commentLabel is not set
+    // Comment sub-field: falls back to singleAnswer.label when commentLabel is absent
     expect(fields['qcommentnolabel-qcommentnolabel-a1-comment']).toEqual({
       name: 'qcommentnolabel-qcommentnolabel-a1-comment',
-      label: undefined,
+      label: 'Enter details:',
       component: 'govukInput',
       validate: ['required'],
       dependent: { field: 'qcommentnolabel', value: 'COMMENT_RESPONSE' },

--- a/server/data/incidentTypeConfiguration/formWizard.test.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.test.ts
@@ -544,6 +544,45 @@ describe('generateFields() for single-answer questions', () => {
           },
         ],
       },
+      // Questions with no commentLabel: sub-field labels should be suppressed
+      qdatenolabel: {
+        code: 'qdatenolabel',
+        question: 'ENTER THE DATE',
+        label: 'Enter the date',
+        active: true,
+        multipleAnswers: false,
+        answers: [
+          {
+            code: 'qdatenolabel-a1',
+            response: 'DATE_RESPONSE',
+            label: 'Date:',
+            active: true,
+            dateMandatory: true,
+            commentRequested: false,
+            commentMandatory: false,
+            nextQuestionCode: null,
+          },
+        ],
+      },
+      qcommentnolabel: {
+        code: 'qcommentnolabel',
+        question: 'ENTER DETAILS',
+        label: 'Enter details',
+        active: true,
+        multipleAnswers: false,
+        answers: [
+          {
+            code: 'qcommentnolabel-a1',
+            response: 'COMMENT_RESPONSE',
+            label: 'Enter details:',
+            active: true,
+            dateMandatory: false,
+            commentRequested: true,
+            commentMandatory: true,
+            nextQuestionCode: null,
+          },
+        ],
+      },
     },
   }
 
@@ -654,6 +693,43 @@ describe('generateFields() for single-answer questions', () => {
 
     expect(fields['qnone-qnone-a1-date']).toBeUndefined()
     expect(fields['qnone-qnone-a1-comment']).toBeUndefined()
+  })
+
+  it('single-answer date with no commentLabel: date sub-field has no visible label', () => {
+    const fields = generateFields(singleAnswerConfig)
+
+    // Hidden field is unaffected
+    expect(fields.qdatenolabel).toMatchObject({ component: 'hidden', singleAnswer: true, default: 'DATE_RESPONSE' })
+
+    // Date sub-field: label is undefined because commentLabel is not set
+    expect(fields['qdatenolabel-qdatenolabel-a1-date']).toEqual({
+      name: 'qdatenolabel-qdatenolabel-a1-date',
+      label: undefined,
+      hint: undefined,
+      component: 'mojDatePicker',
+      validate: ['required', 'ukDate'],
+      dependent: { field: 'qdatenolabel', value: 'DATE_RESPONSE' },
+    })
+  })
+
+  it('single-answer comment with no commentLabel: comment sub-field has no visible label', () => {
+    const fields = generateFields(singleAnswerConfig)
+
+    // Hidden field is unaffected
+    expect(fields.qcommentnolabel).toMatchObject({
+      component: 'hidden',
+      singleAnswer: true,
+      default: 'COMMENT_RESPONSE',
+    })
+
+    // Comment sub-field: label is undefined because commentLabel is not set
+    expect(fields['qcommentnolabel-qcommentnolabel-a1-comment']).toEqual({
+      name: 'qcommentnolabel-qcommentnolabel-a1-comment',
+      label: undefined,
+      component: 'govukInput',
+      validate: ['required'],
+      dependent: { field: 'qcommentnolabel', value: 'COMMENT_RESPONSE' },
+    })
   })
 })
 

--- a/server/data/incidentTypeConfiguration/formWizard.test.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.test.ts
@@ -313,8 +313,7 @@ describe('generateFields()', () => {
       },
       'qsingledate-qsingledate-a1-date': {
         name: 'qsingledate-qsingledate-a1-date',
-        label: 'Date',
-        visuallyHiddenText: 'for Enter date',
+        label: 'Enter date',
         hint: 'For example, 17/5/2026',
         component: 'mojDatePicker',
         validate: ['required', 'ukDate'],
@@ -566,8 +565,7 @@ describe('generateFields() for single-answer questions', () => {
 
     expect(fields['qdateonly-qdateonly-a1-date']).toEqual({
       name: 'qdateonly-qdateonly-a1-date',
-      label: 'Date',
-      visuallyHiddenText: 'for Enter date',
+      label: 'Enter date',
       hint: 'For example, 17/5/2026',
       component: 'mojDatePicker',
       validate: ['required', 'ukDate'],
@@ -600,7 +598,6 @@ describe('generateFields() for single-answer questions', () => {
     expect(fields['qcommentonly-qcommentonly-a1-comment']).toEqual({
       name: 'qcommentonly-qcommentonly-a1-comment',
       label: 'Provide your comment here',
-      visuallyHiddenText: 'for Enter details',
       component: 'govukInput',
       validate: ['required'],
       dependent: { field: 'qcommentonly', value: 'COMMENT_RESPONSE' },
@@ -619,11 +616,10 @@ describe('generateFields() for single-answer questions', () => {
       default: 'DATE_AND_COMMENT_RESPONSE',
     })
 
-    // Date field has no hint (commentLabel belongs to the comment field, not the date)
+    // Date field uses the answer's descriptive label; no hint (commentLabel belongs to the comment field)
     expect(fields['qdatepluscomment-qdatepluscomment-a1-date']).toEqual({
       name: 'qdatepluscomment-qdatepluscomment-a1-date',
-      label: 'Date',
-      visuallyHiddenText: 'for Enter date and comment',
+      label: 'Enter date and comment',
       hint: undefined,
       component: 'mojDatePicker',
       validate: ['required', 'ukDate'],
@@ -634,7 +630,6 @@ describe('generateFields() for single-answer questions', () => {
     expect(fields['qdatepluscomment-qdatepluscomment-a1-comment']).toEqual({
       name: 'qdatepluscomment-qdatepluscomment-a1-comment',
       label: 'Describe the event',
-      visuallyHiddenText: 'for Enter date and comment',
       component: 'govukInput',
       validate: ['required'],
       dependent: { field: 'qdatepluscomment', value: 'DATE_AND_COMMENT_RESPONSE' },

--- a/server/data/incidentTypeConfiguration/formWizard.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.ts
@@ -240,61 +240,123 @@ function generateFields(config: IncidentTypeConfiguration): FormWizard.Fields {
       const activeAnswers = question.answers.filter(answer => answer.active)
 
       const fieldName = question.code
-      fields[fieldName] = {
-        name: fieldName,
-        label: question.label,
-        hint: question.questionHint,
-        validate: ['required'],
-        multiple: question.multipleAnswers,
-        component: question.multipleAnswers ? 'govukCheckboxes' : 'govukRadios',
-        items: activeAnswers.map(answer => {
-          const fieldItem: FormWizard.FieldItem = {
-            value: answer.response,
-            label: answer.label,
-            hint: answer.responseHint,
-            dateRequired: answer.dateMandatory,
-            commentRequired: answer.commentRequested,
-          }
 
-          if (answer.commentMandatory) {
-            fieldItem.visuallyHiddenText = 'If selected, provide details'
-          }
+      if (activeAnswers.length === 1) {
+        // Single active answer: auto-select it and show date/comment fields directly,
+        // skipping the unnecessary radio/checkbox step
+        const singleAnswer = activeAnswers[0]
 
-          return fieldItem
-        }),
-      } satisfies FormWizard.Field
+        fields[fieldName] = {
+          name: fieldName,
+          label: question.label,
+          hint: question.questionHint,
+          validate: [],
+          multiple: question.multipleAnswers,
+          component: 'hidden',
+          singleAnswer: true,
+          default: singleAnswer.response,
+          items: [
+            {
+              value: singleAnswer.response,
+              label: singleAnswer.label,
+              hint: singleAnswer.responseHint,
+              dateRequired: singleAnswer.dateMandatory,
+              commentRequired: singleAnswer.commentRequested,
+            },
+          ],
+        } satisfies FormWizard.Field
 
-      // Add conditional comment/date fields
-      for (const answer of activeAnswers) {
-        if (answer.dateMandatory) {
-          const dateFieldName = conditionalFieldName(question, answer, 'date')
+        if (singleAnswer.dateMandatory) {
+          const dateFieldName = conditionalFieldName(question, singleAnswer, 'date')
           fields[dateFieldName] = {
             name: dateFieldName,
             label: 'Date',
-            visuallyHiddenText: `for ${answer.label}`,
+            visuallyHiddenText: `for ${singleAnswer.label}`,
+            // When there is no comment field, commentLabel is used as the date hint
+            // (e.g. "For example, 17/5/2026")
+            hint: !singleAnswer.commentRequested ? singleAnswer.commentLabel : undefined,
             component: 'mojDatePicker',
             validate: ['required', 'ukDate'],
             dependent: {
               field: fieldName,
-              value: answer.response,
+              value: singleAnswer.response,
             },
           } satisfies FormWizard.Field
         }
 
-        if (answer.commentRequested) {
-          const commentFieldName = conditionalFieldName(question, answer, 'comment')
-          const commentLabel = answer.commentLabel || 'Comment'
+        if (singleAnswer.commentRequested) {
+          const commentFieldName = conditionalFieldName(question, singleAnswer, 'comment')
+          const commentLabel = singleAnswer.commentLabel || 'Comment'
           fields[commentFieldName] = {
             name: commentFieldName,
             label: commentLabel,
-            visuallyHiddenText: `for ${answer.label}`,
+            visuallyHiddenText: `for ${singleAnswer.label}`,
             component: 'govukInput',
             validate: ['required'],
             dependent: {
               field: fieldName,
-              value: answer.response,
+              value: singleAnswer.response,
             },
           } satisfies FormWizard.Field
+        }
+      } else {
+        // Multiple active answers: render as radio buttons or checkboxes
+        fields[fieldName] = {
+          name: fieldName,
+          label: question.label,
+          hint: question.questionHint,
+          validate: ['required'],
+          multiple: question.multipleAnswers,
+          component: question.multipleAnswers ? 'govukCheckboxes' : 'govukRadios',
+          items: activeAnswers.map(answer => {
+            const fieldItem: FormWizard.FieldItem = {
+              value: answer.response,
+              label: answer.label,
+              hint: answer.responseHint,
+              dateRequired: answer.dateMandatory,
+              commentRequired: answer.commentRequested,
+            }
+
+            if (answer.commentMandatory) {
+              fieldItem.visuallyHiddenText = 'If selected, provide details'
+            }
+
+            return fieldItem
+          }),
+        } satisfies FormWizard.Field
+
+        // Add conditional comment/date fields
+        for (const answer of activeAnswers) {
+          if (answer.dateMandatory) {
+            const dateFieldName = conditionalFieldName(question, answer, 'date')
+            fields[dateFieldName] = {
+              name: dateFieldName,
+              label: 'Date',
+              visuallyHiddenText: `for ${answer.label}`,
+              component: 'mojDatePicker',
+              validate: ['required', 'ukDate'],
+              dependent: {
+                field: fieldName,
+                value: answer.response,
+              },
+            } satisfies FormWizard.Field
+          }
+
+          if (answer.commentRequested) {
+            const commentFieldName = conditionalFieldName(question, answer, 'comment')
+            const commentLabel = answer.commentLabel || 'Comment'
+            fields[commentFieldName] = {
+              name: commentFieldName,
+              label: commentLabel,
+              visuallyHiddenText: `for ${answer.label}`,
+              component: 'govukInput',
+              validate: ['required'],
+              dependent: {
+                field: fieldName,
+                value: answer.response,
+              },
+            } satisfies FormWizard.Field
+          }
         }
       }
     })

--- a/server/data/incidentTypeConfiguration/formWizard.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.ts
@@ -290,8 +290,9 @@ function generateFields(config: IncidentTypeConfiguration): FormWizard.Fields {
         if (singleAnswer.commentRequested) {
           const commentFieldName = conditionalFieldName(question, singleAnswer, 'comment')
           // Use commentLabel as the visible label (e.g. "Provide your comment here").
-          // When not set the fieldset legend provides context; suppress the generic "Comment" fallback.
-          const { commentLabel } = singleAnswer
+          // Fall back to the answer's own label (e.g. "Specify location") when commentLabel is absent.
+          // Never show the generic word "Comment".
+          const commentLabel = singleAnswer.commentLabel || singleAnswer.label
           fields[commentFieldName] = {
             name: commentFieldName,
             label: commentLabel,

--- a/server/data/incidentTypeConfiguration/formWizard.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.ts
@@ -270,9 +270,11 @@ function generateFields(config: IncidentTypeConfiguration): FormWizard.Fields {
           const dateFieldName = conditionalFieldName(question, singleAnswer, 'date')
           fields[dateFieldName] = {
             name: dateFieldName,
-            // Use the answer's descriptive label (e.g. "Enter date of first error identified")
-            // rather than the generic "Date", since the radio is not shown to provide context
-            label: singleAnswer.label,
+            // Only show a label when commentLabel is set — it signals that a descriptive label
+            // (e.g. "Enter date of first error identified") is meaningful. Without commentLabel
+            // the fieldset legend alone provides sufficient context, so we suppress the label
+            // to avoid showing a generic "Date:" above the picker.
+            label: singleAnswer.commentLabel ? singleAnswer.label : undefined,
             // When there is no comment field, commentLabel is used as the date hint
             // (e.g. "For example, 17/5/2026")
             hint: !singleAnswer.commentRequested ? singleAnswer.commentLabel : undefined,
@@ -287,8 +289,9 @@ function generateFields(config: IncidentTypeConfiguration): FormWizard.Fields {
 
         if (singleAnswer.commentRequested) {
           const commentFieldName = conditionalFieldName(question, singleAnswer, 'comment')
-          // commentLabel is the specific label for the comment input (e.g. "Provide your comment here")
-          const commentLabel = singleAnswer.commentLabel || 'Comment'
+          // Use commentLabel as the visible label (e.g. "Provide your comment here").
+          // When not set the fieldset legend provides context; suppress the generic "Comment" fallback.
+          const { commentLabel } = singleAnswer
           fields[commentFieldName] = {
             name: commentFieldName,
             label: commentLabel,

--- a/server/data/incidentTypeConfiguration/formWizard.ts
+++ b/server/data/incidentTypeConfiguration/formWizard.ts
@@ -270,8 +270,9 @@ function generateFields(config: IncidentTypeConfiguration): FormWizard.Fields {
           const dateFieldName = conditionalFieldName(question, singleAnswer, 'date')
           fields[dateFieldName] = {
             name: dateFieldName,
-            label: 'Date',
-            visuallyHiddenText: `for ${singleAnswer.label}`,
+            // Use the answer's descriptive label (e.g. "Enter date of first error identified")
+            // rather than the generic "Date", since the radio is not shown to provide context
+            label: singleAnswer.label,
             // When there is no comment field, commentLabel is used as the date hint
             // (e.g. "For example, 17/5/2026")
             hint: !singleAnswer.commentRequested ? singleAnswer.commentLabel : undefined,
@@ -286,11 +287,11 @@ function generateFields(config: IncidentTypeConfiguration): FormWizard.Fields {
 
         if (singleAnswer.commentRequested) {
           const commentFieldName = conditionalFieldName(question, singleAnswer, 'comment')
+          // commentLabel is the specific label for the comment input (e.g. "Provide your comment here")
           const commentLabel = singleAnswer.commentLabel || 'Comment'
           fields[commentFieldName] = {
             name: commentFieldName,
             label: commentLabel,
-            visuallyHiddenText: `for ${singleAnswer.label}`,
             component: 'govukInput',
             validate: ['required'],
             dependent: {

--- a/server/routes/reports/questions/index.test.ts
+++ b/server/routes/reports/questions/index.test.ts
@@ -320,6 +320,123 @@ describe('Displaying questions and responses', () => {
       })
     })
 
+    describe('Single-answer questions', () => {
+      /**
+       * RELEASE_IN_ERROR_1 questions 45184 ("What date was the error identified?")
+       * and 45185 ("What was the category of the person?") each have exactly one active answer.
+       *
+       * After groupSteps merging, questions 45182+45183+45184+45185 end up on the same
+       * form wizard step at URL /45182 (7+8+1+1 = 17 answers ≤ MAX_ANSWERS_PER_PAGE=20).
+       * Questions 45179+45180+45181 are on the prior step at URL /45179.
+       *
+       * Pre-requisite: provide answers for step /45179 (questions 45179→45181) so that
+       * the form wizard allows access to step /45182.
+       */
+      function answeredQuestionsOnStep45179(): Question[] {
+        return [
+          makeSimpleQuestion('45179', 'HOW WAS THIS PERSON RELEASED', ['Bail', '183020']),
+          {
+            code: '45180',
+            question: 'WHERE DID THE RELEASE OCCUR FROM',
+            label: 'Where did the release occur from?',
+            additionalInformation: null,
+            responses: [
+              {
+                code: '183026',
+                response: 'Establishment : Enter name',
+                label: 'Establishment : enter name',
+                responseDate: null,
+                additionalInformation: 'Test prison',
+                recordedBy: 'USER1',
+                recordedAt: now,
+              },
+            ],
+          },
+          makeSimpleQuestion('45181', 'WHAT WAS THE NATURE OF THE INCIDENT', ['Wrong person released', '183029']),
+        ]
+      }
+
+      it('single-answer date/comment questions are rendered directly without radio buttons', () => {
+        reportWithDetails.type = 'RELEASE_IN_ERROR_1'
+        reportWithDetails.questions = answeredQuestionsOnStep45179()
+
+        // Step /45182 is the merged step containing questions 45182, 45183, 45184, 45185
+        return agent
+          .get(`${reportQuestionsUrl(createJourney)}/45182`)
+          .redirects(1)
+          .expect(200)
+          .expect(res => {
+            // Single-answer main fields must NOT render radio buttons
+            expect(res.text).not.toContain('name="45184" type="radio"')
+            expect(res.text).not.toContain('name="45185" type="radio"')
+            // The date and comment sub-fields must be rendered directly (no conditional wrapper)
+            expect(res.text).toContain('name="45184-183055-date"')
+            expect(res.text).toContain('name="45185-183056-comment"')
+            // Question labels are shown as fieldset legends
+            expect(res.text).toContain('What date was the error identified?')
+            expect(res.text).toContain('What was the category of the person?')
+          })
+      })
+
+      it('single-answer questions are prefilled from existing report answers', () => {
+        reportWithDetails.type = 'RELEASE_IN_ERROR_1'
+        reportWithDetails.questions = [
+          ...answeredQuestionsOnStep45179(),
+          makeSimpleQuestion(
+            '45182',
+            'WHAT ACTION IS BEING TAKEN TO RETURN THE PERSON TO CUSTODY BY THE ESTABLISHMENT',
+            ['Recall procedures', '183040'],
+          ),
+          makeSimpleQuestion('45183', 'HOW WAS THE ERROR IDENTIFIED', ['Contact from courts', '183048']),
+          {
+            code: '45184',
+            question: 'WHAT DATE WAS THE ERROR IDENTIFIED',
+            label: 'What date was the error identified?',
+            additionalInformation: null,
+            responses: [
+              {
+                code: '183055',
+                response: 'Date:',
+                label: 'Date:',
+                responseDate: now,
+                additionalInformation: null,
+                recordedBy: 'USER1',
+                recordedAt: now,
+              },
+            ],
+          },
+          {
+            code: '45185',
+            question: 'WHAT WAS THE CATEGORY OF THE PERSON',
+            label: 'What was the category of the person?',
+            additionalInformation: null,
+            responses: [
+              {
+                code: '183056',
+                response: 'Enter details:',
+                label: 'Enter details:',
+                responseDate: null,
+                additionalInformation: 'Category A',
+                recordedBy: 'USER1',
+                recordedAt: now,
+              },
+            ],
+          },
+        ]
+
+        // Step /45182 is the merged step containing questions 45182, 45183, 45184, 45185
+        return agent
+          .get(`${reportQuestionsUrl(createJourney)}/45182`)
+          .redirects(1)
+          .expect(200)
+          .expect(res => {
+            // The date and comment are pre-filled from saved answers
+            expect(res.text).toContain('name="45184-183055-date" type="text" value="5/12/2023"')
+            expect(res.text).toContain('value="Category A"')
+          })
+      })
+    })
+
     describe('Moving between question pages', () => {
       it.each([
         { scenario: 'no responses so far', someResponses: false },

--- a/server/views/macros/renderDateField.njk
+++ b/server/views/macros/renderDateField.njk
@@ -15,6 +15,7 @@
     id: fieldName,
     label: {
       html: field.label + visuallyHiddenText,
+      classes: "govuk-visually-hidden" if not (field.label or visuallyHiddenText),
       attributes: {
         id: fieldName + "__label"
       }

--- a/server/views/macros/renderDateField.njk
+++ b/server/views/macros/renderDateField.njk
@@ -14,7 +14,7 @@
     name: fieldName,
     id: fieldName,
     label: {
-      html: field.label + visuallyHiddenText,
+      html: (field.label or "") + visuallyHiddenText,
       classes: "govuk-visually-hidden" if not (field.label or visuallyHiddenText),
       attributes: {
         id: fieldName + "__label"

--- a/server/views/macros/renderField.njk
+++ b/server/views/macros/renderField.njk
@@ -46,7 +46,7 @@
       id: fieldName,
       classes: "govuk-!-width-three-quarters",
       label: {
-        html: field.label + visuallyHiddenText,
+        html: (field.label or "") + visuallyHiddenText,
         classes: "govuk-visually-hidden" if not (field.label or visuallyHiddenText),
         attributes: {
           id: fieldName + "__label"

--- a/server/views/macros/renderField.njk
+++ b/server/views/macros/renderField.njk
@@ -47,6 +47,7 @@
       classes: "govuk-!-width-three-quarters",
       label: {
         html: field.label + visuallyHiddenText,
+        classes: "govuk-visually-hidden" if not (field.label or visuallyHiddenText),
         attributes: {
           id: fieldName + "__label"
         }

--- a/server/views/pages/reports/questions.njk
+++ b/server/views/pages/reports/questions.njk
@@ -16,10 +16,36 @@
   {% for fieldName in questionSteps[options.route].fields %}
     {% set field = options.fields[fieldName] %}
 
-    {# NB:
-      - dependent fields are currently only used in conditionals so are rendered separately
-    #}
-    {% if not field.dependent %}
+    {% if field.singleAnswer %}
+      {# Single-answer question: the answer is auto-selected via a hidden input.
+         Date/comment sub-fields are rendered directly inside a fieldset, skipping
+         the unnecessary radio/checkbox selection step. #}
+      {% set numberedLabel = (firstQuestionNumber + index) + ". " + field.label %}
+      <div class="app-question-block">
+        <a id="question-{{ fieldName }}"></a>
+        <input type="hidden" name="{{ fieldName }}" value="{{ values[fieldName] | default(field.default) }}" />
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              {{ numberedLabel }}
+            </legend>
+            {% if field.hint %}
+              <div class="govuk-hint">{{ field.hint }}</div>
+            {% endif %}
+            {% for subfieldName, subfield in options.fields %}
+              {% if subfield.dependent and subfield.dependent.field == fieldName %}
+                {{ renderField(subfieldName, subfield, options, values, errors) }}
+              {% endif %}
+            {% endfor %}
+          </fieldset>
+        </div>
+      </div>
+      {% set index = index + 1 %}
+
+    {% elif not field.dependent %}
+      {# NB:
+        - dependent fields are currently only used in conditionals so are rendered separately
+      #}
       {% set label = (firstQuestionNumber + index) + ". " + field.label %}
       {% set field = mergeObjects(field, {label: label}) %}
       <div class="app-question-block">


### PR DESCRIPTION
## What

When a question has exactly one active answer, the radio/checkbox selection step is unnecessary — the user must always pick the sole option before a required date or comment field becomes visible.

This change automatically detects single-answer questions and:
- Renders the main field as a **hidden input** (value auto-set to the single answer's response), bypassing the radio/checkbox entirely
- Shows date/comment sub-fields **directly** inside a labelled fieldset

<img width="809" height="1072" alt="Screenshot 2026-05-27 at 18 25 38" src="https://github.com/user-attachments/assets/2c9b4754-fc7d-4f39-b2f7-29e781e3fbbd" />

### Sub-field label behaviour

| Situation | Label shown |
|---|---|
| Date field — `commentLabel` set on answer | `singleAnswer.label` (e.g. _'Enter date of first error identified'_) |
| Date field — no `commentLabel` | No visible label (fieldset legend is sufficient) |
| Comment field — `commentLabel` set | `commentLabel` (e.g. _'Provide your comment here'_) |
| Comment field — no `commentLabel` | `singleAnswer.label` (e.g. _'Specify location'_) |

Generic words like _'Date'_ or _'Comment'_ are never shown. The `commentLabel` value is also promoted to a hint on date fields where it contains format guidance (e.g. _'For example, 17/5/2026'_).

## Why

Affected questions include things like _'When was the error first identified?'_ in UNLAWFUL_DETENTION and _'What date was the error identified?'_ in RELEASE_IN_ERROR_1 — where the user had to click a single radio button just to reveal a mandatory date field. This removes that pointless step.

The improvement applies to ~50+ questions across many active incident types (BOMB_1, FIRE_1, ATTEMPTED_ESCAPE_FROM_PRISON_1, DEATH_OTHER_1, RELEASE_IN_ERROR_1, DRONE_SIGHTING_3, etc.).

## How

No configuration changes are required. The behaviour is derived automatically from the existing incident type config: if `activeAnswers.length === 1`, `generateFields()` in `formWizard.ts` emits a hidden field with `singleAnswer: true`, and `questions.njk` renders the sub-fields directly inside a fieldset.

Template macros (`renderDateField.njk`, `renderField.njk`) were updated to apply `govuk-visually-hidden` when the label text is empty (preventing a 5 px gap), and to guard against `undefined` being concatenated as the literal string `"undefined"`.

## Testing

- New unit tests in `formWizard.test.ts` covering all single-answer cases (date-only, comment-only, date+comment, neither, date with no commentLabel, comment with no commentLabel)
- New integration tests in `questions/index.test.ts` using RELEASE_IN_ERROR_1 verifying no radio buttons are rendered and that date/comment values pre-fill correctly
