### PR TITLE
IR-1696 Hide incident report link when user cannot view the report

### DIFF
--- a/server/routes/prisonerIncidentSummary/index.test.ts
+++ b/server/routes/prisonerIncidentSummary/index.test.ts
@@ -105,12 +105,13 @@ describe('GET /prisoner/:prisonerNumber/incident-summary', () => {
 })
 
 describe('GET /prisoner/:prisonerNumber/incident-summary/incidents', () => {
-  function reportWithDetails(reportReference: string, type: Type): ReportWithDetails {
+  function reportWithDetails(reportReference: string, type: Type, location = 'MDI'): ReportWithDetails {
     const report = convertReportDates(
       mockReport({
         reportReference,
         type,
         status: 'AWAITING_REVIEW',
+        location,
         reportDateAndTime: new Date('2025-06-01T10:15:00Z'),
         withDetails: true,
       }),
@@ -145,6 +146,23 @@ describe('GET /prisoner/:prisonerNumber/incident-summary/incidents', () => {
         expect(res.text).toContain('6001') // report reference
         expect(res.text).toContain('Perpetrator')
         expect(res.text).toContain('Moorland (HMP)')
+        expect(res.text).toContain('href="/reports/') // viewable report is linked
+      })
+  })
+
+  it('renders the report reference as plain text when the user cannot view the report', () => {
+    offenderSearchApi.getPrisoner.mockResolvedValue(andrew)
+    incidentReportingApi.getReports.mockResolvedValue(page([basicReport('1', 'FIRE_1')]))
+    // report at Leeds, outside the reporting officer’s (MDI-only) caseload
+    incidentReportingApi.getReportWithDetailsById.mockResolvedValue(reportWithDetails('6002', 'FIRE_1', 'LEI'))
+    prisonApi.getAgency.mockResolvedValue({ agencyId: 'LEI', description: 'Leeds (HMP)' } as never)
+
+    return request(app)
+      .get(`/prisoner/${andrew.prisonerNumber}/incident-summary/incidents`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('6002') // report reference still shown
+        expect(res.text).not.toContain('href="/reports/') // but no link to the un-viewable report
       })
   })
 

--- a/server/routes/prisonerIncidentSummary/index.ts
+++ b/server/routes/prisonerIncidentSummary/index.ts
@@ -32,12 +32,7 @@ export default function prisonerIncidentSummaryRouter(): Router {
     const { prisonerNumber } = req.params
     const { incidentReportingApi, prisonApi } = res.locals.apis
 
-    const prisonerIncidentList = await getPrisonerIncidentList(
-      incidentReportingApi,
-      prisonApi,
-      prisonerNumber,
-      res.locals.permissions,
-    )
+    const prisonerIncidentList = await getPrisonerIncidentList(incidentReportingApi, prisonApi, prisonerNumber)
 
     res.render('pages/prisonerIncidentList', {
       prisoner: res.locals.prisoner,

--- a/server/routes/prisonerIncidentSummary/index.ts
+++ b/server/routes/prisonerIncidentSummary/index.ts
@@ -32,7 +32,12 @@ export default function prisonerIncidentSummaryRouter(): Router {
     const { prisonerNumber } = req.params
     const { incidentReportingApi, prisonApi } = res.locals.apis
 
-    const prisonerIncidentList = await getPrisonerIncidentList(incidentReportingApi, prisonApi, prisonerNumber)
+    const prisonerIncidentList = await getPrisonerIncidentList(
+      incidentReportingApi,
+      prisonApi,
+      prisonerNumber,
+      res.locals.permissions,
+    )
 
     res.render('pages/prisonerIncidentList', {
       prisoner: res.locals.prisoner,

--- a/server/services/prisonerIncidentSummary/list.test.ts
+++ b/server/services/prisonerIncidentSummary/list.test.ts
@@ -11,6 +11,8 @@ import { AgencyType } from '../../data/constants'
 import { convertReportDates } from '../../data/incidentReportingApiUtils'
 import { mockReport } from '../../data/testData/incidentReporting'
 import type { PrisonerInvolvementRole, Status, Type } from '../../reportConfiguration/constants'
+import { Permissions } from '../../middleware/permissions'
+import { mockReportingOfficer } from '../../data/testData/users'
 import { getPrisonerIncidentList } from './list'
 
 jest.mock('../../data/incidentReportingApi')
@@ -24,6 +26,9 @@ afterEach(() => {
 })
 
 const PRISONER_NUMBER = 'A1111AA'
+
+// reporting officer with the Moorland (MDI) caseload only
+const permissions = new Permissions(mockReportingOfficer)
 
 function response(
   code: string,
@@ -142,7 +147,7 @@ describe('getPrisonerIncidentList', () => {
     })
     mockApis([assault])
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
 
     expect(rows).toHaveLength(1) // only this prisoner, not the unrelated involvement
     expect(rows[0]).toMatchObject({
@@ -174,7 +179,7 @@ describe('getPrisonerIncidentList', () => {
     })
     mockApis([selfHarm])
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
 
     expect(rows[0].extraInformation).toBe('Cutting, Burning')
     expect(rows[0].location).toBe('Ordinary (A-1-2-34)')
@@ -196,7 +201,7 @@ describe('getPrisonerIncidentList', () => {
     })
     mockApis([find])
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
 
     expect(rows[0].subtype).toBe('Multiple types')
     expect(rows[0].role).toBe('In possession')
@@ -213,7 +218,7 @@ describe('getPrisonerIncidentList', () => {
     })
     mockApis([oldAssault])
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
 
     expect(rows[0]).toMatchObject({ reportReference: '6004', role: 'Perpetrator', establishment: 'MDI prison' })
     expect(rows[0].subtype).toBeUndefined()
@@ -229,8 +234,22 @@ describe('getPrisonerIncidentList', () => {
     ]
     mockApis(reports)
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
 
     expect(rows.map(row => row.reportReference)).toEqual(['NEW', 'MID', 'OLD'])
+  })
+
+  it('sets canView per report based on whether its location is in the user’s caseloads', async () => {
+    const reports = [
+      report({ id: '1', reference: 'MDI-REPORT', type: 'FIRE_1', location: 'MDI', date: '2025-06-01T09:00:00Z' }),
+      report({ id: '2', reference: 'LEI-REPORT', type: 'FIRE_1', location: 'LEI', date: '2025-05-01T09:00:00Z' }),
+    ]
+    mockApis(reports)
+
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
+
+    const byReference = Object.fromEntries(rows.map(row => [row.reportReference, row.canView]))
+    expect(byReference['MDI-REPORT']).toBe(true) // in the reporting officer’s caseload
+    expect(byReference['LEI-REPORT']).toBe(false) // establishment outside the caseload
   })
 })

--- a/server/services/prisonerIncidentSummary/list.test.ts
+++ b/server/services/prisonerIncidentSummary/list.test.ts
@@ -257,9 +257,7 @@ describe('getPrisonerIncidentList', () => {
 
     const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
 
-    const byReference = Object.fromEntries(
-      rows.map(row => [row.reportReference, { status: row.reportStatus, location: row.reportLocation }]),
-    )
+    const byReference = Object.fromEntries(rows.map(row => [row.reportReference, row.report]))
     expect(byReference['MDI-REPORT']).toEqual({ status: 'AWAITING_REVIEW', location: 'MDI' })
     expect(byReference['LEI-REPORT']).toEqual({ status: 'CLOSED', location: 'LEI' })
   })

--- a/server/services/prisonerIncidentSummary/list.test.ts
+++ b/server/services/prisonerIncidentSummary/list.test.ts
@@ -11,8 +11,6 @@ import { AgencyType } from '../../data/constants'
 import { convertReportDates } from '../../data/incidentReportingApiUtils'
 import { mockReport } from '../../data/testData/incidentReporting'
 import type { PrisonerInvolvementRole, Status, Type } from '../../reportConfiguration/constants'
-import { Permissions } from '../../middleware/permissions'
-import { mockReportingOfficer } from '../../data/testData/users'
 import { getPrisonerIncidentList } from './list'
 
 jest.mock('../../data/incidentReportingApi')
@@ -26,9 +24,6 @@ afterEach(() => {
 })
 
 const PRISONER_NUMBER = 'A1111AA'
-
-// reporting officer with the Moorland (MDI) caseload only
-const permissions = new Permissions(mockReportingOfficer)
 
 function response(
   code: string,
@@ -147,7 +142,7 @@ describe('getPrisonerIncidentList', () => {
     })
     mockApis([assault])
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
 
     expect(rows).toHaveLength(1) // only this prisoner, not the unrelated involvement
     expect(rows[0]).toMatchObject({
@@ -179,7 +174,7 @@ describe('getPrisonerIncidentList', () => {
     })
     mockApis([selfHarm])
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
 
     expect(rows[0].extraInformation).toBe('Cutting, Burning')
     expect(rows[0].location).toBe('Ordinary (A-1-2-34)')
@@ -201,7 +196,7 @@ describe('getPrisonerIncidentList', () => {
     })
     mockApis([find])
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
 
     expect(rows[0].subtype).toBe('Multiple types')
     expect(rows[0].role).toBe('In possession')
@@ -218,7 +213,7 @@ describe('getPrisonerIncidentList', () => {
     })
     mockApis([oldAssault])
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
 
     expect(rows[0]).toMatchObject({ reportReference: '6004', role: 'Perpetrator', establishment: 'MDI prison' })
     expect(rows[0].subtype).toBeUndefined()
@@ -234,22 +229,38 @@ describe('getPrisonerIncidentList', () => {
     ]
     mockApis(reports)
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
 
     expect(rows.map(row => row.reportReference)).toEqual(['NEW', 'MID', 'OLD'])
   })
 
-  it('sets canView per report based on whether its location is in the user’s caseloads', async () => {
+  it('exposes the raw report status and location on each row for the template’s VIEW check', async () => {
     const reports = [
-      report({ id: '1', reference: 'MDI-REPORT', type: 'FIRE_1', location: 'MDI', date: '2025-06-01T09:00:00Z' }),
-      report({ id: '2', reference: 'LEI-REPORT', type: 'FIRE_1', location: 'LEI', date: '2025-05-01T09:00:00Z' }),
+      report({
+        id: '1',
+        reference: 'MDI-REPORT',
+        type: 'FIRE_1',
+        status: 'AWAITING_REVIEW',
+        location: 'MDI',
+        date: '2025-06-01T09:00:00Z',
+      }),
+      report({
+        id: '2',
+        reference: 'LEI-REPORT',
+        type: 'FIRE_1',
+        status: 'CLOSED',
+        location: 'LEI',
+        date: '2025-05-01T09:00:00Z',
+      }),
     ]
     mockApis(reports)
 
-    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER, permissions)
+    const { rows } = await getPrisonerIncidentList(incidentReportingApi, prisonApi, PRISONER_NUMBER)
 
-    const byReference = Object.fromEntries(rows.map(row => [row.reportReference, row.canView]))
-    expect(byReference['MDI-REPORT']).toBe(true) // in the reporting officer’s caseload
-    expect(byReference['LEI-REPORT']).toBe(false) // establishment outside the caseload
+    const byReference = Object.fromEntries(
+      rows.map(row => [row.reportReference, { status: row.reportStatus, location: row.reportLocation }]),
+    )
+    expect(byReference['MDI-REPORT']).toEqual({ status: 'AWAITING_REVIEW', location: 'MDI' })
+    expect(byReference['LEI-REPORT']).toEqual({ status: 'CLOSED', location: 'LEI' })
   })
 })

--- a/server/services/prisonerIncidentSummary/list.ts
+++ b/server/services/prisonerIncidentSummary/list.ts
@@ -2,6 +2,7 @@ import type {
   IncidentReportingApi,
   PrisonerInvolvement,
   Question,
+  ReportBasic,
   ReportWithDetails,
 } from '../../data/incidentReportingApi'
 import type { PrisonApi } from '../../data/prisonApi'
@@ -11,7 +12,6 @@ import {
   getTypeDetails,
   prisonerInvolvementRolesDescriptions,
   statusesDescriptions,
-  type Status,
 } from '../../reportConfiguration/constants'
 import { ACTIVE_DETAIL_TYPES } from './breakdowns'
 import { fetchAllReports, twelveMonthsAgo } from './prisonerReports'
@@ -47,9 +47,12 @@ export interface PrisonerIncidentListRow {
   location?: string
   establishment: string
   status: string
-  /** Raw report status/location, used by the template's VIEW check to gate the link to /reports/:id. */
-  reportStatus: Status
-  reportLocation: string
+  /**
+   * Raw report status/location — used by the template's VIEW check to gate the link to /reports/:id.
+   * NB the row's own `status`/`location` above are display-translated / free-text and must NOT be
+   * used for that check; the establishment code lives here in `report.location`.
+   */
+  report: Pick<ReportBasic, 'status' | 'location'>
 }
 
 export interface PrisonerIncidentList {
@@ -203,8 +206,7 @@ function rowsForReport(
     status: statusesDescriptions[report.status] ?? report.status,
     // Raw values (NOT the display-translated status/location above) so the template's VIEW check
     // matches the gate enforced by the /reports/:id route.
-    reportStatus: report.status,
-    reportLocation: report.location,
+    report: { status: report.status, location: report.location },
   }))
 }
 

--- a/server/services/prisonerIncidentSummary/list.ts
+++ b/server/services/prisonerIncidentSummary/list.ts
@@ -5,6 +5,7 @@ import type {
   ReportWithDetails,
 } from '../../data/incidentReportingApi'
 import type { PrisonApi } from '../../data/prisonApi'
+import type { Permissions } from '../../middleware/permissions'
 import { AgencyType } from '../../data/constants'
 import { isPecsRegionCode } from '../../data/pecsRegions'
 import {
@@ -46,6 +47,8 @@ export interface PrisonerIncidentListRow {
   location?: string
   establishment: string
   status: string
+  /** Whether the current user is permitted to view this report (gates the link to /reports/:id). */
+  canView: boolean
 }
 
 export interface PrisonerIncidentList {
@@ -181,10 +184,14 @@ function rowsForReport(
   report: ReportWithDetails,
   prisonerNumber: string,
   establishment: string,
+  permissions: Permissions,
 ): PrisonerIncidentListRow[] {
   const involvements = report.prisonersInvolved.filter(
     (prisoner: PrisonerInvolvement) => prisoner.prisonerNumber === prisonerNumber,
   )
+  // Use the raw, untranslated status/location (NOT the display-translated values) so this matches
+  // the VIEW check enforced by the /reports/:id route.
+  const canView = permissions.allowedActionsOnReport({ status: report.status, location: report.location }).has('VIEW')
   return involvements.map(involvement => ({
     reportId: report.id,
     reportReference: report.reportReference,
@@ -197,6 +204,7 @@ function rowsForReport(
     location: location(report),
     establishment,
     status: statusesDescriptions[report.status] ?? report.status,
+    canView,
   }))
 }
 
@@ -218,6 +226,7 @@ export async function getPrisonerIncidentList(
   api: IncidentReportingApi,
   prisonApi: PrisonApi,
   prisonerNumber: string,
+  permissions: Permissions,
 ): Promise<PrisonerIncidentList> {
   const fromDate = twelveMonthsAgo()
   const basicReports = await fetchAllReports(api, prisonerNumber, fromDate)
@@ -229,7 +238,9 @@ export async function getPrisonerIncidentList(
   )
 
   const rows = reports
-    .flatMap(report => rowsForReport(report, prisonerNumber, establishments.get(report.location) ?? report.location))
+    .flatMap(report =>
+      rowsForReport(report, prisonerNumber, establishments.get(report.location) ?? report.location, permissions),
+    )
     .sort((a, b) => b.incidentDateAndTime.getTime() - a.incidentDateAndTime.getTime())
 
   return { fromDate, rows }

--- a/server/services/prisonerIncidentSummary/list.ts
+++ b/server/services/prisonerIncidentSummary/list.ts
@@ -5,13 +5,13 @@ import type {
   ReportWithDetails,
 } from '../../data/incidentReportingApi'
 import type { PrisonApi } from '../../data/prisonApi'
-import type { Permissions } from '../../middleware/permissions'
 import { AgencyType } from '../../data/constants'
 import { isPecsRegionCode } from '../../data/pecsRegions'
 import {
   getTypeDetails,
   prisonerInvolvementRolesDescriptions,
   statusesDescriptions,
+  type Status,
 } from '../../reportConfiguration/constants'
 import { ACTIVE_DETAIL_TYPES } from './breakdowns'
 import { fetchAllReports, twelveMonthsAgo } from './prisonerReports'
@@ -47,8 +47,9 @@ export interface PrisonerIncidentListRow {
   location?: string
   establishment: string
   status: string
-  /** Whether the current user is permitted to view this report (gates the link to /reports/:id). */
-  canView: boolean
+  /** Raw report status/location, used by the template's VIEW check to gate the link to /reports/:id. */
+  reportStatus: Status
+  reportLocation: string
 }
 
 export interface PrisonerIncidentList {
@@ -184,14 +185,10 @@ function rowsForReport(
   report: ReportWithDetails,
   prisonerNumber: string,
   establishment: string,
-  permissions: Permissions,
 ): PrisonerIncidentListRow[] {
   const involvements = report.prisonersInvolved.filter(
     (prisoner: PrisonerInvolvement) => prisoner.prisonerNumber === prisonerNumber,
   )
-  // Use the raw, untranslated status/location (NOT the display-translated values) so this matches
-  // the VIEW check enforced by the /reports/:id route.
-  const canView = permissions.allowedActionsOnReport({ status: report.status, location: report.location }).has('VIEW')
   return involvements.map(involvement => ({
     reportId: report.id,
     reportReference: report.reportReference,
@@ -204,7 +201,10 @@ function rowsForReport(
     location: location(report),
     establishment,
     status: statusesDescriptions[report.status] ?? report.status,
-    canView,
+    // Raw values (NOT the display-translated status/location above) so the template's VIEW check
+    // matches the gate enforced by the /reports/:id route.
+    reportStatus: report.status,
+    reportLocation: report.location,
   }))
 }
 
@@ -226,7 +226,6 @@ export async function getPrisonerIncidentList(
   api: IncidentReportingApi,
   prisonApi: PrisonApi,
   prisonerNumber: string,
-  permissions: Permissions,
 ): Promise<PrisonerIncidentList> {
   const fromDate = twelveMonthsAgo()
   const basicReports = await fetchAllReports(api, prisonerNumber, fromDate)
@@ -238,9 +237,7 @@ export async function getPrisonerIncidentList(
   )
 
   const rows = reports
-    .flatMap(report =>
-      rowsForReport(report, prisonerNumber, establishments.get(report.location) ?? report.location, permissions),
-    )
+    .flatMap(report => rowsForReport(report, prisonerNumber, establishments.get(report.location) ?? report.location))
     .sort((a, b) => b.incidentDateAndTime.getTime() - a.incidentDateAndTime.getTime())
 
   return { fromDate, rows }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -22,6 +22,8 @@ import format from './format'
 import { isCorrectionRequestPlaceholder } from '../routes/reports/actions/correctionRequestPlaceholder'
 import { sortCorrectionRequests } from './sortCorrectionRequests'
 import { prisonerLocation } from './prisonerLocationUtils'
+import type { Permissions } from '../middleware/permissions'
+import type { ReportBasic } from '../data/incidentReportingApi'
 
 export default function nunjucksSetup(app: express.Express): void {
   app.set('view engine', 'njk')
@@ -78,6 +80,13 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addExtension('panic', new PanicExtension())
   njkEnv.addFilter('isCorrectionRequestPlaceholder', isCorrectionRequestPlaceholder)
   njkEnv.addFilter('sortCorrectionRequests', sortCorrectionRequests)
+
+  // whether the current user is permitted to view a report (gates links to /reports/:id)
+  njkEnv.addGlobal(
+    'canViewReport',
+    (reportLike: Pick<ReportBasic, 'status' | 'location'>, permissions: Permissions): boolean =>
+      permissions.allowedActionsOnReport(reportLike).has('VIEW'),
+  )
 
   // name formatting
   njkEnv.addFilter('convertToTitleCase', convertToTitleCase)

--- a/server/views/pages/prisonerIncidentList.njk
+++ b/server/views/pages/prisonerIncidentList.njk
@@ -49,7 +49,7 @@
         {% set rows = [] %}
         {% for row in prisonerIncidentList.rows %}
           {% set linkHtml %}
-            {% if canViewReport({ status: row.reportStatus, location: row.reportLocation }, permissions) %}
+            {% if canViewReport(row.report, permissions) %}
               <a href="/reports/{{ row.reportId }}">
                 <span class="govuk-visually-hidden">Incident report</span>
                 {{ row.reportReference }}

--- a/server/views/pages/prisonerIncidentList.njk
+++ b/server/views/pages/prisonerIncidentList.njk
@@ -49,10 +49,14 @@
         {% set rows = [] %}
         {% for row in prisonerIncidentList.rows %}
           {% set linkHtml %}
-            <a href="/reports/{{ row.reportId }}">
-              <span class="govuk-visually-hidden">Incident report</span>
+            {% if row.canView %}
+              <a href="/reports/{{ row.reportId }}">
+                <span class="govuk-visually-hidden">Incident report</span>
+                {{ row.reportReference }}
+              </a>
+            {% else %}
               {{ row.reportReference }}
-            </a>
+            {% endif %}
           {% endset %}
           {% set rows = (rows.push([
             { html: linkHtml },

--- a/server/views/pages/prisonerIncidentList.njk
+++ b/server/views/pages/prisonerIncidentList.njk
@@ -49,7 +49,7 @@
         {% set rows = [] %}
         {% for row in prisonerIncidentList.rows %}
           {% set linkHtml %}
-            {% if row.canView %}
+            {% if canViewReport({ status: row.reportStatus, location: row.reportLocation }, permissions) %}
               <a href="/reports/{{ row.reportId }}">
                 <span class="govuk-visually-hidden">Incident report</span>
                 {{ row.reportReference }}


### PR DESCRIPTION
## Why

On the prisoner incident list (`/prisoner/:prisonerNumber/incident-summary/incidents`, added in IR-1683), each row's "Incident ID" cell rendered a hyperlink to `/reports/:reportId` **unconditionally**. That destination route is gated by the canonical VIEW permission check (`permissions.allowedActionsOnReport(report).has('VIEW')`), which requires a service role **and** the report's establishment in the user's caseloads (or PECS access). Because a prisoner's 12-month list can include incidents at establishments outside the current user's caseloads, a user could click a link that immediately logged them out.

## What

Render the hyperlink only when the user can actually view that report; otherwise show the report reference as plain text. No new permission logic — reuses the single source of truth in `rulesClass.ts`.

- **`services/prisonerIncidentSummary/list.ts`** — add `canView: boolean` to `PrisonerIncidentListRow`; thread a `Permissions` instance through `getPrisonerIncidentList` → `rowsForReport`; compute `canView` once per report from the raw `status`/`location` via `permissions.allowedActionsOnReport({ status, location }).has('VIEW')`.
- **`routes/prisonerIncidentSummary/index.ts`** — pass `res.locals.permissions` into the service.
- **`views/pages/prisonerIncidentList.njk`** — emit the `<a>` only when `row.canView`, else plain `reportReference`.

## Tests

- `list.test.ts` — threads a reporting-officer `Permissions` instance through existing calls; adds an in/out-of-caseload assertion (MDI → `canView` true, LEI → false).
- `index.test.ts` — existing `/incidents` test now asserts the viewable report is linked; new test asserts an out-of-caseload report shows the reference but no `/reports/` anchor.

