### PR TITLE
IR-1681 Add breadcrumb to prisoner incident summary page

### DIFF
--- a/server/routes/prisonerIncidentSummary/index.test.ts
+++ b/server/routes/prisonerIncidentSummary/index.test.ts
@@ -54,6 +54,20 @@ describe('GET /prisoner/:prisonerNumber/incident-summary', () => {
       })
   })
 
+  it('renders a breadcrumb linking back to the prisoner’s DPS profile', () => {
+    offenderSearchApi.getPrisoner.mockResolvedValue(andrew)
+    incidentReportingApi.getReports.mockResolvedValue(page([]))
+
+    return request(app)
+      .get(`/prisoner/${andrew.prisonerNumber}/incident-summary`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('govuk-breadcrumbs')
+        expect(res.text).toContain('Arnold, Andrew')
+        expect(res.text).toContain(`/prisoner/${andrew.prisonerNumber}`)
+      })
+  })
+
   it('renders an empty state when there are no incidents', () => {
     offenderSearchApi.getPrisoner.mockResolvedValue(andrew)
     incidentReportingApi.getReports.mockResolvedValue(page([]))

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -8,7 +8,7 @@ import mojFrontendFilters from '@ministryofjustice/frontend/moj/filters/all'
 
 import logger from '../../logger'
 import config from '../config'
-import { convertToTitleCase, initialiseName, nameOfPerson, possessive } from './utils'
+import { convertToTitleCase, initialiseName, nameOfPerson, possessive, reversedNameOfPerson } from './utils'
 import {
   findFieldInGovukErrorSummary,
   govukCheckedItems,
@@ -83,6 +83,7 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addFilter('convertToTitleCase', convertToTitleCase)
   njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addFilter('nameOfPerson', nameOfPerson)
+  njkEnv.addFilter('reversedNameOfPerson', reversedNameOfPerson)
   njkEnv.addFilter('possessive', possessive)
 
   // date/datetime handling

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -8,6 +8,7 @@ import {
   initialiseName,
   possessive,
   nameOfPerson,
+  reversedNameOfPerson,
   errorResponseStatusMatches,
 } from './utils'
 import { mockThrownError } from '../data/testData/thrownErrors'
@@ -45,6 +46,21 @@ describe('display of prisoner names', () => {
   ])('trimming whitespace if $scenario is present', person => {
     it('normal', () => {
       expect(nameOfPerson(person as unknown as { firstName: string; lastName: string })).toEqual(person.expected)
+    })
+  })
+
+  it('reversed (surname first)', () => {
+    expect(reversedNameOfPerson(prisoner)).toEqual('Jones, David')
+  })
+
+  describe.each([
+    { scenario: 'only first name', firstName: 'DAVID', expected: 'David' },
+    { scenario: 'only surname', lastName: 'JONES', expected: 'Jones' },
+  ])('reversed name without comma if $scenario is present', person => {
+    it('normal', () => {
+      expect(reversedNameOfPerson(person as unknown as { firstName: string; lastName: string })).toEqual(
+        person.expected,
+      )
     })
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -32,6 +32,18 @@ export function convertToTitleCase(sentence: string | undefined | null): string 
 export const nameOfPerson = (prisoner: { firstName: string; lastName: string }): string =>
   `${convertToTitleCase(prisoner.firstName)} ${convertToTitleCase(prisoner.lastName)}`.trim()
 
+/**
+ * Surname-first display form of a person’s name, matching the Digital Prison Services convention
+ * used in breadcrumbs (e.g. linking back to a prisoner’s profile).
+ * { "firstName": "DAVID", "lastName": "JONES", … } → "Jones, David"
+ */
+export const reversedNameOfPerson = (prisoner: { firstName: string; lastName: string }): string => {
+  const firstName = convertToTitleCase(prisoner.firstName)
+  const lastName = convertToTitleCase(prisoner.lastName)
+  if (firstName && lastName) return `${lastName}, ${firstName}`
+  return `${lastName}${firstName}`.trim()
+}
+
 export const initialiseName = (fullName?: string): string | null => {
   // this check is for the authError page
   if (!fullName) return null

--- a/server/views/pages/prisonerIncidentSummary.njk
+++ b/server/views/pages/prisonerIncidentSummary.njk
@@ -1,10 +1,28 @@
 {% extends "partials/layout.njk" %}
 
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% set prisonerName = prisoner | nameOfPerson %}
 {% set pageTitle = "Incident summary for " + prisoner.prisonerNumber %}
 {% set bodyClasses = "app-prisoner-incident-summary" %}
+
+{% block containerStart %}
+  {{ super() }}
+
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Digital Prison Services",
+        href: dpsUrl
+      },
+      {
+        text: prisoner | reversedNameOfPerson,
+        href: dpsUrl + "/prisoner/" + prisoner.prisonerNumber
+      }
+    ]
+  }) }}
+{% endblock %}
 
 {#
   Render a list of { label, count } breakdown rows as a two-column table.


### PR DESCRIPTION
## Summary
Adds a breadcrumb to the prisoner incident summary page (`/prisoner/:prisonerNumber/incident-summary`) so users can navigate back to the prisoner's profile in Digital Prison Services.

The trail mirrors the Incentives service: **Digital Prison Services > {surname, forename}**, where the name links to `{dpsUrl}/prisoner/{prisonerNumber}`.

This is step 1 of linking the prisoner profile to the incident summary (the profile-side link is a separate PR in hmpps-prisoner-profile under the same ticket).

## Changes
- `prisonerIncidentSummary.njk` — add a `containerStart` block rendering `govukBreadcrumbs`, using the existing app pattern.
- `utils.ts` / `nunjucksSetup.ts` — add `reversedNameOfPerson` helper + Nunjucks filter for the surname-first name format.
- Unit tests for the helper and the breadcrumb render.

## Testing
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npx jest utils prisonerIncidentSummary` ✅ (332 passing)