### PR TITLE
IR-1654 Hide 'add another prisoner?' radio when all role slots are exhausted

### DIFF
--- a/integration_tests/e2e/involvements/prisoners/involvements.cy.ts
+++ b/integration_tests/e2e/involvements/prisoners/involvements.cy.ts
@@ -5,6 +5,7 @@ import { now } from '../../../../server/testutils/fakeClock'
 import Page from '../../../pages/page'
 import { PrisonerInvolvementsPage, PrisonerSearchPage } from '../../../pages/reports/involvements/prisoners'
 import { ReportPage } from '../../../pages/reports/report'
+import type { PrisonerInvolvement } from '../../../../server/data/incidentReportingApi'
 
 context('Prisoner involvements page', () => {
   const reportWithDetails = mockReport({
@@ -17,6 +18,16 @@ context('Prisoner involvements page', () => {
   reportWithDetails.staffInvolvementDone = false
   reportWithDetails.questions = []
   reportWithDetails.correctionRequests = []
+
+  // A prisoner involvement with the sole role for ABSCOND_1
+  const absconderInvolvement: PrisonerInvolvement = {
+    prisonerNumber: andrew.prisonerNumber,
+    firstName: andrew.firstName,
+    lastName: andrew.lastName,
+    prisonerRole: 'ABSCONDER',
+    outcome: null,
+    comment: '',
+  }
 
   let prisonerInvolvementsPage: PrisonerInvolvementsPage
 
@@ -137,6 +148,56 @@ context('Prisoner involvements page', () => {
 
     it('should not show a table', () => {
       prisonerInvolvementsPage.showsNoTable()
+    })
+  })
+
+  context('when all prisoner role slots are exhausted (onlyOneAllowed)', () => {
+    // ABSCOND_1 has a single active role (ABSCONDER, onlyOneAllowed: true).
+    // Once that role is filled no further prisoners can be added, so the radio
+    // question should be hidden and Continue/Save and exit act as implicit "No".
+    const reportAbscond = mockReport({
+      type: 'ABSCOND_1',
+      reportReference: '6545',
+      reportDateAndTime: now,
+      withDetails: true,
+    })
+    reportAbscond.staffInvolved = []
+    reportAbscond.staffInvolvementDone = false
+    reportAbscond.questions = []
+    reportAbscond.correctionRequests = []
+
+    beforeEach(() => {
+      reportAbscond.prisonersInvolved = [absconderInvolvement]
+      reportAbscond.prisonerInvolvementDone = true
+
+      cy.task('stubIncidentReportingApiGetReportWithDetailsById', { report: reportAbscond })
+      cy.visit(`/reports/${reportAbscond.id}/prisoners`)
+      Page.verifyOnPage(PrisonerInvolvementsPage)
+    })
+
+    it('should not show the "add another prisoner?" radio', () => {
+      const page = new PrisonerInvolvementsPage()
+      page.showsNoRadio()
+    })
+
+    it('should still show Continue and Save and exit buttons', () => {
+      cy.contains('button', 'Continue').should('exist')
+      cy.contains('button', 'Save and exit').should('exist')
+    })
+
+    it('should navigate to the report page when Continue is clicked (implicit No)', () => {
+      cy.task('stubIncidentReportingApiGetReportById', { report: reportAbscond })
+      cy.task('stubPrisonApiMockPrison', moorland)
+      cy.task('stubManageKnownUsers')
+
+      cy.contains('button', 'Continue').click()
+
+      Page.verifyOnPage(ReportPage, reportAbscond.reportReference, true)
+    })
+
+    it('should show the table of existing prisoners', () => {
+      const page = new PrisonerInvolvementsPage()
+      page.tableRows.should('have.length', 1)
     })
   })
 

--- a/integration_tests/pages/reports/involvements/abstract/involvements.ts
+++ b/integration_tests/pages/reports/involvements/abstract/involvements.ts
@@ -14,6 +14,10 @@ export abstract class InvolvementsPage extends FormWizardPage {
     return cy.get<HTMLTableRowElement>('.app-involvement-table').should('not.exist').end()
   }
 
+  showsNoRadio(): Cypress.Chainable<void> {
+    return cy.get('#confirmAdd').should('not.exist').end()
+  }
+
   get tableRows(): PageElement<HTMLTableRowElement> {
     return cy.get<HTMLTableRowElement>('table.app-involvement-table tbody tr.govuk-table__row')
   }

--- a/server/controllers/involvements/summary.ts
+++ b/server/controllers/involvements/summary.ts
@@ -35,6 +35,14 @@ export abstract class InvolvementSummary extends BaseController<Values> {
     super.middlewareLocals()
   }
 
+  // Override in subclasses to prevent the "add another?" radio from showing when
+  // no further involvements can be added (e.g. all prisoner roles with onlyOneAllowed
+  // are already used).  Default returns true so staff summary is unaffected.
+
+  protected canAddMoreInvolvements(_res: express.Response): boolean {
+    return true
+  }
+
   private customiseFields(req: FormWizard.Request<Values>, res: express.Response, next: express.NextFunction): void {
     const report = res.locals.report as ReportWithDetails
 
@@ -53,10 +61,19 @@ export abstract class InvolvementSummary extends BaseController<Values> {
     if (involvementsExist) {
       customisedFields.confirmAdd.label = this.labelOnceInvolvementsExist
     }
+
+    const canAddMore = this.canAddMoreInvolvements(res)
+    if (involvementsExist && !canAddMore) {
+      // Remove required validation: the radio will be hidden in the template and
+      // an empty submission is treated as an implicit "No" in successHandler.
+      customisedFields.confirmAdd = { ...customisedFields.confirmAdd, validate: [] }
+    }
+
     req.form.options.fields = customisedFields
 
     res.locals.involvementDone = involvementDone
     res.locals.involvementsExist = involvementsExist
+    res.locals.noMoreCanBeAdded = involvementsExist && !canAddMore
 
     next()
   }

--- a/server/controllers/involvements/summary.ts
+++ b/server/controllers/involvements/summary.ts
@@ -63,7 +63,8 @@ export abstract class InvolvementSummary extends BaseController<Values> {
     }
 
     const canAddMore = this.canAddMoreInvolvements(res)
-    if (involvementsExist && !canAddMore) {
+    const noMoreCanBeAdded = involvementsExist && !canAddMore
+    if (noMoreCanBeAdded) {
       // Remove required validation: the radio will be hidden in the template and
       // an empty submission is treated as an implicit "No" in successHandler.
       customisedFields.confirmAdd = { ...customisedFields.confirmAdd, validate: [] }
@@ -73,7 +74,7 @@ export abstract class InvolvementSummary extends BaseController<Values> {
 
     res.locals.involvementDone = involvementDone
     res.locals.involvementsExist = involvementsExist
-    res.locals.noMoreCanBeAdded = involvementsExist && !canAddMore
+    res.locals.noMoreCanBeAdded = noMoreCanBeAdded
 
     next()
   }

--- a/server/routes/reports/prisoners/summary/controller.ts
+++ b/server/routes/reports/prisoners/summary/controller.ts
@@ -3,7 +3,6 @@ import type FormWizard from 'hmpo-form-wizard'
 
 import { InvolvementSummary } from '../../../../controllers/involvements/summary'
 import type { ReportWithDetails } from '../../../../data/incidentReportingApi'
-import type { IncidentTypeConfiguration } from '../../../../data/incidentTypeConfiguration/types'
 import { populateReportConfiguration } from '../../../../middleware/populateReportConfiguration'
 import {
   prisonerInvolvementOutcomesDescriptions,
@@ -20,7 +19,7 @@ export default class PrisonerSummary extends InvolvementSummary {
   }
 
   protected canAddMoreInvolvements(res: express.Response): boolean {
-    const reportConfig = res.locals.reportConfig as IncidentTypeConfiguration | undefined
+    const { reportConfig } = res.locals
     if (!reportConfig) return true // safe default when config unavailable
 
     const report = res.locals.report as ReportWithDetails

--- a/server/routes/reports/prisoners/summary/controller.ts
+++ b/server/routes/reports/prisoners/summary/controller.ts
@@ -2,6 +2,9 @@ import type express from 'express'
 import type FormWizard from 'hmpo-form-wizard'
 
 import { InvolvementSummary } from '../../../../controllers/involvements/summary'
+import type { ReportWithDetails } from '../../../../data/incidentReportingApi'
+import type { IncidentTypeConfiguration } from '../../../../data/incidentTypeConfiguration/types'
+import { populateReportConfiguration } from '../../../../middleware/populateReportConfiguration'
 import {
   prisonerInvolvementOutcomesDescriptions,
   prisonerInvolvementRolesDescriptions,
@@ -9,6 +12,28 @@ import {
 import type { Values } from './fields'
 
 export default class PrisonerSummary extends InvolvementSummary {
+  middlewareLocals(): void {
+    // Load reportConfig (without generating question steps) so canAddMoreInvolvements()
+    // can inspect prisonerRoles.  Mirrors the pattern in PrisonerInvolvementController.
+    this.router.use(populateReportConfiguration(false))
+    super.middlewareLocals()
+  }
+
+  protected canAddMoreInvolvements(res: express.Response): boolean {
+    const reportConfig = res.locals.reportConfig as IncidentTypeConfiguration | undefined
+    if (!reportConfig) return true // safe default when config unavailable
+
+    const report = res.locals.report as ReportWithDetails
+    const usedRoles = new Set(report.prisonersInvolved.map(p => p.prisonerRole))
+
+    // There is room for another prisoner if ANY active role can still be filled:
+    // • unlimited roles (onlyOneAllowed: false) are always available, or
+    // • single-use roles (onlyOneAllowed: true) that haven't been used yet.
+    return reportConfig.prisonerRoles.some(
+      role => role.active && (!role.onlyOneAllowed || !usedRoles.has(role.prisonerRole)),
+    )
+  }
+
   protected type = 'prisoners' as const
 
   protected involvementField = 'prisonersInvolved' as const

--- a/server/routes/reports/prisoners/summary/index.test.ts
+++ b/server/routes/reports/prisoners/summary/index.test.ts
@@ -395,6 +395,88 @@ describe('Prisoner involvement summary for report', () => {
     })
   })
 
+  describe('…when all prisoner role slots are exhausted (onlyOneAllowed)', () => {
+    // ABSCOND_1 has exactly one active prisoner role: ABSCONDER with onlyOneAllowed: true.
+    // Once that role is used no further prisoners can be added, so the radio should be hidden.
+    beforeEach(() => {
+      mockedReport = convertReportDates(
+        mockReport({ type: 'ABSCOND_1', reportReference: '6543', reportDateAndTime: now, withDetails: true }),
+      )
+      mockedReport.prisonersInvolved = [
+        {
+          prisonerNumber: 'A1111AA',
+          firstName: 'Andrew',
+          lastName: 'Arnold',
+          prisonerRole: 'ABSCONDER',
+          outcome: null,
+          comment: '',
+        },
+      ]
+      mockedReport.prisonerInvolvementDone = true
+      // Reset any queued mock from the outer beforeEach so ABSCOND_1 is always returned
+      incidentReportingApi.getReportWithDetailsById.mockReset()
+      incidentReportingApi.getReportWithDetailsById.mockResolvedValue(mockedReport)
+    })
+
+    it.each([
+      { scenario: 'during create journey', createJourney: true },
+      { scenario: 'normally', createJourney: false },
+    ])('should not render the "add another?" radio ($scenario)', ({ createJourney }) => {
+      return request(app)
+        .get(summaryUrl(createJourney))
+        .expect(200)
+        .expect(res => {
+          expect(res.text).toContain('app-prisoner-summary')
+
+          expect(res.text).not.toContain('Do you want to add another prisoner?')
+          expect(res.text).not.toContain('Do you want to add a prisoner?')
+          expect(res.text).toContain('Continue')
+          expect(res.text).toContain('Save and exit')
+
+          expect(incidentReportingApi.getReportWithDetailsById).toHaveBeenCalledTimes(1)
+          expect(incidentReportingApi.updateReport).not.toHaveBeenCalled()
+          mockHandleReportEdit.expectNotCalled()
+        })
+    })
+
+    it.each([
+      { scenario: 'redirect to adding staff (when continuing create journey)', createJourney: true },
+      {
+        scenario: 'redirect to report page (when exiting create journey)',
+        createJourney: true,
+        formAction: 'exit' as const,
+      },
+      { scenario: 'redirect to report page (normally)', createJourney: false },
+    ])('should $scenario when form is submitted without the radio (implicit No)', ({ createJourney, formAction }) => {
+      return request(app)
+        .post(summaryUrl(createJourney))
+        .send(formAction ? { formAction } : {})
+        .expect(302)
+        .expect(res => {
+          if (createJourney && formAction !== 'exit') {
+            expect(res.headers.location).toEqual(`/create-report/${mockedReport.id}/staff`)
+          } else {
+            expect(res.headers.location).toEqual(`/reports/${mockedReport.id}`)
+          }
+          // Prisoners already exist so prisonerInvolvementDone must NOT be updated
+          expect(incidentReportingApi.updateReport).not.toHaveBeenCalled()
+          mockHandleReportEdit.expectNotCalled()
+        })
+    })
+
+    it('should not block submission with a validation error when radio is absent', () => {
+      // Empty POST body → no confirmAdd in form → must not return 422/error page
+      return request
+        .agent(app)
+        .post(summaryUrl())
+        .send({})
+        .expect(302) // redirect, not a form-error re-render
+        .expect(res => {
+          expect(res.headers.location).toEqual(`/reports/${mockedReport.id}`)
+        })
+    })
+  })
+
   describe('Permissions', () => {
     // NB: these test cases are simplified because the permissions class methods are thoroughly tested elsewhere
 

--- a/server/views/pages/involvements/summary.njk
+++ b/server/views/pages/involvements/summary.njk
@@ -34,35 +34,37 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
     <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}" />
 
-    {% set fieldName = "confirmAdd" %}
-    {% set field = options.fields[fieldName] %}
-    {% set items = [] %}
-    {% for item in field.items %}
-      {% set _ = items.push({
-        value: item.value,
-        text: item.label,
-        hint: {text: item.hint} if item.hint else undefined,
-        attributes: { 'data-test': item.label }
-      }) %}
-    {% endfor %}
-    {{ govukRadios({
-      name: fieldName,
-      attributes: { id: fieldName },
-      classes: "govuk-radios--inline",
-      formGroup: {
-        attributes: { id: fieldName + "__form-group" }
-      },
-      fieldset: {
-        legend: {
-          text: field.label,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      idPrefix: fieldName + "-item",
-      items: items,
-      hint: { text: field.hint } if field.hint else undefined,
-      errorMessage: { text: errors[fieldName].message } if errors[fieldName] else undefined
-    }) }}
+    {% if not noMoreCanBeAdded %}
+      {% set fieldName = "confirmAdd" %}
+      {% set field = options.fields[fieldName] %}
+      {% set items = [] %}
+      {% for item in field.items %}
+        {% set _ = items.push({
+          value: item.value,
+          text: item.label,
+          hint: {text: item.hint} if item.hint else undefined,
+          attributes: { 'data-test': item.label }
+        }) %}
+      {% endfor %}
+      {{ govukRadios({
+        name: fieldName,
+        attributes: { id: fieldName },
+        classes: "govuk-radios--inline",
+        formGroup: {
+          attributes: { id: fieldName + "__form-group" }
+        },
+        fieldset: {
+          legend: {
+            text: field.label,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        idPrefix: fieldName + "-item",
+        items: items,
+        hint: { text: field.hint } if field.hint else undefined,
+        errorMessage: { text: errors[fieldName].message } if errors[fieldName] else undefined
+      }) }}
+    {% endif %}
 
     <div class="govuk-button-group">
       {{ govukButton({


### PR DESCRIPTION
## Problem

When a report type has prisoner roles where every active role has `onlyOneAllowed: true` and all those roles are already filled, the prisoner involvement summary page continued to show the **"Do you want to add another prisoner? Yes / No"** radio button.

Choosing **Yes** sent the user through the full prisoner search flow, only to be rejected at the end with:

> **Error — No more prisoner roles can be added**
> You may need to remove an existing person.

The service had all the information it needed to know no further prisoners could be added; asking the question was pointless and created a frustrating dead-end.

Affected incident types include any type where every active prisoner role has `onlyOneAllowed: true`, for example:
- `ABSCOND_1` — sole role: `ABSCONDER`
- `FOOD_REFUSAL_1` — sole role: `PERPETRATOR`
- `DIRTY_PROTEST_1`, `UNLAWFUL_DETENTION_1`
- Any type once every available role slot has been filled (e.g. `ESCAPE_FROM_PRISON_1` once the single `ESCAPE` role is taken, even though other `onlyOneAllowed: false` roles remain)

## Solution

Detect the exhausted-roles state on the summary page and suppress the radio, so the **Continue** and **Save and exit** buttons act as an implicit "No". If the existing prisoner is removed, the available role slot opens back up and the radio reappears on the next visit.

The check mirrors the logic already present in `PrisonerInvolvementController.getAllowedPrisonerRoles()` (used to produce the error): a role slot is still available if `!onlyOneAllowed` (unlimited) or `onlyOneAllowed && !alreadyUsed`.

## Technical changes

### `server/routes/reports/prisoners/summary/controller.ts`
- Added `middlewareLocals()` override that prepends `populateReportConfiguration(false)` via `this.router.use()` before calling `super.middlewareLocals()`. This mirrors the identical pattern in `PrisonerInvolvementController` and makes `res.locals.reportConfig` available on the summary page for the first time.
- Added `protected canAddMoreInvolvements(res)`: iterates `reportConfig.prisonerRoles` against the involvements already on the report to return `false` when every active role is `onlyOneAllowed: true` and already used.

### `server/controllers/involvements/summary.ts` (abstract base)
- Added `protected canAddMoreInvolvements(_res): boolean { return true }` — the safe default ensures the staff summary page (which has no `onlyOneAllowed` concept) is completely unaffected.
- In `customiseFields()`: calls `canAddMoreInvolvements()`. When `involvementsExist && !canAddMore`, the `validate` array on the `confirmAdd` field is cleared (removing the `required` rule so form-wizard does not reject an empty POST) and `res.locals.noMoreCanBeAdded` is set to `true`.
- No change to `successHandler()`: an absent/undefined `confirmAdd` already falls through the `else` branch (not `'yes'`), and the `prisonerInvolvementDone` API update is only triggered when `confirmAdd === 'no' && involvements.length === 0` — neither condition applies here.

### `server/views/pages/involvements/summary.njk`
- Wrapped the entire `govukRadios(…)` call in `{% if not noMoreCanBeAdded %}…{% endif %}`.
- The Continue and Save and exit buttons remain **unconditional**.

## Tests

### Unit tests — `server/routes/reports/prisoners/summary/index.test.ts`
New `describe` block using a report of type `ABSCOND_1` (the simplest case: one role, `ABSCONDER`, `onlyOneAllowed: true`) with that role already filled:

| Test | What it covers |
|---|---|
| GET — radio absent, buttons present (create + normal) | visual suppression |
| POST empty body — correct redirect (create / exit / normal) | implicit No navigation |
| POST empty body — `updateReport` not called | no spurious API write (prisoners exist) |
| POST empty body — 302, not validation error | `validate: []` clears required rule |

All 37 pre-existing tests continue to pass unchanged; `FIND_6` (the default test type) has only `onlyOneAllowed: false` roles so the radio still shows as before.

### Cypress integration tests — `integration_tests/e2e/involvements/prisoners/involvements.cy.ts`
New `context` block with `ABSCOND_1` + one `ABSCONDER` prisoner:
- Radio is absent (`showsNoRadio()` helper added to `InvolvementsPage`)
- Continue and Save and exit buttons exist
- Clicking Continue navigates to the report page
