### PR TITLE
IR-1673 Prisoner incident summary page

### DIFF
--- a/integration_tests/e2e/prisonerIncidentSummary.cy.ts
+++ b/integration_tests/e2e/prisonerIncidentSummary.cy.ts
@@ -1,0 +1,67 @@
+import type { ReportWithDetails } from '../../server/data/incidentReportingApi'
+import { mockReport } from '../../server/data/testData/incidentReporting'
+import { makeSimpleQuestion } from '../../server/data/testData/incidentReportingJest'
+import { andrew } from '../../server/data/testData/offenderSearch'
+import { mockReportingOfficer } from '../../server/data/testData/users'
+import { now } from '../../server/testutils/fakeClock'
+
+/** Build a closed report of the given type with crafted questions, all within the last 12 months. */
+function reportOfType(reference: string, type: string, questions: ReportWithDetails['questions']): ReportWithDetails {
+  const report = mockReport({
+    reportReference: reference,
+    reportDateAndTime: now,
+    type: type as ReportWithDetails['type'],
+    status: 'CLOSED',
+    location: andrew.prisonId,
+    withDetails: true,
+  }) as unknown as ReportWithDetails
+  report.questions = questions
+  return report
+}
+
+describe('Prisoner incident summary', () => {
+  it('shows the overall and per-family breakdowns', () => {
+    const assaultA = reportOfType('6001', 'ASSAULT_5', [
+      makeSimpleQuestion('61287', 'WHAT TYPE OF ASSAULT WAS IT', ['PRISONER ON PRISONER', '213115']),
+      makeSimpleQuestion('61285', 'WAS THIS A SEXUAL ASSAULT', ['YES', '1']),
+      makeSimpleQuestion('61290', 'WAS SPITTING USED IN THIS INCIDENT', ['YES', '2']),
+    ])
+    const assaultB = reportOfType('6002', 'ASSAULT_5', [
+      makeSimpleQuestion('61287', 'WHAT TYPE OF ASSAULT WAS IT', ['PRISONER ON STAFF', '213116']),
+      makeSimpleQuestion('61298', 'WAS A SERIOUS INJURY SUSTAINED', ['YES', '3']),
+      makeSimpleQuestion('61305', 'WAS MEDICAL TREATMENT FOR CONCUSSION OR INTERNAL INJURIES REQUIRED', ['YES', '4']),
+    ])
+    const disorder = reportOfType('6003', 'DISORDER_2', [
+      makeSimpleQuestion('63179', 'WHAT TYPE OF DISORDER INCIDENT WAS THIS?', ['HOSTAGE', '214686']),
+    ])
+    const selfHarm = reportOfType('6004', 'SELF_HARM_1', [
+      makeSimpleQuestion('44753', 'DID SELF HARM METHOD INVOLVE CUTTING', ['YES', '5']),
+      makeSimpleQuestion('45167', 'DID SELF HARM METHOD INVOLVE BURNING', ['YES', '6']),
+    ])
+    const find = reportOfType('6005', 'FIND_6', [
+      makeSimpleQuestion('67187', 'PLEASE SELECT CATEGORY OF FIND', ['DRUG / DRUG EQUIPMENT', '218785']),
+      makeSimpleQuestion('67190', 'DESCRIBE THE DRUG FOUND', ['CANNABIS', '7'], ['CRACK', '8']),
+    ])
+    const fire = reportOfType('6006', 'FIRE_1', [])
+    const misc = reportOfType('6007', 'MISCELLANEOUS_1', [])
+
+    const allReports = [assaultA, assaultB, disorder, selfHarm, find, fire, misc]
+    const detailedReports = [assaultA, assaultB, disorder, selfHarm, find]
+
+    cy.resetBasicStubs({ user: mockReportingOfficer })
+    cy.signIn()
+    cy.task('stubOffenderSearchMockPrisoners')
+    cy.task('stubIncidentReportingApiGetReports', { reports: allReports })
+    detailedReports.forEach(report => cy.task('stubIncidentReportingApiGetReportWithDetailsById', { report }))
+
+    cy.visit(`/prisoner/${andrew.prisonerNumber}/incident-summary`)
+
+    cy.get('h1').should('contain.text', 'Incident summary')
+    cy.contains('Assault').should('exist')
+    cy.contains('Prisoner on prisoner').should('exist')
+    cy.contains('Hostage').should('exist')
+    cy.contains('Cannabis').should('exist')
+
+    cy.screenshot('prisoner-incident-summary', { capture: 'fullPage' })
+  })
+})

--- a/integration_tests/e2e/prisonerIncidentSummary.cy.ts
+++ b/integration_tests/e2e/prisonerIncidentSummary.cy.ts
@@ -1,20 +1,24 @@
 import type { ReportWithDetails } from '../../server/data/incidentReportingApi'
+import { convertReportWithDetailsDates } from '../../server/data/incidentReportingApiUtils'
 import { mockReport } from '../../server/data/testData/incidentReporting'
 import { makeSimpleQuestion } from '../../server/data/testData/incidentReportingJest'
 import { andrew } from '../../server/data/testData/offenderSearch'
 import { mockReportingOfficer } from '../../server/data/testData/users'
+import type { Type } from '../../server/reportConfiguration/constants'
 import { now } from '../../server/testutils/fakeClock'
 
 /** Build a closed report of the given type with crafted questions, all within the last 12 months. */
-function reportOfType(reference: string, type: string, questions: ReportWithDetails['questions']): ReportWithDetails {
-  const report = mockReport({
-    reportReference: reference,
-    reportDateAndTime: now,
-    type: type as ReportWithDetails['type'],
-    status: 'CLOSED',
-    location: andrew.prisonId,
-    withDetails: true,
-  }) as unknown as ReportWithDetails
+function reportOfType(reference: string, type: Type, questions: ReportWithDetails['questions']): ReportWithDetails {
+  const report = convertReportWithDetailsDates(
+    mockReport({
+      reportReference: reference,
+      reportDateAndTime: now,
+      type,
+      status: 'CLOSED',
+      location: andrew.prisonId,
+      withDetails: true,
+    }),
+  )
   report.questions = questions
   return report
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -5,7 +5,7 @@ import type { CaseLoad } from '../../data/frontendComponentsClient'
 import type { IncidentReportingApi, ReportBasic, ReportWithDetails } from '../../data/incidentReportingApi'
 import type { QuestionProgress } from '../../data/incidentTypeConfiguration/questionProgress'
 import type { IncidentTypeConfiguration } from '../../data/incidentTypeConfiguration/types'
-import type { OffenderSearchApi } from '../../data/offenderSearchApi'
+import type { OffenderSearchApi, OffenderSearchResult } from '../../data/offenderSearchApi'
 import type { PrisonApi } from '../../data/prisonApi'
 import type { Permissions, UserAction, ReportTransitions } from '../../middleware/permissions'
 import type { TypeFamily } from '../../reportConfiguration/constants'
@@ -74,6 +74,8 @@ export declare global {
         prisonApi: PrisonApi
         offenderSearchApi: OffenderSearchApi
       }
+      /** Some routes load a prisoner into locals (via populatePrisoner) */
+      prisoner?: OffenderSearchResult
       /** Many routes load a report into locals */
       report?: ReportBasic | ReportWithDetails
       /** URL of current report (if loaded) */

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -2,6 +2,7 @@ import { InternalServerError } from 'http-errors'
 
 const middlewareMapping = {
   'res.locals.permissions': 'Permissions.middleware()',
+  'res.locals.prisoner': 'populatePrisoner()',
   'res.locals.report': 'populateReport()',
   'res.locals.report (with details)': 'populateReport(withDetails=true)',
   'res.locals.reportUrl': 'populateReport()',

--- a/server/middleware/requirePrisonerInCaseload.test.ts
+++ b/server/middleware/requirePrisonerInCaseload.test.ts
@@ -1,0 +1,49 @@
+import type { NextFunction, Request, Response } from 'express'
+
+import { andrew, ernie } from '../data/testData/offenderSearch'
+import { moorland } from '../data/testData/prisonApi'
+import { requirePrisonerInCaseload } from './requirePrisonerInCaseload'
+
+function makeRes(locals: Record<string, unknown>): Response {
+  return { locals } as unknown as Response
+}
+
+const userWithMoorland = { caseLoads: [{ caseLoadId: moorland.agencyId }] }
+
+describe('requirePrisonerInCaseload', () => {
+  it('calls next with no error when the prisoner is in one of the user’s caseloads', () => {
+    const res = makeRes({ prisoner: andrew, user: userWithMoorland })
+    const next: NextFunction = jest.fn()
+
+    requirePrisonerInCaseload()({} as Request, res, next)
+
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it('responds 404 when the prisoner is not in the user’s caseloads', () => {
+    const res = makeRes({ prisoner: andrew, user: { caseLoads: [{ caseLoadId: 'LEI' }] } })
+    const next: NextFunction = jest.fn()
+
+    requirePrisonerInCaseload()({} as Request, res, next)
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 404 }))
+  })
+
+  it('responds 404 for an out/transfer prisoner whose prisonId matches no caseload', () => {
+    const res = makeRes({ prisoner: ernie, user: userWithMoorland })
+    const next: NextFunction = jest.fn()
+
+    requirePrisonerInCaseload()({} as Request, res, next)
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 404 }))
+  })
+
+  it('errors when populatePrisoner has not run', () => {
+    const res = makeRes({ user: userWithMoorland })
+    const next: NextFunction = jest.fn()
+
+    requirePrisonerInCaseload()({} as Request, res, next)
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 500 }))
+  })
+})

