### PR TITLE
IR-1733: Fix bug list of active types not updated

### DIFF
--- a/server/reportConfiguration/constants/typeActivePeriods.ts
+++ b/server/reportConfiguration/constants/typeActivePeriods.ts
@@ -125,8 +125,6 @@ export function areTypeFamiliesInactive(
   )
 }
 
-export const familyInactiveStatus = areTypeFamiliesInactive(types)
-
 /**
  * In preparation for the incident type autocomplete items on the dashboard, this generates an object with
  * the incident type families as a key, and then the corresponding value is either null if the type family has no

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -17,7 +17,7 @@ import {
   typesDescriptions,
   typeFamilies,
   familyExpiryDates,
-  familyInactiveStatus,
+  areTypeFamiliesInactive,
 } from '../../reportConfiguration/constants'
 import type { PaginatedBasicReports } from '../../data/incidentReportingApi'
 import { type Order, orderOptions } from '../../data/offenderSearchApi'
@@ -308,6 +308,7 @@ export default function dashboard(): Router {
     const usernames = reports.map(report => report.reportedBy)
     const usersLookup = await userService.getUsers(res.locals.systemToken, usernames)
 
+    const familyInactiveStatus = areTypeFamiliesInactive(types)
     const activeTypeFamilyItems: GovukSelectItem[] = typeFamilies
       .filter(({ code: someFamilyCode }) => !familyInactiveStatus[someFamilyCode])
       .map(family => ({


### PR DESCRIPTION
Incident types can have a date range when they'll come online or be deactivated. The theory is that, on the day new types versions come online, we don't need to do anything and the service will show the correct list of incident types.

However this morning we discovered that the list of active types was not updated until the pods were restarted.

This was caused by the `typeActivePeriods` module exporting the computed list. This means that the list was a "snapshot" created at the point in time when the module was first imported (aka shorly after the pods started).

The smallest possible fix to this problem is to remove this calculated list from the module and calculate the updated list inside the request handler using it.