### PR TITLE
IR-1733: Types list up-to-date with retired/activated types

### DIFF
--- a/server/routes/reports/details/typeController.ts
+++ b/server/routes/reports/details/typeController.ts
@@ -2,7 +2,7 @@ import type express from 'express'
 import type FormWizard from 'hmpo-form-wizard'
 
 import { BaseController } from '../../../controllers'
-import type { TypeFieldNames, TypeValues } from './typeFields'
+import { typeFieldItems, type TypeFieldNames, type TypeValues } from './typeFields'
 
 /**
  * Controller for selecting an incident type for new reports or changing the type for existing reports.
@@ -11,6 +11,27 @@ import type { TypeFieldNames, TypeValues } from './typeFields'
  */
 export abstract class BaseTypeController<V extends TypeValues> extends BaseController<V, TypeFieldNames> {
   protected keyField = 'type' as const
+
+  middlewareSetup(): void {
+    this.use(this.updateTypeFieldItems)
+
+    super.middlewareSetup()
+  }
+
+  /**
+   * Update the list of active types
+   *
+   * so that it's up-to-date when old types are retired or new ones are activated
+   */
+  protected updateTypeFieldItems(
+    req: FormWizard.Request<V, TypeFieldNames>,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) {
+    req.form.options.fields.type.items = typeFieldItems()
+
+    next()
+  }
 
   protected errorMessage(
     error: FormWizard.Error,

--- a/server/routes/reports/details/typeFields.ts
+++ b/server/routes/reports/details/typeFields.ts
@@ -1,32 +1,36 @@
 import type FormWizard from 'hmpo-form-wizard'
 
-import { types, typeHints, isTypeActive, type Type } from '../../../reportConfiguration/constants'
+import { types, typeHints, isTypeActive, type TypeDetails, type Type } from '../../../reportConfiguration/constants'
 import config from '../../../config'
+
+export function typeFieldItems() {
+  const isActive = (type: TypeDetails) => isTypeActive(type.code) || config.incidentTypesOverride.has(type.code)
+
+  const byDescription = ({ description: description1 }: TypeDetails, { description: description2 }: TypeDetails) => {
+    if (description1.startsWith('Miscellaneous')) {
+      return 1
+    }
+    if (description2.startsWith('Miscellaneous')) {
+      return -1
+    }
+    return description1 < description2 ? -1 : 1
+  }
+
+  const toFieldItem = (type: TypeDetails) => ({
+    label: type.description,
+    value: type.code,
+    hint: typeHints[type.code],
+  })
+
+  return types.filter(isActive).sort(byDescription).map(toFieldItem)
+}
 
 export const typeFields = {
   type: {
     label: 'Select the incident type',
     validate: ['required'],
     component: 'govukRadios',
-    items: types
-      .filter(type => isTypeActive(type.code) || config.incidentTypesOverride.has(type.code))
-      .sort(({ description: description1 }, { description: description2 }) => {
-        if (description1.startsWith('Miscellaneous')) {
-          return 1
-        }
-        if (description2.startsWith('Miscellaneous')) {
-          return -1
-        }
-        return description1 < description2 ? -1 : 1
-      })
-      .map(
-        type =>
-          ({
-            label: type.description,
-            value: type.code,
-            hint: typeHints[type.code],
-          }) satisfies FormWizard.FieldItem,
-      ),
+    items: typeFieldItems(),
   },
 } satisfies FormWizard.Fields
 export type TypeValues = FormWizard.ValuesFromFields<typeof typeFields> & {


### PR DESCRIPTION
The list of active types was not updated when types were retired or activated and required the pods to be restarted to pick-up this change.

This was caused by the fact that the FormWizard field for the `type` was "static" in a module and not changing once the module was imported the first time.

To ensure this list is always up-to-date the field's items are updated in a request handler.