--- a/server/middleware/requirePrisonerInCaseload.ts
+++ b/server/middleware/requirePrisonerInCaseload.ts
@@ -1,7 +1,8 @@
 import type { RequestHandler } from 'express'
-import { InternalServerError, NotFound } from 'http-errors'
+import { NotFound } from 'http-errors'
 
 import logger from '../../logger'
+import { missingLocalsError } from '../errors'
 
 /**
  * Guards a route so that it can only be accessed when the loaded prisoner is held in one of the
@@ -18,7 +19,7 @@ export function requirePrisonerInCaseload(): RequestHandler {
   return (_req, res, next): void => {
     const { prisoner, user } = res.locals
     if (!prisoner) {
-      next(new InternalServerError('requirePrisonerInCaseload() requires populatePrisoner() to run first'))
+      next(missingLocalsError('requirePrisonerInCaseload()', 'res.locals.prisoner'))
       return
     }
 

--- a/server/middleware/requirePrisonerInCaseload.ts
+++ b/server/middleware/requirePrisonerInCaseload.ts
@@ -1,0 +1,34 @@
+import type { RequestHandler } from 'express'
+import { InternalServerError, NotFound } from 'http-errors'
+
+import logger from '../../logger'
+
+/**
+ * Guards a route so that it can only be accessed when the loaded prisoner is held in one of the
+ * current user's caseloads (caseloadId === prisonId). Must run after populatePrisoner().
+ *
+ * This naturally denies prisoners who are out or in transit, as their prisonId ("OUT" / "TRN")
+ * will not match any caseload.
+ *
+ * A denied prisoner is treated as Not Found rather than Forbidden: the user is legitimately
+ * signed in (so the app's 403-triggers-sign-out behaviour would be wrong), and we avoid
+ * confirming that a prisoner outside their caseload exists.
+ */
+export function requirePrisonerInCaseload(): RequestHandler {
+  return (_req, res, next): void => {
+    const { prisoner, user } = res.locals
+    if (!prisoner) {
+      next(new InternalServerError('requirePrisonerInCaseload() requires populatePrisoner() to run first'))
+      return
+    }
+
+    const caseloadIds = new Set(user?.caseLoads?.map(caseLoad => caseLoad.caseLoadId) ?? [])
+    if (!caseloadIds.has(prisoner.prisonId)) {
+      logger.warn(`User denied access to prisoner ${prisoner.prisonerNumber}: not in caseload`)
+      next(new NotFound('Prisoner is not in your caseload'))
+      return
+    }
+
+    next()
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -16,6 +16,7 @@ import { editReportRouter } from './reports/editReportRouter'
 import { reopenRouter } from './reports/actions/reopen'
 import { requestRemovalRouter } from './reports/actions/requestRemoval'
 import dashboard from './dashboard'
+import prisonerIncidentSummaryRouter from './prisonerIncidentSummary'
 
 export default function routes(services: Services): Router {
   const router = Router()
@@ -56,6 +57,8 @@ export default function routes(services: Services): Router {
   router.use('/reports/:reportId', editReportRouter)
 
   // Auxiliary routes
+  router.use('/prisoner/:prisonerNumber/incident-summary', prisonerIncidentSummaryRouter())
+
   router.get('/prisoner/:prisonerNumber/photo.jpeg', async (req, res) => {
     const { prisonerNumber } = req.params
 

--- a/server/routes/prisonerIncidentSummary/index.test.ts
+++ b/server/routes/prisonerIncidentSummary/index.test.ts
@@ -1,0 +1,79 @@
+import type { Express } from 'express'
+import request from 'supertest'
+
+import { appWithAllRoutes } from '../testutils/appSetup'
+import { IncidentReportingApi, type Page, type ReportBasic } from '../../data/incidentReportingApi'
+import { OffenderSearchApi } from '../../data/offenderSearchApi'
+import type { Type } from '../../reportConfiguration/constants'
+import { andrew, ernie } from '../../data/testData/offenderSearch'
+
+jest.mock('../../data/incidentReportingApi')
+jest.mock('../../data/offenderSearchApi')
+
+const incidentReportingApi = IncidentReportingApi.prototype as jest.Mocked<IncidentReportingApi>
+const offenderSearchApi = OffenderSearchApi.prototype as jest.Mocked<OffenderSearchApi>
+
+function basicReport(id: string, type: Type): ReportBasic {
+  return { id, type } as ReportBasic
+}
+
+function page(content: ReportBasic[]): Page<ReportBasic> {
+  return {
+    content,
+    number: 0,
+    size: content.length,
+    numberOfElements: content.length,
+    totalElements: content.length,
+    totalPages: 1,
+    sort: [],
+  }
+}
+
+let app: Express
+
+beforeEach(() => {
+  app = appWithAllRoutes({})
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET /prisoner/:prisonerNumber/incident-summary', () => {
+  it('renders the summary for a prisoner in the user’s caseload', () => {
+    offenderSearchApi.getPrisoner.mockResolvedValue(andrew) // MDI, in the reporting officer’s caseload
+    incidentReportingApi.getReports.mockResolvedValue(page([basicReport('1', 'FIRE_1'), basicReport('2', 'FIRE_1')]))
+
+    return request(app)
+      .get(`/prisoner/${andrew.prisonerNumber}/incident-summary`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Incident summary')
+        expect(res.text).toContain('Fire')
+        expect(incidentReportingApi.getReports).toHaveBeenCalled()
+      })
+  })
+
+  it('renders an empty state when there are no incidents', () => {
+    offenderSearchApi.getPrisoner.mockResolvedValue(andrew)
+    incidentReportingApi.getReports.mockResolvedValue(page([]))
+
+    return request(app)
+      .get(`/prisoner/${andrew.prisonerNumber}/incident-summary`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('No incidents have been recorded')
+      })
+  })
+
+  it('returns 404 when the prisoner is not in the user’s caseload', () => {
+    offenderSearchApi.getPrisoner.mockResolvedValue(ernie) // outside, not in caseload
+
+    return request(app)
+      .get(`/prisoner/${ernie.prisonerNumber}/incident-summary`)
+      .expect(404)
+      .expect(() => {
+        expect(incidentReportingApi.getReports).not.toHaveBeenCalled()
+      })
+  })
+})

--- a/server/routes/prisonerIncidentSummary/index.test.ts
+++ b/server/routes/prisonerIncidentSummary/index.test.ts
@@ -62,7 +62,7 @@ describe('GET /prisoner/:prisonerNumber/incident-summary', () => {
       .get(`/prisoner/${andrew.prisonerNumber}/incident-summary`)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('No incidents have been recorded')
+        expect(res.text).toContain('been involved in any recorded incident')
       })
   })
 

--- a/server/routes/prisonerIncidentSummary/index.ts
+++ b/server/routes/prisonerIncidentSummary/index.ts
@@ -1,0 +1,30 @@
+import express, { type Router } from 'express'
+
+import { populatePrisoner } from '../../middleware/populatePrisoner'
+import { requirePrisonerInCaseload } from '../../middleware/requirePrisonerInCaseload'
+import { getPrisonerIncidentSummary } from '../../services/prisonerIncidentSummary'
+
+/**
+ * Read-only page summarising the incidents a prisoner has been involved in over the past 12
+ * months. Accessible to any signed-in user, provided the prisoner is in one of their caseloads
+ * (enforced by requirePrisonerInCaseload).
+ *
+ * Mounted under `/prisoner/:prisonerNumber/incident-summary`, so the router merges params.
+ */
+export default function prisonerIncidentSummaryRouter(): Router {
+  const router = express.Router({ mergeParams: true })
+
+  router.get('/', populatePrisoner(), requirePrisonerInCaseload(), async (req, res) => {
+    const { prisonerNumber } = req.params
+    const { incidentReportingApi } = res.locals.apis
+
+    const summary = await getPrisonerIncidentSummary(incidentReportingApi, prisonerNumber)
+
+    res.render('pages/prisonerIncidentSummary', {
+      prisoner: res.locals.prisoner,
+      summary,
+    })
+  })
+
+  return router
+}

--- a/server/services/prisonerIncidentSummary/breakdowns.test.ts
+++ b/server/services/prisonerIncidentSummary/breakdowns.test.ts
@@ -1,0 +1,158 @@
+import type { Question, Response } from '../../data/incidentReportingApi'
+import { assaultBreakdown, disorderBreakdown, selfHarmBreakdown, findBreakdown } from './breakdowns'
+
+function response(code: string, value: string): Response {
+  return {
+    code,
+    response: value,
+    label: value,
+    responseDate: null,
+    additionalInformation: null,
+    recordedBy: 'user1',
+    recordedAt: new Date('2025-01-01T00:00:00Z'),
+  }
+}
+
+function question(code: string, responses: Response[]): Question {
+  return { code, question: code, label: code, additionalInformation: null, responses }
+}
+
+/** Count for a given row id in a list of breakdown rows. */
+function count(rows: { id: string; count: number }[], id: string): number {
+  return rows.find(row => row.id === id)?.count ?? 0
+}
+
+describe('assaultBreakdown', () => {
+  it('counts assault types, and serious/sexual/spitting/concussion flags', () => {
+    const reports = [
+      // prisoner on prisoner, sexual, spitting
+      [
+        question('61287', [response('213115', 'PRISONER ON PRISONER')]),
+        question('61285', [response('212000', 'YES')]),
+        question('61290', [response('212001', 'YES')]),
+      ],
+      // prisoner on staff, serious + concussion
+      [
+        question('61287', [response('213116', 'PRISONER ON STAFF')]),
+        question('61298', [response('212002', 'YES')]),
+        question('61305', [response('212003', 'YES')]),
+      ],
+      // prisoner on other, all the yes/no questions answered NO
+      [
+        question('61287', [response('213117', 'PRISONER ON OTHER')]),
+        question('61285', [response('212004', 'NO')]),
+        question('61298', [response('212005', 'NO')]),
+      ],
+    ]
+
+    const rows = assaultBreakdown(reports)
+    expect(count(rows, 'prisonerOnPrisoner')).toBe(1)
+    expect(count(rows, 'prisonerOnStaff')).toBe(1)
+    expect(count(rows, 'prisonerOnOther')).toBe(1)
+    expect(count(rows, 'serious')).toBe(1)
+    expect(count(rows, 'sexual')).toBe(1)
+    expect(count(rows, 'spitting')).toBe(1)
+    expect(count(rows, 'concussion')).toBe(1)
+  })
+
+  it('returns zero counts when there are no reports', () => {
+    expect(assaultBreakdown([]).every(row => row.count === 0)).toBe(true)
+  })
+})
+
+describe('disorderBreakdown', () => {
+  it('counts each disorder sub-type', () => {
+    const reports = [
+      [question('63179', [response('214684', 'BARRICADE/PREVENTION OF ACCESS')])],
+      [question('63179', [response('214686', 'HOSTAGE')])],
+      [question('63179', [response('214687', 'INCIDENT AT HEIGHT')])],
+    ]
+
+    const rows = disorderBreakdown(reports)
+    expect(count(rows, 'barricade')).toBe(1)
+    expect(count(rows, 'concertedIndiscipline')).toBe(0)
+    expect(count(rows, 'hostage')).toBe(1)
+    expect(count(rows, 'incidentAtHeight')).toBe(1)
+  })
+})
+
+describe('selfHarmBreakdown', () => {
+  it('counts cutting, combines strangulation/hanging, burning and other', () => {
+    const reports = [
+      [question('44753', [response('1', 'YES')])], // cutting
+      [question('44207', [response('2', 'YES')])], // strangulation
+      [question('44244', [response('3', 'YES')])], // hanging
+      [
+        question('45167', [response('4', 'YES')]), // burning
+        question('44552', [response('5', 'YES')]), // other
+      ],
+    ]
+
+    const rows = selfHarmBreakdown(reports)
+    expect(count(rows, 'cutting')).toBe(1)
+    expect(count(rows, 'strangulationOrHanging')).toBe(2)
+    expect(count(rows, 'burning')).toBe(1)
+    expect(count(rows, 'other')).toBe(1)
+  })
+})
+
+describe('findBreakdown', () => {
+  it('detects categories from the single-select path', () => {
+    const reports = [
+      [question('67187', [response('218784', 'ALCOHOL / HOOCH / DISTILLING EQUIPMENT')])],
+      [question('67187', [response('218785', 'DRUG / DRUG EQUIPMENT')])],
+      [question('67187', [response('218789', 'WEAPON')])],
+    ]
+
+    const { categories } = findBreakdown(reports)
+    expect(count(categories, 'alcohol')).toBe(1)
+    expect(count(categories, 'drugs')).toBe(1)
+    expect(count(categories, 'weapons')).toBe(1)
+  })
+
+  it('detects categories from the multiple-types path', () => {
+    const reports = [
+      [
+        question('67187', [response('218783', 'MULTIPLE TYPES (SEE FULL BELOW LIST BEFORE SELECTING)')]),
+        question('67205', [response('218955', '1 LITRE TO LESS THAN 2 LITRES - (PLEASE STATE NUMBER IN COMMENTS)')]),
+        question('67207', [response('218965', 'YES')]),
+        question('67224', [response('218947', 'YES - BLUNT INSTRUMENT (COSH, ITEM IN SOCK, ETC)')]),
+      ],
+    ]
+
+    const { categories } = findBreakdown(reports)
+    expect(count(categories, 'alcohol')).toBe(1)
+    expect(count(categories, 'drugs')).toBe(1)
+    expect(count(categories, 'weapons')).toBe(1)
+  })
+
+  it('does not count alcohol when only a NIL quantity is recorded', () => {
+    const reports = [
+      [
+        question('67187', [response('218783', 'MULTIPLE TYPES (SEE FULL BELOW LIST BEFORE SELECTING)')]),
+        question('67205', [response('218953', 'NIL')]),
+      ],
+    ]
+
+    const { categories } = findBreakdown(reports)
+    expect(count(categories, 'alcohol')).toBe(0)
+  })
+
+  it('breaks drugs down by type across both drug questions, grouping cannabis/cocaine and bucketing others', () => {
+    const reports = [
+      [question('67190', [response('1', 'CANNABIS'), response('2', 'CANNABIS PLANT')])], // cannabis (once)
+      [question('67208', [response('3', 'CRACK')])], // cocaine
+      [question('67190', [response('4', 'NPS (NEW PSYCHOACTIVE SUBSTANCES)')])], // nps
+      [question('67190', [response('5', 'HEROIN')])], // other
+      [question('67190', [response('6', 'UNKNOWN')])], // unknown
+      [question('67190', [response('7', 'NONE FOUND')])], // none -> no drug bucket
+    ]
+
+    const { drugs } = findBreakdown(reports)
+    expect(count(drugs, 'cannabis')).toBe(1)
+    expect(count(drugs, 'cocaine')).toBe(1)
+    expect(count(drugs, 'nps')).toBe(1)
+    expect(count(drugs, 'other')).toBe(1)
+    expect(count(drugs, 'unknown')).toBe(1)
+  })
+})

--- a/server/services/prisonerIncidentSummary/breakdowns.ts
+++ b/server/services/prisonerIncidentSummary/breakdowns.ts
@@ -41,18 +41,18 @@ function runRules(reportsQuestions: Question[][], rules: BreakdownRule[]): Break
 
 // --- helpers operating on a single report's questions ---
 
-function findQuestion(questions: Question[], code: string): Question | undefined {
-  return questions.find(question => question.code === code)
+function findQuestion(questions: Question[], questionCode: string): Question | undefined {
+  return questions.find(question => question.code === questionCode)
 }
 
-/** Uppercase response *values* (the `response` field) given to a question, or [] if unanswered. */
-function responseValues(questions: Question[], code: string): string[] {
-  return findQuestion(questions, code)?.responses.map(response => response.response) ?? []
+/** Uppercase responses (the `response` field) given to a question, or [] if unanswered. */
+function responses(questions: Question[], questionCode: string): string[] {
+  return findQuestion(questions, questionCode)?.responses.map(response => response.response) ?? []
 }
 
 /** True if the question has any response whose *code* is in `responseCodes`. */
-function hasAnyResponseCode(questions: Question[], code: string, responseCodes: string[]): boolean {
-  const question = findQuestion(questions, code)
+function hasAnyResponseCode(questions: Question[], questionCode: string, responseCodes: string[]): boolean {
+  const question = findQuestion(questions, questionCode)
   if (!question) {
     return false
   }
@@ -61,19 +61,19 @@ function hasAnyResponseCode(questions: Question[], code: string, responseCodes: 
 }
 
 /** True if the question was answered "YES" (used for the many yes/no questions). */
-function answeredYes(questions: Question[], code: string): boolean {
-  return responseValues(questions, code).some(value => value === 'YES')
+function answeredYes(questions: Question[], questionCode: string): boolean {
+  return responses(questions, questionCode).some(response => response === 'YES')
 }
 
-/** True if the question has any response value starting with `prefix` (e.g. "YES - BLUNT..."). */
-function hasResponseValueStartingWith(questions: Question[], code: string, prefix: string): boolean {
-  return responseValues(questions, code).some(value => value.startsWith(prefix))
+/** True if the question has any response starting with `prefix` (e.g. "YES - BLUNT..."). */
+function hasResponseStartingWith(questions: Question[], questionCode: string, prefix: string): boolean {
+  return responses(questions, questionCode).some(response => response.startsWith(prefix))
 }
 
-/** True if the question has any response value outside `excluded` (e.g. a non-NIL quantity). */
-function hasResponseValueNotIn(questions: Question[], code: string, excluded: string[]): boolean {
+/** True if the question has any response outside `excluded` (e.g. a non-NIL quantity). */
+function hasResponseNotIn(questions: Question[], questionCode: string, excluded: string[]): boolean {
   const exclude = new Set(excluded)
-  return responseValues(questions, code).some(value => !exclude.has(value))
+  return responses(questions, questionCode).some(response => !exclude.has(response))
 }
 
 // --- ASSAULT_5 ---
@@ -136,18 +136,18 @@ const SELF_HARM_RULES: BreakdownRule[] = [
 
 // "DESCRIBE THE DRUG FOUND" appears twice: single-select path (67190) and multiple-types path (67208).
 const DRUG_QUESTION_CODES = ['67190', '67208'] as const
-const NO_DRUG_VALUES = ['NONE FOUND', 'NIL'] as const
+const NO_DRUG_RESPONSES = ['NONE FOUND', 'NIL'] as const
 
-function drugValues(questions: Question[]): string[] {
-  return DRUG_QUESTION_CODES.flatMap(code => responseValues(questions, code))
+function drugResponses(questions: Question[]): string[] {
+  return DRUG_QUESTION_CODES.flatMap(questionCode => responses(questions, questionCode))
 }
 
 function findInvolvesAlcohol(questions: Question[]): boolean {
   return (
     hasAnyResponseCode(questions, '67187', ['218784']) || // category = ALCOHOL / HOOCH / DISTILLING EQUIPMENT
-    hasResponseValueNotIn(questions, '67188', ['NIL']) || // single-path alcohol quantity
-    hasResponseValueNotIn(questions, '67205', ['NIL']) || // multiple-types alcohol quantity
-    hasResponseValueStartingWith(questions, '67206', 'YES') // distilling equipment found
+    hasResponseNotIn(questions, '67188', ['NIL']) || // single-path alcohol quantity
+    hasResponseNotIn(questions, '67205', ['NIL']) || // multiple-types alcohol quantity
+    hasResponseStartingWith(questions, '67206', 'YES') // distilling equipment found
   )
 }
 
@@ -155,15 +155,15 @@ function findInvolvesDrugs(questions: Question[]): boolean {
   return (
     hasAnyResponseCode(questions, '67187', ['218785']) || // category = DRUG / DRUG EQUIPMENT
     answeredYes(questions, '67207') || // multiple-types "WERE ANY DRUGS FOUND"
-    drugValues(questions).some(value => !(NO_DRUG_VALUES as readonly string[]).includes(value))
+    drugResponses(questions).some(response => !(NO_DRUG_RESPONSES as readonly string[]).includes(response))
   )
 }
 
 function findInvolvesWeapons(questions: Question[]): boolean {
   return (
     hasAnyResponseCode(questions, '67187', ['218789']) || // category = WEAPON
-    hasResponseValueStartingWith(questions, '67203', 'YES') || // single-path "WHAT WEAPON WAS FOUND?"
-    hasResponseValueStartingWith(questions, '67224', 'YES') // multiple-types "WHAT WEAPON WAS FOUND?"
+    hasResponseStartingWith(questions, '67203', 'YES') || // single-path "WHAT WEAPON WAS FOUND?"
+    hasResponseStartingWith(questions, '67224', 'YES') // multiple-types "WHAT WEAPON WAS FOUND?"
   )
 }
 
@@ -173,35 +173,35 @@ const FIND_CATEGORY_RULES: BreakdownRule[] = [
   { id: 'weapons', label: 'Weapons', matches: findInvolvesWeapons },
 ]
 
-// Drug sub-types are matched on the response value text because the codes differ between the two
+// Drug sub-types are matched on the response text because the codes differ between the two
 // "DESCRIBE THE DRUG FOUND" questions.
-const CANNABIS_VALUES = ['CANNABIS', 'CANNABIS PLANT']
-const COCAINE_VALUES = ['COCAINE', 'CRACK']
-const NPS_VALUES = ['NPS (NEW PSYCHOACTIVE SUBSTANCES)']
-const UNKNOWN_DRUG_VALUES = ['UNKNOWN']
+const CANNABIS_RESPONSES = ['CANNABIS', 'CANNABIS PLANT']
+const COCAINE_RESPONSES = ['COCAINE', 'CRACK']
+const NPS_RESPONSES = ['NPS (NEW PSYCHOACTIVE SUBSTANCES)']
+const UNKNOWN_DRUG_RESPONSES = ['UNKNOWN']
 
-function drugMatches(questions: Question[], values: string[]): boolean {
-  const present = new Set(drugValues(questions))
-  return values.some(value => present.has(value))
+function drugMatches(questions: Question[], wantedResponses: string[]): boolean {
+  const present = new Set(drugResponses(questions))
+  return wantedResponses.some(response => present.has(response))
 }
 
 function drugMatchesOther(questions: Question[]): boolean {
   const accountedFor = new Set<string>([
-    ...CANNABIS_VALUES,
-    ...COCAINE_VALUES,
-    ...NPS_VALUES,
-    ...UNKNOWN_DRUG_VALUES,
-    ...NO_DRUG_VALUES,
+    ...CANNABIS_RESPONSES,
+    ...COCAINE_RESPONSES,
+    ...NPS_RESPONSES,
+    ...UNKNOWN_DRUG_RESPONSES,
+    ...NO_DRUG_RESPONSES,
   ])
-  return drugValues(questions).some(value => !accountedFor.has(value))
+  return drugResponses(questions).some(response => !accountedFor.has(response))
 }
 
 const FIND_DRUG_RULES: BreakdownRule[] = [
-  { id: 'cannabis', label: 'Cannabis', matches: q => drugMatches(q, CANNABIS_VALUES) },
-  { id: 'cocaine', label: 'Cocaine', matches: q => drugMatches(q, COCAINE_VALUES) },
-  { id: 'nps', label: 'NPS (new psychoactive substances)', matches: q => drugMatches(q, NPS_VALUES) },
+  { id: 'cannabis', label: 'Cannabis', matches: q => drugMatches(q, CANNABIS_RESPONSES) },
+  { id: 'cocaine', label: 'Cocaine', matches: q => drugMatches(q, COCAINE_RESPONSES) },
+  { id: 'nps', label: 'NPS (new psychoactive substances)', matches: q => drugMatches(q, NPS_RESPONSES) },
   { id: 'other', label: 'Other drug', matches: drugMatchesOther },
-  { id: 'unknown', label: 'Unknown drug', matches: q => drugMatches(q, UNKNOWN_DRUG_VALUES) },
+  { id: 'unknown', label: 'Unknown drug', matches: q => drugMatches(q, UNKNOWN_DRUG_RESPONSES) },
 ]
 
 // --- public extractors ---

--- a/server/services/prisonerIncidentSummary/breakdowns.ts
+++ b/server/services/prisonerIncidentSummary/breakdowns.ts
@@ -1,0 +1,239 @@
+import type { Question } from '../../data/incidentReportingApi'
+
+/**
+ * Detail breakdowns for the prisoner incident summary page.
+ *
+ * Each breakdown drills into a report's questions/responses to produce extra sub-counts for a
+ * family. To keep this robust we only map the *currently active* type version for each family
+ * (ASSAULT_5, DISORDER_2, SELF_HARM_1, FIND_6). Reports of older versions are skipped by these
+ * extractors (they still count towards the family total in the overall section).
+ *
+ * The question/response codes below are taken from the matching config file in
+ * `server/reportConfiguration/types/`. If a new active version ships, add a new extractor and
+ * re-verify these codes against the new config.
+ *
+ * A single report may match several buckets (questions can have multiple answers), so the
+ * sub-counts are report-counts and are not expected to sum to the family total.
+ */
+
+/** A single labelled count within a breakdown. */
+export interface BreakdownRow {
+  id: string
+  label: string
+  count: number
+}
+
+/** One rule: a stable id, a display label, and a predicate over a report's questions. */
+interface BreakdownRule {
+  id: string
+  label: string
+  matches: (questions: Question[]) => boolean
+}
+
+/** Run a set of rules across every report's questions, returning ordered labelled counts. */
+function runRules(reportsQuestions: Question[][], rules: BreakdownRule[]): BreakdownRow[] {
+  return rules.map(({ id, label, matches }) => ({
+    id,
+    label,
+    count: reportsQuestions.filter(questions => matches(questions)).length,
+  }))
+}
+
+// --- helpers operating on a single report's questions ---
+
+function findQuestion(questions: Question[], code: string): Question | undefined {
+  return questions.find(question => question.code === code)
+}
+
+/** Uppercase response *values* (the `response` field) given to a question, or [] if unanswered. */
+function responseValues(questions: Question[], code: string): string[] {
+  return findQuestion(questions, code)?.responses.map(response => response.response) ?? []
+}
+
+/** True if the question has any response whose *code* is in `responseCodes`. */
+function hasAnyResponseCode(questions: Question[], code: string, responseCodes: string[]): boolean {
+  const question = findQuestion(questions, code)
+  if (!question) {
+    return false
+  }
+  const wanted = new Set(responseCodes)
+  return question.responses.some(response => wanted.has(response.code))
+}
+
+/** True if the question was answered "YES" (used for the many yes/no questions). */
+function answeredYes(questions: Question[], code: string): boolean {
+  return responseValues(questions, code).some(value => value === 'YES')
+}
+
+/** True if the question has any response value starting with `prefix` (e.g. "YES - BLUNT..."). */
+function hasResponseValueStartingWith(questions: Question[], code: string, prefix: string): boolean {
+  return responseValues(questions, code).some(value => value.startsWith(prefix))
+}
+
+/** True if the question has any response value outside `excluded` (e.g. a non-NIL quantity). */
+function hasResponseValueNotIn(questions: Question[], code: string, excluded: string[]): boolean {
+  const exclude = new Set(excluded)
+  return responseValues(questions, code).some(value => !exclude.has(value))
+}
+
+// --- ASSAULT_5 ---
+
+const ASSAULT_RULES: BreakdownRule[] = [
+  // "WHAT TYPE OF ASSAULT WAS IT" (61287)
+  { id: 'prisonerOnPrisoner', label: 'Prisoner on prisoner', matches: q => hasAnyResponseCode(q, '61287', ['213115']) },
+  { id: 'prisonerOnStaff', label: 'Prisoner on staff', matches: q => hasAnyResponseCode(q, '61287', ['213116']) },
+  { id: 'prisonerOnOther', label: 'Prisoner on other', matches: q => hasAnyResponseCode(q, '61287', ['213117']) },
+  // "WAS A SERIOUS INJURY SUSTAINED" (61298)
+  { id: 'serious', label: 'Serious injury sustained', matches: q => answeredYes(q, '61298') },
+  // "WAS THIS A SEXUAL ASSAULT" (61285)
+  { id: 'sexual', label: 'Sexual assault', matches: q => answeredYes(q, '61285') },
+  // "WAS SPITTING USED IN THIS INCIDENT" (61290)
+  { id: 'spitting', label: 'Spitting used', matches: q => answeredYes(q, '61290') },
+  // "WAS MEDICAL TREATMENT FOR CONCUSSION OR INTERNAL INJURIES REQUIRED" (61305)
+  { id: 'concussion', label: 'Concussion or internal injury treatment', matches: q => answeredYes(q, '61305') },
+]
+
+// --- DISORDER_2 ---
+
+const DISORDER_RULES: BreakdownRule[] = [
+  // "WHAT TYPE OF DISORDER INCIDENT WAS THIS?" (63179)
+  {
+    id: 'barricade',
+    label: 'Barricade / prevention of access',
+    matches: q => hasAnyResponseCode(q, '63179', ['214684']),
+  },
+  {
+    id: 'concertedIndiscipline',
+    label: 'Concerted indiscipline',
+    matches: q => hasAnyResponseCode(q, '63179', ['214685']),
+  },
+  { id: 'hostage', label: 'Hostage', matches: q => hasAnyResponseCode(q, '63179', ['214686']) },
+  { id: 'incidentAtHeight', label: 'Incident at height', matches: q => hasAnyResponseCode(q, '63179', ['214687']) },
+]
+
+// --- SELF_HARM_1 ---
+
+const SELF_HARM_RULES: BreakdownRule[] = [
+  // "DID SELF HARM METHOD INVOLVE CUTTING" (44753)
+  { id: 'cutting', label: 'Cutting', matches: q => answeredYes(q, '44753') },
+  // "DID SELF HARM METHOD INVOLVE SELF STRANGULATION" (44207) or "...HANGING" (44244)
+  {
+    id: 'strangulationOrHanging',
+    label: 'Strangulation or hanging',
+    matches: q => answeredYes(q, '44207') || answeredYes(q, '44244'),
+  },
+  // "DID SELF HARM METHOD INVOLVE BURNING" (45167)
+  { id: 'burning', label: 'Burning', matches: q => answeredYes(q, '45167') },
+  // "WAS ANY OTHER SELF HARM METHOD INVOLVED" (44552)
+  { id: 'other', label: 'Other method', matches: q => answeredYes(q, '44552') },
+]
+
+// --- FIND_6 ---
+//
+// Categories can be recorded two ways: a single-select "PLEASE SELECT CATEGORY OF FIND" (67187),
+// or "MULTIPLE TYPES" (67187 -> 218783) which walks each category as its own question. The rules
+// below detect a category across both paths.
+
+// "DESCRIBE THE DRUG FOUND" appears twice: single-select path (67190) and multiple-types path (67208).
+const DRUG_QUESTION_CODES = ['67190', '67208'] as const
+const NO_DRUG_VALUES = ['NONE FOUND', 'NIL'] as const
+
+function drugValues(questions: Question[]): string[] {
+  return DRUG_QUESTION_CODES.flatMap(code => responseValues(questions, code))
+}
+
+function findInvolvesAlcohol(questions: Question[]): boolean {
+  return (
+    hasAnyResponseCode(questions, '67187', ['218784']) || // category = ALCOHOL / HOOCH / DISTILLING EQUIPMENT
+    hasResponseValueNotIn(questions, '67188', ['NIL']) || // single-path alcohol quantity
+    hasResponseValueNotIn(questions, '67205', ['NIL']) || // multiple-types alcohol quantity
+    hasResponseValueStartingWith(questions, '67206', 'YES') // distilling equipment found
+  )
+}
+
+function findInvolvesDrugs(questions: Question[]): boolean {
+  return (
+    hasAnyResponseCode(questions, '67187', ['218785']) || // category = DRUG / DRUG EQUIPMENT
+    answeredYes(questions, '67207') || // multiple-types "WERE ANY DRUGS FOUND"
+    drugValues(questions).some(value => !(NO_DRUG_VALUES as readonly string[]).includes(value))
+  )
+}
+
+function findInvolvesWeapons(questions: Question[]): boolean {
+  return (
+    hasAnyResponseCode(questions, '67187', ['218789']) || // category = WEAPON
+    hasResponseValueStartingWith(questions, '67203', 'YES') || // single-path "WHAT WEAPON WAS FOUND?"
+    hasResponseValueStartingWith(questions, '67224', 'YES') // multiple-types "WHAT WEAPON WAS FOUND?"
+  )
+}
+
+const FIND_CATEGORY_RULES: BreakdownRule[] = [
+  { id: 'alcohol', label: 'Alcohol', matches: findInvolvesAlcohol },
+  { id: 'drugs', label: 'Drugs', matches: findInvolvesDrugs },
+  { id: 'weapons', label: 'Weapons', matches: findInvolvesWeapons },
+]
+
+// Drug sub-types are matched on the response value text because the codes differ between the two
+// "DESCRIBE THE DRUG FOUND" questions.
+const CANNABIS_VALUES = ['CANNABIS', 'CANNABIS PLANT']
+const COCAINE_VALUES = ['COCAINE', 'CRACK']
+const NPS_VALUES = ['NPS (NEW PSYCHOACTIVE SUBSTANCES)']
+const UNKNOWN_DRUG_VALUES = ['UNKNOWN']
+
+function drugMatches(questions: Question[], values: string[]): boolean {
+  const present = new Set(drugValues(questions))
+  return values.some(value => present.has(value))
+}
+
+function drugMatchesOther(questions: Question[]): boolean {
+  const accountedFor = new Set<string>([
+    ...CANNABIS_VALUES,
+    ...COCAINE_VALUES,
+    ...NPS_VALUES,
+    ...UNKNOWN_DRUG_VALUES,
+    ...NO_DRUG_VALUES,
+  ])
+  return drugValues(questions).some(value => !accountedFor.has(value))
+}
+
+const FIND_DRUG_RULES: BreakdownRule[] = [
+  { id: 'cannabis', label: 'Cannabis', matches: q => drugMatches(q, CANNABIS_VALUES) },
+  { id: 'cocaine', label: 'Cocaine', matches: q => drugMatches(q, COCAINE_VALUES) },
+  { id: 'nps', label: 'NPS (new psychoactive substances)', matches: q => drugMatches(q, NPS_VALUES) },
+  { id: 'other', label: 'Other drug', matches: drugMatchesOther },
+  { id: 'unknown', label: 'Unknown drug', matches: q => drugMatches(q, UNKNOWN_DRUG_VALUES) },
+]
+
+// --- public extractors ---
+
+export function assaultBreakdown(reportsQuestions: Question[][]): BreakdownRow[] {
+  return runRules(reportsQuestions, ASSAULT_RULES)
+}
+
+export function disorderBreakdown(reportsQuestions: Question[][]): BreakdownRow[] {
+  return runRules(reportsQuestions, DISORDER_RULES)
+}
+
+export function selfHarmBreakdown(reportsQuestions: Question[][]): BreakdownRow[] {
+  return runRules(reportsQuestions, SELF_HARM_RULES)
+}
+
+export interface FindBreakdown {
+  categories: BreakdownRow[]
+  drugs: BreakdownRow[]
+}
+
+export function findBreakdown(reportsQuestions: Question[][]): FindBreakdown {
+  return {
+    categories: runRules(reportsQuestions, FIND_CATEGORY_RULES),
+    drugs: runRules(reportsQuestions, FIND_DRUG_RULES),
+  }
+}
+
+/** The active type version that each extractor understands. Used to skip older versions. */
+export const ACTIVE_DETAIL_TYPES = {
+  ASSAULT: 'ASSAULT_5',
+  DISORDER: 'DISORDER_2',
+  SELF_HARM: 'SELF_HARM_1',
+  FIND: 'FIND_6',
+} as const

--- a/server/services/prisonerIncidentSummary/index.test.ts
+++ b/server/services/prisonerIncidentSummary/index.test.ts
@@ -1,0 +1,127 @@
+import { IncidentReportingApi, type Page, type Question, type ReportBasic } from '../../data/incidentReportingApi'
+import type { Status, Type } from '../../reportConfiguration/constants'
+import { getPrisonerIncidentSummary } from '.'
+
+jest.mock('../../data/incidentReportingApi')
+
+const api = IncidentReportingApi.prototype as jest.Mocked<IncidentReportingApi>
+
+function basicReport(id: string, type: Type): ReportBasic {
+  return { id, type } as ReportBasic
+}
+
+function page(content: ReportBasic[], totalPages = 1, number = 0): Page<ReportBasic> {
+  return {
+    content,
+    number,
+    size: content.length,
+    numberOfElements: content.length,
+    totalElements: content.length,
+    totalPages,
+    sort: [],
+  }
+}
+
+function withQuestions(id: string, questions: Question[]) {
+  return { id, questions } as Awaited<ReturnType<IncidentReportingApi['getReportWithDetailsById']>>
+}
+
+function question(code: string, responseCode: string, value: string): Question {
+  return {
+    code,
+    question: code,
+    label: code,
+    additionalInformation: null,
+    responses: [
+      {
+        code: responseCode,
+        response: value,
+        label: value,
+        responseDate: null,
+        additionalInformation: null,
+        recordedBy: 'user1',
+        recordedAt: new Date(),
+      },
+    ],
+  }
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('getPrisonerIncidentSummary', () => {
+  it('queries the API excluding DRAFT/DUPLICATE/NOT_REPORTABLE and filtering by prisoner and incident date', async () => {
+    api.getReports.mockResolvedValue(page([]))
+
+    await getPrisonerIncidentSummary(api, 'A1111AA')
+
+    const query = api.getReports.mock.calls[0][0]
+    expect(query.involvingPrisonerNumber).toBe('A1111AA')
+    expect(query.incidentDateFrom).toBeInstanceOf(Date)
+    const excluded: Status[] = ['DRAFT', 'DUPLICATE', 'NOT_REPORTABLE']
+    excluded.forEach(status => expect(query.status).not.toContain(status))
+    expect(query.status).toContain('CLOSED')
+    expect(query.status).toContain('AWAITING_REVIEW')
+    // roughly 12 months ago
+    const monthsAgo = (Date.now() - (query.incidentDateFrom as Date).getTime()) / (1000 * 60 * 60 * 24 * 30)
+    expect(monthsAgo).toBeGreaterThan(11)
+    expect(monthsAgo).toBeLessThan(13)
+  })
+
+  it('groups reports by family ordered by description, with no breakdowns for plain families', async () => {
+    api.getReports.mockResolvedValue(
+      page([basicReport('1', 'MISCELLANEOUS_1'), basicReport('2', 'FIRE_1'), basicReport('3', 'FIRE_1')]),
+    )
+
+    const summary = await getPrisonerIncidentSummary(api, 'A1111AA')
+
+    expect(summary.totalReports).toBe(3)
+    expect(summary.overall).toEqual([
+      { familyCode: 'FIRE', description: 'Fire', count: 2 },
+      { familyCode: 'MISCELLANEOUS', description: 'Miscellaneous', count: 1 },
+    ])
+    expect(summary.assault).toBeUndefined()
+    expect(summary.find).toBeUndefined()
+    expect(api.getReportWithDetailsById).not.toHaveBeenCalled()
+  })
+
+  it('follows pagination', async () => {
+    api.getReports
+      .mockResolvedValueOnce(page([basicReport('1', 'FIRE_1')], 2, 0))
+      .mockResolvedValueOnce(page([basicReport('2', 'FIRE_1')], 2, 1))
+
+    const summary = await getPrisonerIncidentSummary(api, 'A1111AA')
+
+    expect(api.getReports).toHaveBeenCalledTimes(2)
+    expect(summary.totalReports).toBe(2)
+    expect(summary.overall).toEqual([{ familyCode: 'FIRE', description: 'Fire', count: 2 }])
+  })
+
+  it('counts older type versions in the family total but only drills into the active version', async () => {
+    api.getReports.mockResolvedValue(page([basicReport('new', 'ASSAULT_5'), basicReport('old', 'ASSAULT_1')]))
+    api.getReportWithDetailsById.mockResolvedValue(
+      withQuestions('new', [question('61287', '213115', 'PRISONER ON PRISONER')]),
+    )
+
+    const summary = await getPrisonerIncidentSummary(api, 'A1111AA')
+
+    expect(summary.overall).toEqual([{ familyCode: 'ASSAULT', description: 'Assault', count: 2 }])
+    // only the active ASSAULT_5 report is fetched with details
+    expect(api.getReportWithDetailsById).toHaveBeenCalledTimes(1)
+    expect(api.getReportWithDetailsById).toHaveBeenCalledWith('new')
+    expect(summary.assault?.find(row => row.id === 'prisonerOnPrisoner')?.count).toBe(1)
+  })
+
+  it('produces a find breakdown with categories and drugs', async () => {
+    api.getReports.mockResolvedValue(page([basicReport('f', 'FIND_6')]))
+    api.getReportWithDetailsById.mockResolvedValue(
+      withQuestions('f', [question('67187', '218785', 'DRUG / DRUG EQUIPMENT'), question('67190', '999', 'CANNABIS')]),
+    )
+
+    const summary = await getPrisonerIncidentSummary(api, 'A1111AA')
+
+    expect(summary.find?.categories.find(row => row.id === 'drugs')?.count).toBe(1)
+    expect(summary.find?.drugs.find(row => row.id === 'cannabis')?.count).toBe(1)
+  })
+})

--- a/server/services/prisonerIncidentSummary/index.ts
+++ b/server/services/prisonerIncidentSummary/index.ts
@@ -1,0 +1,136 @@
+import type { IncidentReportingApi, ReportBasic } from '../../data/incidentReportingApi'
+import type { Status, TypeFamily } from '../../reportConfiguration/constants'
+import { getTypeDetails, statuses, typeFamiliesDescriptions } from '../../reportConfiguration/constants'
+import {
+  ACTIVE_DETAIL_TYPES,
+  assaultBreakdown,
+  disorderBreakdown,
+  selfHarmBreakdown,
+  findBreakdown,
+  type BreakdownRow,
+  type FindBreakdown,
+} from './breakdowns'
+
+/** Statuses that are excluded from the prisoner incident summary. */
+const EXCLUDED_STATUSES: ReadonlySet<Status> = new Set<Status>(['DRAFT', 'DUPLICATE', 'NOT_REPORTABLE'])
+
+/** All other statuses are included when querying the API. */
+const INCLUDED_STATUSES: Status[] = statuses.map(status => status.code).filter(code => !EXCLUDED_STATUSES.has(code))
+
+/** Page size used when paging through a prisoner's reports (small volumes expected per prisoner). */
+const PAGE_SIZE = 100
+
+/** A count of reports for one incident-type family. */
+export interface FamilyCount {
+  familyCode: TypeFamily
+  description: string
+  count: number
+}
+
+/** Everything the summary page needs for a single prisoner. */
+export interface PrisonerIncidentSummary {
+  /** Inclusive start of the 12-month window (by incident date). */
+  fromDate: Date
+  /** Total number of (non-excluded) reports involving the prisoner in the window. */
+  totalReports: number
+  /** Per-family counts, ordered by family description. */
+  overall: FamilyCount[]
+  /** Detail breakdowns, present only when the family has at least one report in the window. */
+  assault?: BreakdownRow[]
+  disorder?: BreakdownRow[]
+  selfHarm?: BreakdownRow[]
+  find?: FindBreakdown
+}
+
+/** today minus 12 months, used as the inclusive incidentDateFrom filter. */
+function twelveMonthsAgo(): Date {
+  const date = new Date()
+  date.setFullYear(date.getFullYear() - 1)
+  return date
+}
+
+/** Fetch every (non-excluded) report involving the prisoner since fromDate, following pagination. */
+async function fetchAllReports(
+  api: IncidentReportingApi,
+  prisonerNumber: string,
+  fromDate: Date,
+): Promise<ReportBasic[]> {
+  const reports: ReportBasic[] = []
+  let page = 0
+  let totalPages = 1
+  do {
+    // eslint-disable-next-line no-await-in-loop -- pages must be fetched sequentially
+    const response = await api.getReports({
+      involvingPrisonerNumber: prisonerNumber,
+      incidentDateFrom: fromDate,
+      status: INCLUDED_STATUSES,
+      page,
+      size: PAGE_SIZE,
+      sort: ['incidentDateAndTime,DESC'],
+    })
+    reports.push(...response.content)
+    totalPages = response.totalPages
+    page += 1
+  } while (page < totalPages)
+  return reports
+}
+
+/** Group reports by family code, returning counts ordered by family description. */
+function countByFamily(reports: ReportBasic[]): FamilyCount[] {
+  const counts = new Map<TypeFamily, number>()
+  for (const report of reports) {
+    const family = getTypeDetails(report.type)?.familyCode
+    if (family) {
+      counts.set(family, (counts.get(family) ?? 0) + 1)
+    }
+  }
+  return [...counts.entries()]
+    .map(([familyCode, count]) => ({ familyCode, description: typeFamiliesDescriptions[familyCode], count }))
+    .sort((a, b) => a.description.localeCompare(b.description))
+}
+
+/**
+ * Fetch the questions of every report whose type matches the given active version, in parallel.
+ * Older type versions are not understood by the detail extractors so they are excluded.
+ */
+async function activeVersionQuestions(
+  api: IncidentReportingApi,
+  reports: ReportBasic[],
+  activeType: string,
+): Promise<Array<Awaited<ReturnType<IncidentReportingApi['getReportWithDetailsById']>>['questions']>> {
+  const matching = reports.filter(report => report.type === activeType)
+  const detailed = await Promise.all(matching.map(report => api.getReportWithDetailsById(report.id)))
+  return detailed.map(report => report.questions)
+}
+
+/** Build the 12-month incident summary for a single prisoner. */
+export async function getPrisonerIncidentSummary(
+  api: IncidentReportingApi,
+  prisonerNumber: string,
+): Promise<PrisonerIncidentSummary> {
+  const fromDate = twelveMonthsAgo()
+  const reports = await fetchAllReports(api, prisonerNumber, fromDate)
+  const overall = countByFamily(reports)
+  const families = new Set(overall.map(family => family.familyCode))
+
+  const summary: PrisonerIncidentSummary = {
+    fromDate,
+    totalReports: reports.length,
+    overall,
+  }
+
+  if (families.has('ASSAULT')) {
+    summary.assault = assaultBreakdown(await activeVersionQuestions(api, reports, ACTIVE_DETAIL_TYPES.ASSAULT))
+  }
+  if (families.has('DISORDER')) {
+    summary.disorder = disorderBreakdown(await activeVersionQuestions(api, reports, ACTIVE_DETAIL_TYPES.DISORDER))
+  }
+  if (families.has('SELF_HARM')) {
+    summary.selfHarm = selfHarmBreakdown(await activeVersionQuestions(api, reports, ACTIVE_DETAIL_TYPES.SELF_HARM))
+  }
+  if (families.has('FIND')) {
+    summary.find = findBreakdown(await activeVersionQuestions(api, reports, ACTIVE_DETAIL_TYPES.FIND))
+  }
+
+  return summary
+}

--- a/server/services/prisonerIncidentSummary/index.ts
+++ b/server/services/prisonerIncidentSummary/index.ts
@@ -1,4 +1,4 @@
-import type { IncidentReportingApi, ReportBasic } from '../../data/incidentReportingApi'
+import type { IncidentReportingApi, Question, ReportBasic } from '../../data/incidentReportingApi'
 import type { Status, TypeFamily } from '../../reportConfiguration/constants'
 import { getTypeDetails, statuses, typeFamiliesDescriptions } from '../../reportConfiguration/constants'
 import {
@@ -66,7 +66,6 @@ async function fetchAllReports(
       status: INCLUDED_STATUSES,
       page,
       size: PAGE_SIZE,
-      sort: ['incidentDateAndTime,DESC'],
     })
     reports.push(...response.content)
     totalPages = response.totalPages
@@ -97,7 +96,7 @@ async function activeVersionQuestions(
   api: IncidentReportingApi,
   reports: ReportBasic[],
   activeType: string,
-): Promise<Array<Awaited<ReturnType<IncidentReportingApi['getReportWithDetailsById']>>['questions']>> {
+): Promise<Question[][]> {
   const matching = reports.filter(report => report.type === activeType)
   const detailed = await Promise.all(matching.map(report => api.getReportWithDetailsById(report.id)))
   return detailed.map(report => report.questions)

--- a/server/views/pages/prisonerIncidentSummary.njk
+++ b/server/views/pages/prisonerIncidentSummary.njk
@@ -1,0 +1,93 @@
+{% extends "partials/layout.njk" %}
+
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% set prisonerName = prisoner | nameOfPerson %}
+{% set pageTitle = "Incident summary for " + prisoner.prisonerNumber %}
+{% set bodyClasses = "app-prisoner-incident-summary" %}
+
+{#
+  Render a list of { label, count } breakdown rows as a two-column table.
+#}
+{% macro breakdownTable(caption, rows) %}
+  {% set tableRows = [] %}
+  {% for row in rows %}
+    {% set tableRows = (tableRows.push([
+      { text: row.label },
+      { text: row.count, format: "numeric" }
+    ]), tableRows) %}
+  {% endfor %}
+  {{ govukTable({
+    caption: caption,
+    captionClasses: "govuk-table__caption--m",
+    firstCellIsHeader: true,
+    head: [
+      { text: "Detail" },
+      { text: "Number of reports", format: "numeric" }
+    ],
+    rows: tableRows
+  }) }}
+{% endmacro %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <span class="govuk-caption-l">{{ prisonerName }} ({{ prisoner.prisonerNumber }})</span>
+      <h1 class="govuk-heading-l">Incident summary</h1>
+
+      <p class="govuk-body">
+        Incidents involving this person in the 12 months since {{ summary.fromDate | longDate }}.
+        Draft, duplicate and not-reportable reports are excluded.
+      </p>
+
+      {% if summary.totalReports == 0 %}
+
+        <p class="govuk-body">No incidents have been recorded for this person in the last 12 months.</p>
+
+      {% else %}
+
+        {% set overallRows = [] %}
+        {% for family in summary.overall %}
+          {% set overallRows = (overallRows.push([
+            { text: family.description },
+            { text: family.count, format: "numeric" }
+          ]), overallRows) %}
+        {% endfor %}
+        {{ govukTable({
+          caption: "All incidents by type",
+          captionClasses: "govuk-table__caption--m",
+          firstCellIsHeader: true,
+          head: [
+            { text: "Incident type" },
+            { text: "Number of reports", format: "numeric" }
+          ],
+          rows: overallRows
+        }) }}
+
+        {% if summary.assault %}
+          <h2 class="govuk-heading-m">Assault detail</h2>
+          {{ breakdownTable("Assaults", summary.assault) }}
+        {% endif %}
+
+        {% if summary.disorder %}
+          <h2 class="govuk-heading-m">Disorder detail</h2>
+          {{ breakdownTable("Disorder types", summary.disorder) }}
+        {% endif %}
+
+        {% if summary.selfHarm %}
+          <h2 class="govuk-heading-m">Self-harm detail</h2>
+          {{ breakdownTable("Self-harm methods", summary.selfHarm) }}
+        {% endif %}
+
+        {% if summary.find %}
+          <h2 class="govuk-heading-m">Find detail</h2>
+          {{ breakdownTable("Categories of find", summary.find.categories) }}
+          {{ breakdownTable("Drugs found", summary.find.drugs) }}
+        {% endif %}
+
+      {% endif %}
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/pages/prisonerIncidentSummary.njk
+++ b/server/views/pages/prisonerIncidentSummary.njk
@@ -9,7 +9,7 @@
 {#
   Render a list of { label, count } breakdown rows as a two-column table.
 #}
-{% macro breakdownTable(caption, rows) %}
+{% macro breakdownTable(caption, rows, firstColumnHeader = "Detail") %}
   {% set tableRows = [] %}
   {% for row in rows %}
     {% set tableRows = (tableRows.push([
@@ -22,7 +22,7 @@
     captionClasses: "govuk-table__caption--m",
     firstCellIsHeader: true,
     head: [
-      { text: "Detail" },
+      { text: firstColumnHeader },
       { text: "Number of reports", format: "numeric" }
     ],
     rows: tableRows
@@ -43,27 +43,15 @@
 
       {% if summary.totalReports == 0 %}
 
-        <p class="govuk-body">No incidents have been recorded for this person in the last 12 months.</p>
+        <p class="govuk-body">This person hasn't been involved in any recorded incident in the last 12 months.</p>
 
       {% else %}
 
         {% set overallRows = [] %}
         {% for family in summary.overall %}
-          {% set overallRows = (overallRows.push([
-            { text: family.description },
-            { text: family.count, format: "numeric" }
-          ]), overallRows) %}
+          {% set overallRows = (overallRows.push({ label: family.description, count: family.count }), overallRows) %}
         {% endfor %}
-        {{ govukTable({
-          caption: "All incidents by type",
-          captionClasses: "govuk-table__caption--m",
-          firstCellIsHeader: true,
-          head: [
-            { text: "Incident type" },
-            { text: "Number of reports", format: "numeric" }
-          ],
-          rows: overallRows
-        }) }}
+        {{ breakdownTable("All incidents by type", overallRows, "Incident type") }}
 
         {% if summary.assault %}
           <h2 class="govuk-heading-m">Assault detail</h2>


### PR DESCRIPTION
## What & why

Adds a new read-only page that, for a given prisoner, summarises the incidents they have been
involved in over the past 12 months. It is intended to be linked to from other HMPPS services,
so unlike the rest of this app it is **accessible to any signed-in user**, provided the prisoner
is in one of their caseloads.

The page shows:

- **All incidents by type** — a count of (non-excluded) reports per incident-type family.
- **Detail subsections** for Assault, Disorder, Self-harm and Find, drilling into each report's
  questions/responses for extra sub-counts.

URL: `GET /prisoner/:prisonerNumber/incident-summary`

<img width="2400" height="5850" alt="prisoner-incident-summary" src="https://github.com/user-attachments/assets/a19e38e4-84ba-4d05-9504-370c2db3fcee" />

## Behaviour & decisions

- **12-month window** is measured against the **incident date** (`incidentDateFrom = today − 12
  months`).
- **Excluded statuses**: `DRAFT`, `DUPLICATE`, `NOT_REPORTABLE`. All other statuses are included
  (derived from the `statuses` constant so it stays correct if new statuses are added).
- **Caseload access**: a prisoner outside the user's caseloads returns **404 Not Found**, not
    403. The app's error handler turns 403 into a sign-out, which is wrong for a legitimately
         signed-in user; 404 also avoids confirming a prisoner exists. This naturally denies out/transfer
         prisoners (prisonId `OUT`/`TRN`).
- **Detail extraction covers active type versions only** — `ASSAULT_5`, `DISORDER_2`,
  `SELF_HARM_1`, `FIND_6`. Reports of older versions are still counted in the overall/family
  totals but are not drilled into. A short doc comment in `breakdowns.ts` explains how to add a
  new version when one becomes active.
- A report can fall into several sub-buckets (questions allow multiple answers), so sub-counts are
  report-counts and are not expected to sum to the family total.

### Detail sub-counts

| Family | Sub-counts |
|---|---|
| Assault | Prisoner-on-prisoner / staff / other, serious injury, sexual, spitting, concussion/internal-injury treatment |
| Disorder | Barricade/prevention of access, concerted indiscipline, hostage, incident at height |
| Self-harm | Cutting, strangulation **or** hanging (combined), burning, other method |
| Find | Categories: alcohol / drugs / weapons; drug sub-types: cannabis, cocaine, NPS, other, unknown |

Find category detection covers both the single-select "category of find" path and the "multiple
types" path (which records each category as its own question). Drug sub-types are matched on the
response text because the codes differ between the two "describe the drug found" questions.
Drug grouping assumption: **CRACK → cocaine**, **CANNABIS PLANT → cannabis**.

## Implementation

The summary logic is a plain function module (not a registered singleton service) because the
`incidentReportingApi` client is built per-request in `setApis`; the controller passes
`res.locals.apis.incidentReportingApi` into it.

| File | Purpose |
|---|---|
| `server/services/prisonerIncidentSummary/breakdowns.ts` | Config-driven per-active-type extractors + helpers; response codes commented against their source config file |
| `server/services/prisonerIncidentSummary/index.ts` | `getPrisonerIncidentSummary(api, prisonerNumber)` — pages through `getReports`, groups by family, fetches `with-details` only for active-version reports in the four special families |
| `server/middleware/requirePrisonerInCaseload.ts` | Guards the route (404 when prisoner not in caseload); runs after `populatePrisoner()` |
| `server/routes/prisonerIncidentSummary/index.ts` | Router: `populatePrisoner()` → `requirePrisonerInCaseload()` → controller |
| `server/views/pages/prisonerIncidentSummary.njk` | GOV.UK page: overall table, per-family detail tables, empty state |
| `server/routes/index.ts` | Mounts the router at `/prisoner/:prisonerNumber/incident-summary` |
| `server/@types/express/index.d.ts` | Adds `prisoner?: OffenderSearchResult` to `res.locals` (set by `populatePrisoner`) |

Reuses existing building blocks: `IncidentReportingApi.getReports` / `getReportWithDetailsById`,
`getTypeDetails` / `typeFamiliesDescriptions`, the `statuses` constant, `populatePrisoner()`,
and the caseload pattern from `permissions/rulesClass.ts`.

## Tests

- `breakdowns.test.ts` — extractor logic, incl. multi-answer, non-YES, multiple-types find path,
  NIL-quantity alcohol, and drug grouping across both drug questions.
- `index.test.ts` (service) — status filter, ~12-month boundary, family grouping/ordering,
  pagination, older-version reports counted but not drilled into, find breakdown.
- `requirePrisonerInCaseload.test.ts` — allow / 404 (out of caseload) / 404 (out-of-prison) / 500
  (middleware misordered).
- `routes/prisonerIncidentSummary/index.test.ts` — renders for in-caseload prisoner, empty state,
  404 for out-of-caseload.
- `integration_tests/e2e/prisonerIncidentSummary.cy.ts` — Cypress test stubbing all four special
  families plus plain ones, asserting the rendered content and capturing a screenshot.
