### PR TITLE
IR-1762: Dashboard refactoring

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -29,7 +29,7 @@ type DashboardFilters = {
   fromDate?: string
   toDate?: string
   typeFamily?: TypeFamily
-  incidentStatuses?: IncidentStatuses | IncidentStatuses[]
+  incidentStatuses?: IncidentStatuses[]
   latestUserActions?: ApiUserAction | ApiUserAction[] | 'REQUEST_REMOVAL'
   sort?: string
   order?: 'DESC' | 'ASC'

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -26,8 +26,8 @@ declare module 'express-session' {
 type DashboardFilters = {
   searchID?: string
   location?: string
-  fromDateInput?: string
-  toDateInput?: string
+  fromDate?: string
+  toDate?: string
   typeFamily?: TypeFamily
   incidentStatuses?: IncidentStatuses | IncidentStatuses[]
   latestUserActions?: ApiUserAction | ApiUserAction[] | 'REQUEST_REMOVAL'

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -30,7 +30,8 @@ type DashboardFilters = {
   toDate?: string
   typeFamily?: TypeFamily
   incidentStatuses?: IncidentStatuses[]
-  latestUserActions?: ApiUserAction | ApiUserAction[] | 'REQUEST_REMOVAL'
+  // TODO: Why is dashboard adding 'REQUEST_REMOVAL'??
+  latestUserActions?: (ApiUserAction | 'REQUEST_REMOVAL')[]
   sort?: string
   order?: 'DESC' | 'ASC'
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -10,7 +10,7 @@ import type { PrisonApi } from '../../data/prisonApi'
 import type { Permissions, UserAction, ReportTransitions } from '../../middleware/permissions'
 import type { TypeFamily } from '../../reportConfiguration/constants'
 import { IncidentStatuses } from '../../routes/dashboard'
-import { ApiUserAction } from '../../middleware/permissions'
+import { LatestUserActions } from '../../routes/dashboard/filters'
 
 export default {}
 
@@ -30,8 +30,7 @@ type DashboardFilters = {
   toDate?: string
   typeFamily?: TypeFamily
   incidentStatuses?: IncidentStatuses[]
-  // TODO: Why is dashboard adding 'REQUEST_REMOVAL'??
-  latestUserActions?: (ApiUserAction | 'REQUEST_REMOVAL')[]
+  latestUserActions?: LatestUserActions[]
   sort?: string
   order?: 'DESC' | 'ASC'
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -10,7 +10,7 @@ import type { PrisonApi } from '../../data/prisonApi'
 import type { Permissions, UserAction, ReportTransitions } from '../../middleware/permissions'
 import type { TypeFamily } from '../../reportConfiguration/constants'
 import { IncidentStatuses } from '../../routes/dashboard'
-import { LatestUserActions } from '../../routes/dashboard/filters'
+import { LatestUserAction } from '../../routes/dashboard/filters'
 
 export default {}
 
@@ -30,7 +30,7 @@ type DashboardFilters = {
   toDate?: string
   typeFamily?: TypeFamily
   incidentStatuses?: IncidentStatuses[]
-  latestUserActions?: LatestUserActions[]
+  latestUserActions?: LatestUserAction[]
   sort?: string
   order?: 'DESC' | 'ASC'
 }

--- a/server/reportConfiguration/constants/familyToTypesMapping.ts
+++ b/server/reportConfiguration/constants/familyToTypesMapping.ts
@@ -1,0 +1,16 @@
+import { typeFamilies } from './typeFamilies'
+import { type Type, types } from './types'
+
+/** Returns the list of types for a type family */
+export function typesForFamily(typeFamily: string): Type[] | undefined {
+  return familyToTypesMapping[typeFamily]
+}
+
+const familyToTypesMapping = Object.fromEntries(
+  Object.values(typeFamilies).map(({ code: familyCode }) => [
+    familyCode,
+    Object.values(types)
+      .filter(({ familyCode: someFamilyCode }) => someFamilyCode === familyCode)
+      .map(({ code }) => code),
+  ]),
+)

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -17,7 +17,7 @@ import { parseDateInput } from '../../utils/parseDateTime'
 import format from '../../utils/format'
 import { type Order } from '../../data/offenderSearchApi'
 import { hasInvalidValues } from '../../utils/utils'
-import { type ApiUserAction, apiUserActions } from '../../middleware/permissions'
+import { type ApiUserAction, type Permissions, type UserAction, apiUserActions } from '../../middleware/permissions'
 
 // `latestUserActions` can include 'REQUEST_REMOVAL' (not a valid `ApiUserAction`)
 // which maps/is replaced with 'REQUEST_NOT_REPORTABLE' and 'REQUEST_DUPLICATE'
@@ -46,6 +46,7 @@ interface Filters {
   toDate?: Date
   type?: Type[]
   status?: Status[]
+  userAction?: ApiUserAction[]
   sort: string[]
   page: number
 }
@@ -143,7 +144,7 @@ export function validateUiFilters(uiFilters: UiFilters, useWorklists: boolean): 
   return errors
 }
 
-export function filtersFromUiFilters(uiFilters: UiFilters, useWorklists: boolean): Filters {
+export function filtersFromUiFilters(uiFilters: UiFilters, useWorklists: boolean, permissions: Permissions): Filters {
   let page = (uiFilters.page && parseInt(uiFilters.page, 10)) || 1
   if (page < 1) {
     page = 1
@@ -163,6 +164,7 @@ export function filtersFromUiFilters(uiFilters: UiFilters, useWorklists: boolean
     toDate: validDateOrder ? toDate : undefined,
     type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
     status: processStatus(uiFilters.incidentStatuses, useWorklists),
+    userAction: processUserAction(uiFilters.latestUserActions, permissions),
     sort: [`${uiFilters.sort},${uiFilters.order}`],
     page,
   }
@@ -178,12 +180,42 @@ function processStatus(incidentStatuses: IncidentStatuses[] | undefined, useWork
   if (useWorklists) {
     if (validWorkListCodes(incidentStatuses)) {
       // eslint-disable-next-line consistent-return
-      return incidentStatuses.map(worklist => workListMapping[worklist as WorkList]).flat(1)
+      return incidentStatuses.map(worklist => workListMapping[worklist]).flat(1)
     }
   } else if (validReportStatusCodes(incidentStatuses)) {
-    // @ts-expect-error - incidentStatuses only contains Status
     // eslint-disable-next-line consistent-return
     return incidentStatuses
+  }
+}
+
+function processUserAction(
+  latestUserActions: LatestUserActions[] | undefined,
+  permissions: Permissions,
+): UserAction[] | undefined {
+  if (!latestUserActions) {
+    return
+  }
+
+  // If an RO opens a link containing filter, remove filter
+  if (permissions.isReportingOfficer) {
+    return
+  }
+
+  if (validUserAction(latestUserActions)) {
+    // Convert 'REQUEST_REMOVAL' into corresponding API user actions
+    if (latestUserActions.includes('REQUEST_REMOVAL')) {
+      // @ts-expect-error - latestUserActions has valid API user actions
+      // eslint-disable-next-line consistent-return
+      return [
+        ...latestUserActions.filter(action => action !== 'REQUEST_REMOVAL'),
+        'REQUEST_NOT_REPORTABLE',
+        'REQUEST_DUPLICATE',
+      ] as ApiUserAction[]
+    }
+
+    // @ts-expect-error - latestUserActions has valid API user actions
+    // eslint-disable-next-line consistent-return
+    return latestUserActions
   }
 }
 
@@ -240,15 +272,15 @@ function validateLatestUserActions(uiFilters: UiFilters, errors: GovukErrorSumma
   }
 }
 
-function validUserAction(latestUserActions: string[]): boolean {
+function validUserAction(latestUserActions: LatestUserActions[]): latestUserActions is LatestUserActions[] {
   return !hasInvalidValues(latestUserActions, [...apiUserActions, 'REQUEST_REMOVAL'])
 }
 
-function validWorkListCodes(incidentStatuses: IncidentStatuses[]): boolean {
+function validWorkListCodes(incidentStatuses: IncidentStatuses[]): incidentStatuses is WorkList[] {
   return !hasInvalidValues(incidentStatuses, workListCodes)
 }
 
-function validReportStatusCodes(incidentStatuses: IncidentStatuses[]): boolean {
+function validReportStatusCodes(incidentStatuses: IncidentStatuses[]): incidentStatuses is Status[] {
   const reportStatusCodes = statuses.map(status => status.code)
   return !hasInvalidValues(incidentStatuses, reportStatusCodes)
 }

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -336,8 +336,8 @@ function validLocation({
     return true
   }
   if (permissions.hasPecsAccess) {
-    const pecsRegionCodes = pecsRegions.map(pecsRegion => pecsRegion.code)
-    return location === ALL_PECS_REGIONS_FLAG || pecsRegionCodes.includes(location)
+    const isPecsRegion = pecsRegions.some(pecsRegion => pecsRegion.code === location)
+    return isPecsRegion || location === ALL_PECS_REGIONS_FLAG
   }
 
   return false

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -16,6 +16,8 @@ interface UiFilters {
 }
 
 interface Filters {
+  prisonerNumber?: string
+  referenceNumber?: string
   fromDate?: Date
   toDate?: Date
   page: number
@@ -55,6 +57,7 @@ export function readUiFilters({
 export function validateUiFilters(uiFilters: UiFilters): GovukErrorSummaryItem[] {
   const errors: GovukErrorSummaryItem[] = []
 
+  validateSearchId(uiFilters, errors)
   validateDateRanges(uiFilters, errors)
 
   if (uiFilters.typeFamily && !(uiFilters.typeFamily in familyToType)) {
@@ -70,12 +73,24 @@ export function filtersFromUiFilters(uiFilters: UiFilters): Filters {
     page = 1
   }
 
+  let prisonerNumber
+  let referenceNumber
+  if (uiFilters.searchID) {
+    if (isPrisonerNumber(uiFilters.searchID)) {
+      prisonerNumber = uiFilters.searchID
+    } else if (isReferenceNumber(uiFilters.searchID)) {
+      referenceNumber = uiFilters.searchID
+    }
+  }
+
   const fromDate = parseDate(uiFilters.fromDate)
   const toDate = parseDate(uiFilters.toDate)
   const validDates = fromDate !== undefined && toDate !== undefined
   const validDateOrder = validDates && toDate >= fromDate
 
   const filters = {
+    prisonerNumber,
+    referenceNumber,
     fromDate: validDateOrder ? fromDate : undefined,
     toDate: validDateOrder ? toDate : undefined,
     page,
@@ -93,6 +108,27 @@ export const familyToType = Object.fromEntries(
       .map(({ code }) => code),
   ]),
 )
+
+function validateSearchId(uiFilters: UiFilters, errors: GovukErrorSummaryItem[]): void {
+  if (!uiFilters.searchID) {
+    return
+  }
+
+  if (!isPrisonerNumber(uiFilters.searchID) && !isReferenceNumber(uiFilters.searchID)) {
+    errors.push({
+      href: '#searchID',
+      text: `Enter a valid incident number or offender ID. For example, 12345678 or A0011BB`,
+    })
+  }
+}
+
+function isPrisonerNumber(searchID: string): boolean {
+  return searchID.match(/^[a-zA-Z][0-9]{4}[a-zA-Z]{2}$/) !== null
+}
+
+function isReferenceNumber(searchID: string): boolean {
+  return searchID.match(/^[0-9]+$/) !== null
+}
 
 function validateDateRanges(uiFilters: UiFilters, errors: GovukErrorSummaryItem[]): void {
   const todayAsShortDate = format.shortDate(new Date())

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -2,7 +2,7 @@ import { type Session, type SessionData } from 'express-session'
 import { type ParsedQs } from 'qs'
 
 import { type GovukErrorSummaryItem } from '../../utils/govukFrontend'
-import { typeFamilies, TypeFamily, types } from '../../reportConfiguration/constants'
+import { type Type, type TypeFamily, types, typeFamilies } from '../../reportConfiguration/constants'
 import { parseDateInput } from '../../utils/parseDateTime'
 import format from '../../utils/format'
 
@@ -20,6 +20,7 @@ interface Filters {
   referenceNumber?: string
   fromDate?: Date
   toDate?: Date
+  type?: Type[]
   page: number
 }
 
@@ -93,21 +94,12 @@ export function filtersFromUiFilters(uiFilters: UiFilters): Filters {
     referenceNumber,
     fromDate: validDateOrder ? fromDate : undefined,
     toDate: validDateOrder ? toDate : undefined,
+    type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
     page,
   }
 
   return filters
 }
-
-/** Given a family code, list type codes belonging to the family */
-export const familyToType = Object.fromEntries(
-  Object.values(typeFamilies).map(({ code: familyCode }) => [
-    familyCode,
-    Object.values(types)
-      .filter(({ familyCode: someFamilyCode }) => someFamilyCode === familyCode)
-      .map(({ code }) => code),
-  ]),
-)
 
 function validateSearchId(uiFilters: UiFilters, errors: GovukErrorSummaryItem[]): void {
   if (!uiFilters.searchID) {
@@ -159,3 +151,13 @@ function parseDate(date: string | undefined): Date | undefined {
 
   return undefined
 }
+
+/** Given a family code, list type codes belonging to the family */
+const familyToType = Object.fromEntries(
+  Object.values(typeFamilies).map(({ code: familyCode }) => [
+    familyCode,
+    Object.values(types)
+      .filter(({ familyCode: someFamilyCode }) => someFamilyCode === familyCode)
+      .map(({ code }) => code),
+  ]),
+)

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -10,6 +10,11 @@ interface UiFilters {
   fromDate?: string
   toDate?: string
   typeFamily?: TypeFamily
+  page?: string
+}
+
+interface Filters {
+  page: number
 }
 
 export function readUiFilters({
@@ -27,6 +32,7 @@ export function readUiFilters({
     fromDate: typeof query.fromDate === 'string' ? query.fromDate : undefined,
     toDate: typeof query.toDate === 'string' ? query.toDate : undefined,
     typeFamily: query.typeFamily as TypeFamily | undefined,
+    page: typeof query.page === 'string' ? query.page : undefined,
   }
 
   // If no filters are supplied from query, check for filters in session
@@ -50,6 +56,19 @@ export function validateUiFilters(uiFilters: UiFilters): GovukErrorSummaryItem[]
   }
 
   return errors
+}
+
+export function filtersFromUiFilters(uiFilters: UiFilters): Filters {
+  let page = (uiFilters.page && parseInt(uiFilters.page, 10)) || 1
+  if (page < 1) {
+    page = 1
+  }
+
+  const filters = {
+    page,
+  }
+
+  return filters
 }
 
 /** Given a family code, list type codes belonging to the family */

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -5,6 +5,7 @@ import { type GovukErrorSummaryItem } from '../../utils/govukFrontend'
 import { type Type, type TypeFamily, types, typeFamilies } from '../../reportConfiguration/constants'
 import { parseDateInput } from '../../utils/parseDateTime'
 import format from '../../utils/format'
+import { type Order } from '../../data/offenderSearchApi'
 
 interface UiFilters {
   searchID?: string
@@ -12,6 +13,8 @@ interface UiFilters {
   fromDate?: string
   toDate?: string
   typeFamily?: TypeFamily
+  sort: string
+  order: Order
   page?: string
 }
 
@@ -21,6 +24,7 @@ interface Filters {
   fromDate?: Date
   toDate?: Date
   type?: Type[]
+  sort: string[]
   page: number
 }
 
@@ -33,12 +37,15 @@ export function readUiFilters({
   session: Session & Partial<SessionData>
   url: string
 }): UiFilters {
-  const uiFilters = {
+  const uiFilters: UiFilters = {
     searchID: typeof query.searchID === 'string' ? query.searchID.trim() : undefined,
     location: typeof query.location === 'string' ? query.location : undefined,
     fromDate: typeof query.fromDate === 'string' ? query.fromDate : undefined,
     toDate: typeof query.toDate === 'string' ? query.toDate : undefined,
     typeFamily: query.typeFamily as TypeFamily | undefined,
+    sort: typeof query.sort === 'string' ? query.sort : '',
+    // @ts-expect-error - order is updated with default if invalid
+    order: typeof query.order === 'string' ? query.order : '',
     page: typeof query.page === 'string' ? query.page : undefined,
   }
 
@@ -50,9 +57,27 @@ export function readUiFilters({
     uiFilters.fromDate = sessionFilters?.fromDate
     uiFilters.toDate = sessionFilters?.toDate
     uiFilters.typeFamily = sessionFilters?.typeFamily
+    uiFilters.sort = sessionFilters?.sort ?? ''
+    // @ts-expect-error - order is updated with default if invalid
+    uiFilters.order = sessionFilters?.order ?? ''
   }
 
   return uiFilters
+}
+
+export function fillInDefaults(uiFilters: UiFilters): void {
+  const sortOptions = ['incidentDateAndTime', 'reportReference', 'location', 'type', 'status', 'reportedBy']
+  const orderOptions = ['ASC', 'DESC']
+
+  if (!sortOptions.includes(uiFilters.sort)) {
+    // eslint-disable-next-line no-param-reassign
+    uiFilters.sort = 'incidentDateAndTime'
+  }
+
+  if (!orderOptions.includes(uiFilters.order)) {
+    // eslint-disable-next-line no-param-reassign
+    uiFilters.order = 'DESC'
+  }
 }
 
 export function validateUiFilters(uiFilters: UiFilters): GovukErrorSummaryItem[] {
@@ -95,6 +120,7 @@ export function filtersFromUiFilters(uiFilters: UiFilters): Filters {
     fromDate: validDateOrder ? fromDate : undefined,
     toDate: validDateOrder ? toDate : undefined,
     type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
+    sort: [`${uiFilters.sort},${uiFilters.order}`],
     page,
   }
 

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -157,10 +157,7 @@ export function validateUiFilters({
   validateDateRanges(uiFilters, errors)
   validateIncidentStatuses(uiFilters, errors, useWorkLists)
   validateLatestUserActions(uiFilters, errors)
-
-  if (uiFilters.typeFamily && !validTypeFamily(uiFilters.typeFamily)) {
-    errors.push({ href: '#typeFamily', text: 'Select a valid incident type' })
-  }
+  validateTypeFamily(uiFilters, errors)
 
   return errors
 }
@@ -378,6 +375,16 @@ function validateLatestUserActions(uiFilters: UiFilters, errors: GovukErrorSumma
       href: '#latestUserActions-item',
       text: 'Enter a valid user action',
     })
+  }
+}
+
+function validateTypeFamily(uiFilters: UiFilters, errors: GovukErrorSummaryItem[]): void {
+  if (!uiFilters.typeFamily) {
+    return
+  }
+
+  if (!validTypeFamily(uiFilters.typeFamily)) {
+    errors.push({ href: '#typeFamily', text: 'Select a valid incident type' })
   }
 }
 

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -1,10 +1,15 @@
 import { type Session, type SessionData } from 'express-session'
 import { type ParsedQs } from 'qs'
 
+import { type GovukErrorSummaryItem } from '../../utils/govukFrontend'
+import { typeFamilies, TypeFamily, types } from '../../reportConfiguration/constants'
+
 interface UiFilters {
   searchID?: string
+  location?: string
   fromDate?: string
   toDate?: string
+  typeFamily?: TypeFamily
 }
 
 export function readUiFilters({
@@ -18,17 +23,41 @@ export function readUiFilters({
 }): UiFilters {
   const uiFilters = {
     searchID: typeof query.searchID === 'string' ? query.searchID.trim() : undefined,
+    location: typeof query.location === 'string' ? query.location : undefined,
     fromDate: typeof query.fromDate === 'string' ? query.fromDate : undefined,
     toDate: typeof query.toDate === 'string' ? query.toDate : undefined,
+    typeFamily: query.typeFamily as TypeFamily | undefined,
   }
 
   // If no filters are supplied from query, check for filters in session
   if (url === '/' && session.dashboardFilters) {
     const sessionFilters = session.dashboardFilters
     uiFilters.searchID = sessionFilters?.searchID
+    uiFilters.location = sessionFilters?.location
     uiFilters.fromDate = sessionFilters?.fromDate
     uiFilters.toDate = sessionFilters?.toDate
+    uiFilters.typeFamily = sessionFilters?.typeFamily
   }
 
   return uiFilters
 }
+
+export function validateUiFilters(uiFilters: UiFilters): GovukErrorSummaryItem[] {
+  const errors: GovukErrorSummaryItem[] = []
+
+  if (uiFilters.typeFamily && !(uiFilters.typeFamily in familyToType)) {
+    errors.push({ href: '#typeFamily', text: 'Select a valid incident type' })
+  }
+
+  return errors
+}
+
+/** Given a family code, list type codes belonging to the family */
+export const familyToType = Object.fromEntries(
+  Object.values(typeFamilies).map(({ code: familyCode }) => [
+    familyCode,
+    Object.values(types)
+      .filter(({ familyCode: someFamilyCode }) => someFamilyCode === familyCode)
+      .map(({ code }) => code),
+  ]),
+)

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -25,7 +25,7 @@ export type LatestUserActions = ApiUserAction | 'REQUEST_REMOVAL'
 
 type IncidentStatuses = Status | WorkList
 
-interface UiFilters {
+export interface UiFilters {
   clearFilters?: string
   searchID?: string
   location?: string

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -24,9 +24,9 @@ export const ALL_PECS_REGIONS_FLAG = '.PECS' as const
 
 // `latestUserActions` can include 'REQUEST_REMOVAL' (not a valid `ApiUserAction`)
 // which maps/is replaced with 'REQUEST_NOT_REPORTABLE' and 'REQUEST_DUPLICATE'
-export type LatestUserActions = ApiUserAction | 'REQUEST_REMOVAL'
+export type LatestUserAction = ApiUserAction | 'REQUEST_REMOVAL'
 
-type IncidentStatuses = Status | WorkList
+type StatusOrWorkList = Status | WorkList
 
 export interface UiFilters {
   clearFilters?: string
@@ -35,8 +35,8 @@ export interface UiFilters {
   fromDate?: string
   toDate?: string
   typeFamily?: TypeFamily
-  incidentStatuses?: IncidentStatuses[]
-  latestUserActions?: LatestUserActions[]
+  incidentStatuses?: StatusOrWorkList[]
+  latestUserActions?: LatestUserAction[]
   sort: string
   order: Order
   page?: string
@@ -196,7 +196,7 @@ export function filtersFromUiFilters({
   return filters
 }
 
-function processStatus(incidentStatuses: IncidentStatuses[] | undefined, useWorklists: boolean): Status[] | undefined {
+function processStatus(incidentStatuses: StatusOrWorkList[] | undefined, useWorklists: boolean): Status[] | undefined {
   if (!incidentStatuses) {
     return
   }
@@ -213,7 +213,7 @@ function processStatus(incidentStatuses: IncidentStatuses[] | undefined, useWork
 }
 
 function processUserAction(
-  latestUserActions: LatestUserActions[] | undefined,
+  latestUserActions: LatestUserAction[] | undefined,
   permissions: Permissions,
 ): UserAction[] | undefined {
   if (!latestUserActions) {
@@ -341,15 +341,15 @@ function validateLatestUserActions(uiFilters: UiFilters, errors: GovukErrorSumma
   }
 }
 
-function validUserAction(latestUserActions: LatestUserActions[]): latestUserActions is LatestUserActions[] {
+function validUserAction(latestUserActions: LatestUserAction[]): latestUserActions is LatestUserAction[] {
   return !hasInvalidValues(latestUserActions, [...apiUserActions, 'REQUEST_REMOVAL'])
 }
 
-function validWorkListCodes(incidentStatuses: IncidentStatuses[]): incidentStatuses is WorkList[] {
+function validWorkListCodes(incidentStatuses: StatusOrWorkList[]): incidentStatuses is WorkList[] {
   return !hasInvalidValues(incidentStatuses, workListCodes)
 }
 
-function validReportStatusCodes(incidentStatuses: IncidentStatuses[]): incidentStatuses is Status[] {
+function validReportStatusCodes(incidentStatuses: StatusOrWorkList[]): incidentStatuses is Status[] {
   const reportStatusCodes = statuses.map(status => status.code)
   return !hasInvalidValues(incidentStatuses, reportStatusCodes)
 }

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -281,9 +281,9 @@ function processSearchId(searchID: string | undefined): { prisonerNumber?: strin
   let referenceNumber
 
   if (searchID) {
-    if (isPrisonerNumber(searchID)) {
+    if (validPrisonerNumber(searchID)) {
       prisonerNumber = searchID
-    } else if (isReferenceNumber(searchID)) {
+    } else if (validReferenceNumber(searchID)) {
       referenceNumber = searchID
     }
   }
@@ -390,7 +390,7 @@ function validateSearchId(uiFilters: UiFilters, errors: GovukErrorSummaryItem[])
     return
   }
 
-  if (!isPrisonerNumber(uiFilters.searchID) && !isReferenceNumber(uiFilters.searchID)) {
+  if (!validPrisonerNumber(uiFilters.searchID) && !validReferenceNumber(uiFilters.searchID)) {
     errors.push({
       href: '#searchID',
       text: `Enter a valid incident number or offender ID. For example, 12345678 or A0011BB`,
@@ -402,11 +402,11 @@ export function validTypeFamily(typeFamily: string): typeFamily is TypeFamily {
   return typesForFamily(typeFamily) !== undefined
 }
 
-function isPrisonerNumber(searchID: string): boolean {
+function validPrisonerNumber(searchID: string): boolean {
   return searchID.match(/^[a-zA-Z][0-9]{4}[a-zA-Z]{2}$/) !== null
 }
 
-function isReferenceNumber(searchID: string): boolean {
+function validReferenceNumber(searchID: string): boolean {
   return searchID.match(/^[0-9]+$/) !== null
 }
 

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -19,6 +19,9 @@ import { type Order } from '../../data/offenderSearchApi'
 import { hasInvalidValues } from '../../utils/utils'
 import { type ApiUserAction, type Permissions, type UserAction, apiUserActions } from '../../middleware/permissions'
 
+/** Location search filter which is replaced by all PECS regions when performing search */
+export const ALL_PECS_REGIONS_FLAG = '.PECS' as const
+
 // `latestUserActions` can include 'REQUEST_REMOVAL' (not a valid `ApiUserAction`)
 // which maps/is replaced with 'REQUEST_NOT_REPORTABLE' and 'REQUEST_DUPLICATE'
 export type LatestUserActions = ApiUserAction | 'REQUEST_REMOVAL'
@@ -132,13 +135,20 @@ export function fillInDefaults(uiFilters: UiFilters, useWorklists: boolean): voi
 export function validateUiFilters({
   uiFilters,
   useWorklists,
+  permissions,
+  userCaseloadIds,
+  pecsRegionCodes,
 }: {
   uiFilters: UiFilters
   useWorklists: boolean
+  permissions: Permissions
+  userCaseloadIds: string[]
+  pecsRegionCodes: string[]
 }): GovukErrorSummaryItem[] {
   const errors: GovukErrorSummaryItem[] = []
 
   validateSearchId(uiFilters, errors)
+  validateLocation({ uiFilters, errors, permissions, userCaseloadIds, pecsRegionCodes })
   validateDateRanges(uiFilters, errors)
   validateIncidentStatuses(uiFilters, errors, useWorklists)
   validateLatestUserActions(uiFilters, errors)
@@ -249,6 +259,51 @@ function processSearchId(searchID: string | undefined): { prisonerNumber?: strin
     prisonerNumber,
     referenceNumber,
   }
+}
+
+function validateLocation({
+  uiFilters,
+  errors,
+  permissions,
+  userCaseloadIds,
+  pecsRegionCodes,
+}: {
+  uiFilters: UiFilters
+  errors: GovukErrorSummaryItem[]
+  permissions: Permissions
+  userCaseloadIds: string[]
+  pecsRegionCodes: string[]
+}) {
+  if (!uiFilters.location) {
+    return
+  }
+  if (!validLocation({ location: uiFilters.location, permissions, userCaseloadIds, pecsRegionCodes })) {
+    errors.push({
+      href: '#location',
+      text: 'Select a location to search',
+    })
+  }
+}
+
+function validLocation({
+  location,
+  permissions,
+  userCaseloadIds,
+  pecsRegionCodes,
+}: {
+  location: string
+  permissions: Permissions
+  userCaseloadIds: string[]
+  pecsRegionCodes: string[]
+}): boolean {
+  if (userCaseloadIds.includes(location)) {
+    return true
+  }
+  if (permissions.hasPecsAccess) {
+    return location === ALL_PECS_REGIONS_FLAG || pecsRegionCodes.includes(location)
+  }
+
+  return false
 }
 
 function validateIncidentStatuses(uiFilters: UiFilters, errors: GovukErrorSummaryItem[], useWorklists: boolean): void {

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -129,7 +129,13 @@ export function fillInDefaults(uiFilters: UiFilters, useWorklists: boolean): voi
   }
 }
 
-export function validateUiFilters(uiFilters: UiFilters, useWorklists: boolean): GovukErrorSummaryItem[] {
+export function validateUiFilters({
+  uiFilters,
+  useWorklists,
+}: {
+  uiFilters: UiFilters
+  useWorklists: boolean
+}): GovukErrorSummaryItem[] {
   const errors: GovukErrorSummaryItem[] = []
 
   validateSearchId(uiFilters, errors)
@@ -144,7 +150,15 @@ export function validateUiFilters(uiFilters: UiFilters, useWorklists: boolean): 
   return errors
 }
 
-export function filtersFromUiFilters(uiFilters: UiFilters, useWorklists: boolean, permissions: Permissions): Filters {
+export function filtersFromUiFilters({
+  uiFilters,
+  useWorklists,
+  permissions,
+}: {
+  uiFilters: UiFilters
+  useWorklists: boolean
+  permissions: Permissions
+}): Filters {
   let page = (uiFilters.page && parseInt(uiFilters.page, 10)) || 1
   if (page < 1) {
     page = 1

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -2,17 +2,32 @@ import { type Session, type SessionData } from 'express-session'
 import { type ParsedQs } from 'qs'
 
 import { type GovukErrorSummaryItem } from '../../utils/govukFrontend'
-import { type Type, type TypeFamily, types, typeFamilies } from '../../reportConfiguration/constants'
+import {
+  type Type,
+  type TypeFamily,
+  type Status,
+  type WorkList,
+  types,
+  typeFamilies,
+  workListCodes,
+  statuses,
+  workListMapping,
+} from '../../reportConfiguration/constants'
 import { parseDateInput } from '../../utils/parseDateTime'
 import format from '../../utils/format'
 import { type Order } from '../../data/offenderSearchApi'
+import { hasInvalidValues } from '../../utils/utils'
+
+export type IncidentStatuses = Status | WorkList
 
 interface UiFilters {
+  clearFilters?: string
   searchID?: string
   location?: string
   fromDate?: string
   toDate?: string
   typeFamily?: TypeFamily
+  incidentStatuses?: IncidentStatuses[]
   sort: string
   order: Order
   page?: string
@@ -24,6 +39,7 @@ interface Filters {
   fromDate?: Date
   toDate?: Date
   type?: Type[]
+  status?: Status[]
   sort: string[]
   page: number
 }
@@ -37,12 +53,22 @@ export function readUiFilters({
   session: Session & Partial<SessionData>
   url: string
 }): UiFilters {
+  let incidentStatuses
+  if (typeof query.incidentStatuses === 'string') {
+    incidentStatuses = [query.incidentStatuses]
+  } else if (Array.isArray(query.incidentStatuses)) {
+    incidentStatuses = query.incidentStatuses
+  }
+
   const uiFilters: UiFilters = {
+    clearFilters: typeof query.clearFilters === 'string' ? query.clearFilters : undefined,
     searchID: typeof query.searchID === 'string' ? query.searchID.trim() : undefined,
     location: typeof query.location === 'string' ? query.location : undefined,
     fromDate: typeof query.fromDate === 'string' ? query.fromDate : undefined,
     toDate: typeof query.toDate === 'string' ? query.toDate : undefined,
     typeFamily: query.typeFamily as TypeFamily | undefined,
+    // @ts-expect-error - provided incidentStatuses could be invalid
+    incidentStatuses,
     sort: typeof query.sort === 'string' ? query.sort : '',
     // @ts-expect-error - order is updated with default if invalid
     order: typeof query.order === 'string' ? query.order : '',
@@ -57,6 +83,7 @@ export function readUiFilters({
     uiFilters.fromDate = sessionFilters?.fromDate
     uiFilters.toDate = sessionFilters?.toDate
     uiFilters.typeFamily = sessionFilters?.typeFamily
+    uiFilters.incidentStatuses = sessionFilters?.incidentStatuses
     uiFilters.sort = sessionFilters?.sort ?? ''
     // @ts-expect-error - order is updated with default if invalid
     uiFilters.order = sessionFilters?.order ?? ''
@@ -65,7 +92,7 @@ export function readUiFilters({
   return uiFilters
 }
 
-export function fillInDefaults(uiFilters: UiFilters): void {
+export function fillInDefaults(uiFilters: UiFilters, useWorklists: boolean): void {
   const sortOptions = ['incidentDateAndTime', 'reportReference', 'location', 'type', 'status', 'reportedBy']
   const orderOptions = ['ASC', 'DESC']
 
@@ -78,13 +105,19 @@ export function fillInDefaults(uiFilters: UiFilters): void {
     // eslint-disable-next-line no-param-reassign
     uiFilters.order = 'DESC'
   }
+
+  if (useWorklists && uiFilters.clearFilters === 'ToDo') {
+    // eslint-disable-next-line no-param-reassign
+    uiFilters.incidentStatuses = ['toDo']
+  }
 }
 
-export function validateUiFilters(uiFilters: UiFilters): GovukErrorSummaryItem[] {
+export function validateUiFilters(uiFilters: UiFilters, useWorklists: boolean): GovukErrorSummaryItem[] {
   const errors: GovukErrorSummaryItem[] = []
 
   validateSearchId(uiFilters, errors)
   validateDateRanges(uiFilters, errors)
+  validateIncidentStatuses(uiFilters, errors, useWorklists)
 
   if (uiFilters.typeFamily && !(uiFilters.typeFamily in familyToType)) {
     errors.push({ href: '#typeFamily', text: 'Select a valid incident type' })
@@ -93,7 +126,7 @@ export function validateUiFilters(uiFilters: UiFilters): GovukErrorSummaryItem[]
   return errors
 }
 
-export function filtersFromUiFilters(uiFilters: UiFilters): Filters {
+export function filtersFromUiFilters(uiFilters: UiFilters, useWorklists: boolean): Filters {
   let page = (uiFilters.page && parseInt(uiFilters.page, 10)) || 1
   if (page < 1) {
     page = 1
@@ -112,11 +145,29 @@ export function filtersFromUiFilters(uiFilters: UiFilters): Filters {
     fromDate: validDateOrder ? fromDate : undefined,
     toDate: validDateOrder ? toDate : undefined,
     type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
+    status: processStatus(uiFilters.incidentStatuses, useWorklists),
     sort: [`${uiFilters.sort},${uiFilters.order}`],
     page,
   }
 
   return filters
+}
+
+function processStatus(incidentStatuses: IncidentStatuses[] | undefined, useWorklists: boolean): Status[] | undefined {
+  if (!incidentStatuses) {
+    return
+  }
+
+  if (useWorklists) {
+    if (validWorkListCodes(incidentStatuses)) {
+      // eslint-disable-next-line consistent-return
+      return incidentStatuses.map(worklist => workListMapping[worklist as WorkList]).flat(1)
+    }
+  } else if (validReportStatusCodes(incidentStatuses)) {
+    // @ts-expect-error - incidentStatuses only contains Status
+    // eslint-disable-next-line consistent-return
+    return incidentStatuses
+  }
 }
 
 function processSearchId(searchID: string | undefined): { prisonerNumber?: string; referenceNumber?: string } {
@@ -135,6 +186,37 @@ function processSearchId(searchID: string | undefined): { prisonerNumber?: strin
     prisonerNumber,
     referenceNumber,
   }
+}
+
+function validateIncidentStatuses(uiFilters: UiFilters, errors: GovukErrorSummaryItem[], useWorklists: boolean): void {
+  if (!uiFilters.incidentStatuses) {
+    return
+  }
+
+  let errorMessage
+  if (useWorklists) {
+    if (!validWorkListCodes(uiFilters.incidentStatuses)) {
+      errorMessage = 'Select a valid work list'
+    }
+  } else if (!validReportStatusCodes(uiFilters.incidentStatuses)) {
+    errorMessage = 'Select a valid status'
+  }
+
+  if (errorMessage) {
+    errors.push({
+      href: '#incidentStatuses-item',
+      text: errorMessage,
+    })
+  }
+}
+
+function validWorkListCodes(incidentStatuses: IncidentStatuses[]): boolean {
+  return !hasInvalidValues(incidentStatuses, workListCodes)
+}
+
+function validReportStatusCodes(incidentStatuses: IncidentStatuses[]): boolean {
+  const reportStatusCodes = statuses.map(status => status.code)
+  return !hasInvalidValues(incidentStatuses, reportStatusCodes)
 }
 
 function validateSearchId(uiFilters: UiFilters, errors: GovukErrorSummaryItem[]): void {

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -17,7 +17,7 @@ import { parseDateInput } from '../../utils/parseDateTime'
 import format from '../../utils/format'
 import { type Order } from '../../data/offenderSearchApi'
 import { hasInvalidValues } from '../../utils/utils'
-import { type ApiUserAction } from '../../middleware/permissions'
+import { type ApiUserAction, apiUserActions } from '../../middleware/permissions'
 
 export type IncidentStatuses = Status | WorkList
 
@@ -131,6 +131,7 @@ export function validateUiFilters(uiFilters: UiFilters, useWorklists: boolean): 
   validateSearchId(uiFilters, errors)
   validateDateRanges(uiFilters, errors)
   validateIncidentStatuses(uiFilters, errors, useWorklists)
+  validateLatestUserActions(uiFilters, errors)
 
   if (uiFilters.typeFamily && !(uiFilters.typeFamily in familyToType)) {
     errors.push({ href: '#typeFamily', text: 'Select a valid incident type' })
@@ -221,6 +222,23 @@ function validateIncidentStatuses(uiFilters: UiFilters, errors: GovukErrorSummar
       text: errorMessage,
     })
   }
+}
+
+function validateLatestUserActions(uiFilters: UiFilters, errors: GovukErrorSummaryItem[]): void {
+  if (!uiFilters.latestUserActions) {
+    return
+  }
+
+  if (!validUserAction(uiFilters.latestUserActions)) {
+    errors.push({
+      href: '#latestUserActions-item',
+      text: 'Enter a valid user action',
+    })
+  }
+}
+
+function validUserAction(latestUserActions: string[]): boolean {
+  return !hasInvalidValues(latestUserActions, [...apiUserActions, 'REQUEST_REMOVAL'])
 }
 
 function validWorkListCodes(incidentStatuses: IncidentStatuses[]): boolean {

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -183,17 +183,14 @@ export function filtersFromUiFilters({
 
   const { prisonerNumber, referenceNumber } = processSearchId(uiFilters.searchID)
 
-  const incidentDateFrom = parseDate(uiFilters.fromDate)
-  const incidentDateUntil = parseDate(uiFilters.toDate)
-  const validDates = incidentDateFrom !== undefined && incidentDateUntil !== undefined
-  const validDateOrder = validDates && incidentDateUntil >= incidentDateFrom
+  const { incidentDateFrom, incidentDateUntil } = processDateRange(uiFilters)
 
   const filters = {
     involvingPrisonerNumber: prisonerNumber,
     reference: referenceNumber,
     location: processLocation(uiFilters.location, permissions, userCaseloadIds),
-    incidentDateFrom: validDateOrder ? incidentDateFrom : undefined,
-    incidentDateUntil: validDateOrder ? incidentDateUntil : undefined,
+    incidentDateFrom,
+    incidentDateUntil,
     type: uiFilters.typeFamily && typesForFamily(uiFilters.typeFamily),
     status: processStatus(uiFilters.incidentStatuses, useWorkLists),
     userAction: processUserAction(uiFilters.latestUserActions, permissions),
@@ -202,6 +199,18 @@ export function filtersFromUiFilters({
   }
 
   return filters
+}
+
+function processDateRange(uiFilters: UiFilters): { incidentDateFrom?: Date; incidentDateUntil?: Date } {
+  const incidentDateFrom = parseDate(uiFilters.fromDate)
+  const incidentDateUntil = parseDate(uiFilters.toDate)
+  const validDates = incidentDateFrom !== undefined && incidentDateUntil !== undefined
+  const validDateOrder = validDates && incidentDateUntil >= incidentDateFrom
+
+  return {
+    incidentDateFrom: validDateOrder ? incidentDateFrom : undefined,
+    incidentDateUntil: validDateOrder ? incidentDateUntil : undefined,
+  }
 }
 
 function processLocation(location: string | undefined, permissions: Permissions, userCaseloadIds: string[]): string[] {

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -62,10 +62,12 @@ export function readUiFilters({
   query,
   session,
   url,
+  useWorkLists,
 }: {
   query: ParsedQs
   session: Session & Partial<SessionData>
   url: string
+  useWorkLists: boolean
 }): UiFilters {
   let incidentStatuses
   if (typeof query.incidentStatuses === 'string') {
@@ -113,10 +115,12 @@ export function readUiFilters({
     uiFilters.order = sessionFilters?.order ?? ''
   }
 
+  fillInDefaults(uiFilters, useWorkLists)
+
   return uiFilters
 }
 
-export function fillInDefaults(uiFilters: UiFilters, useWorkLists: boolean): void {
+function fillInDefaults(uiFilters: UiFilters, useWorkLists: boolean): void {
   const sortOptions = ['incidentDateAndTime', 'reportReference', 'location', 'type', 'status', 'reportedBy']
   const orderOptions = ['ASC', 'DESC']
 

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -40,6 +40,7 @@ export interface UiFilters {
   latestUserActions?: LatestUserAction[]
   sort: string
   order: Order
+  // UI page starts at 1
   page?: string
 }
 
@@ -53,6 +54,7 @@ interface Filters {
   status?: Status[]
   userAction?: ApiUserAction[]
   sort: string[]
+  // API page starts at 0
   page: number
 }
 
@@ -171,9 +173,9 @@ export function filtersFromUiFilters({
   permissions: Permissions
   userCaseloadIds: string[]
 }): Filters {
-  let page = (uiFilters.page && parseInt(uiFilters.page, 10)) || 1
-  if (page < 1) {
-    page = 1
+  let uiPage = (uiFilters.page && parseInt(uiFilters.page, 10)) || 1
+  if (uiPage < 1) {
+    uiPage = 1
   }
 
   const { prisonerNumber, referenceNumber } = processSearchId(uiFilters.searchID)
@@ -193,7 +195,7 @@ export function filtersFromUiFilters({
     status: processStatus(uiFilters.incidentStatuses, useWorkLists),
     userAction: processUserAction(uiFilters.latestUserActions, permissions),
     sort: [`${uiFilters.sort},${uiFilters.order}`],
-    page,
+    page: uiPage - 1,
   }
 
   return filters

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -18,6 +18,7 @@ import format from '../../utils/format'
 import { type Order } from '../../data/offenderSearchApi'
 import { hasInvalidValues } from '../../utils/utils'
 import { type ApiUserAction, type Permissions, type UserAction, apiUserActions } from '../../middleware/permissions'
+import { pecsRegions } from '../../data/pecsRegions'
 
 /** Location search filter which is replaced by all PECS regions when performing search */
 export const ALL_PECS_REGIONS_FLAG = '.PECS' as const
@@ -45,6 +46,7 @@ export interface UiFilters {
 interface Filters {
   prisonerNumber?: string
   referenceNumber?: string
+  location: string[]
   fromDate?: Date
   toDate?: Date
   type?: Type[]
@@ -137,18 +139,16 @@ export function validateUiFilters({
   useWorkLists,
   permissions,
   userCaseloadIds,
-  pecsRegionCodes,
 }: {
   uiFilters: UiFilters
   useWorkLists: boolean
   permissions: Permissions
   userCaseloadIds: string[]
-  pecsRegionCodes: string[]
 }): GovukErrorSummaryItem[] {
   const errors: GovukErrorSummaryItem[] = []
 
   validateSearchId(uiFilters, errors)
-  validateLocation({ uiFilters, errors, permissions, userCaseloadIds, pecsRegionCodes })
+  validateLocation({ uiFilters, errors, permissions, userCaseloadIds })
   validateDateRanges(uiFilters, errors)
   validateIncidentStatuses(uiFilters, errors, useWorkLists)
   validateLatestUserActions(uiFilters, errors)
@@ -164,10 +164,12 @@ export function filtersFromUiFilters({
   uiFilters,
   useWorkLists,
   permissions,
+  userCaseloadIds,
 }: {
   uiFilters: UiFilters
   useWorkLists: boolean
   permissions: Permissions
+  userCaseloadIds: string[]
 }): Filters {
   let page = (uiFilters.page && parseInt(uiFilters.page, 10)) || 1
   if (page < 1) {
@@ -184,6 +186,7 @@ export function filtersFromUiFilters({
   const filters = {
     prisonerNumber,
     referenceNumber,
+    location: processLocation(uiFilters.location, permissions, userCaseloadIds),
     fromDate: validDateOrder ? fromDate : undefined,
     toDate: validDateOrder ? toDate : undefined,
     type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
@@ -194,6 +197,31 @@ export function filtersFromUiFilters({
   }
 
   return filters
+}
+
+function processLocation(location: string | undefined, permissions: Permissions, userCaseloadIds: string[]): string[] {
+  const pecsRegionCodes = pecsRegions.map(pecsRegion => pecsRegion.code)
+
+  // Set locations to user’s caseloads by default and PECS regions if allowed
+  const allUserLocations = userCaseloadIds
+  if (permissions.hasPecsAccess) {
+    allUserLocations.push(...pecsRegionCodes)
+  }
+
+  let locations = allUserLocations
+  if (location) {
+    const isInCaseLoads = userCaseloadIds.includes(location)
+    const isPecsRegion = pecsRegionCodes.includes(location)
+    const isAllPecsRegions = location === ALL_PECS_REGIONS_FLAG
+
+    if (isInCaseLoads || (permissions.hasPecsAccess && isPecsRegion)) {
+      locations = [location]
+    } else if (permissions.hasPecsAccess && isAllPecsRegions) {
+      locations = pecsRegionCodes
+    }
+  }
+
+  return locations
 }
 
 function processStatus(incidentStatuses: StatusOrWorkList[] | undefined, useWorkLists: boolean): Status[] | undefined {
@@ -266,18 +294,17 @@ function validateLocation({
   errors,
   permissions,
   userCaseloadIds,
-  pecsRegionCodes,
 }: {
   uiFilters: UiFilters
   errors: GovukErrorSummaryItem[]
   permissions: Permissions
   userCaseloadIds: string[]
-  pecsRegionCodes: string[]
 }) {
   if (!uiFilters.location) {
     return
   }
-  if (!validLocation({ location: uiFilters.location, permissions, userCaseloadIds, pecsRegionCodes })) {
+
+  if (!validLocation({ location: uiFilters.location, permissions, userCaseloadIds })) {
     errors.push({
       href: '#location',
       text: 'Select a location to search',
@@ -289,17 +316,16 @@ function validLocation({
   location,
   permissions,
   userCaseloadIds,
-  pecsRegionCodes,
 }: {
   location: string
   permissions: Permissions
   userCaseloadIds: string[]
-  pecsRegionCodes: string[]
 }): boolean {
   if (userCaseloadIds.includes(location)) {
     return true
   }
   if (permissions.hasPecsAccess) {
+    const pecsRegionCodes = pecsRegions.map(pecsRegion => pecsRegion.code)
     return location === ALL_PECS_REGIONS_FLAG || pecsRegionCodes.includes(location)
   }
 

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -112,7 +112,7 @@ export function readUiFilters({
   return uiFilters
 }
 
-export function fillInDefaults(uiFilters: UiFilters, useWorklists: boolean): void {
+export function fillInDefaults(uiFilters: UiFilters, useWorkLists: boolean): void {
   const sortOptions = ['incidentDateAndTime', 'reportReference', 'location', 'type', 'status', 'reportedBy']
   const orderOptions = ['ASC', 'DESC']
 
@@ -126,7 +126,7 @@ export function fillInDefaults(uiFilters: UiFilters, useWorklists: boolean): voi
     uiFilters.order = 'DESC'
   }
 
-  if (useWorklists && uiFilters.clearFilters === 'ToDo') {
+  if (useWorkLists && uiFilters.clearFilters === 'ToDo') {
     // eslint-disable-next-line no-param-reassign
     uiFilters.incidentStatuses = ['toDo']
   }
@@ -134,13 +134,13 @@ export function fillInDefaults(uiFilters: UiFilters, useWorklists: boolean): voi
 
 export function validateUiFilters({
   uiFilters,
-  useWorklists,
+  useWorkLists,
   permissions,
   userCaseloadIds,
   pecsRegionCodes,
 }: {
   uiFilters: UiFilters
-  useWorklists: boolean
+  useWorkLists: boolean
   permissions: Permissions
   userCaseloadIds: string[]
   pecsRegionCodes: string[]
@@ -150,7 +150,7 @@ export function validateUiFilters({
   validateSearchId(uiFilters, errors)
   validateLocation({ uiFilters, errors, permissions, userCaseloadIds, pecsRegionCodes })
   validateDateRanges(uiFilters, errors)
-  validateIncidentStatuses(uiFilters, errors, useWorklists)
+  validateIncidentStatuses(uiFilters, errors, useWorkLists)
   validateLatestUserActions(uiFilters, errors)
 
   if (uiFilters.typeFamily && !(uiFilters.typeFamily in familyToType)) {
@@ -162,11 +162,11 @@ export function validateUiFilters({
 
 export function filtersFromUiFilters({
   uiFilters,
-  useWorklists,
+  useWorkLists,
   permissions,
 }: {
   uiFilters: UiFilters
-  useWorklists: boolean
+  useWorkLists: boolean
   permissions: Permissions
 }): Filters {
   let page = (uiFilters.page && parseInt(uiFilters.page, 10)) || 1
@@ -187,7 +187,7 @@ export function filtersFromUiFilters({
     fromDate: validDateOrder ? fromDate : undefined,
     toDate: validDateOrder ? toDate : undefined,
     type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
-    status: processStatus(uiFilters.incidentStatuses, useWorklists),
+    status: processStatus(uiFilters.incidentStatuses, useWorkLists),
     userAction: processUserAction(uiFilters.latestUserActions, permissions),
     sort: [`${uiFilters.sort},${uiFilters.order}`],
     page,
@@ -196,12 +196,12 @@ export function filtersFromUiFilters({
   return filters
 }
 
-function processStatus(incidentStatuses: StatusOrWorkList[] | undefined, useWorklists: boolean): Status[] | undefined {
+function processStatus(incidentStatuses: StatusOrWorkList[] | undefined, useWorkLists: boolean): Status[] | undefined {
   if (!incidentStatuses) {
     return
   }
 
-  if (useWorklists) {
+  if (useWorkLists) {
     if (validWorkListCodes(incidentStatuses)) {
       // eslint-disable-next-line consistent-return
       return incidentStatuses.map(worklist => workListMapping[worklist]).flat(1)
@@ -306,13 +306,13 @@ function validLocation({
   return false
 }
 
-function validateIncidentStatuses(uiFilters: UiFilters, errors: GovukErrorSummaryItem[], useWorklists: boolean): void {
+function validateIncidentStatuses(uiFilters: UiFilters, errors: GovukErrorSummaryItem[], useWorkLists: boolean): void {
   if (!uiFilters.incidentStatuses) {
     return
   }
 
   let errorMessage
-  if (useWorklists) {
+  if (useWorkLists) {
     if (!validWorkListCodes(uiFilters.incidentStatuses)) {
       errorMessage = 'Select a valid work list'
     }

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -1,0 +1,34 @@
+import { type Session, type SessionData } from 'express-session'
+import { type ParsedQs } from 'qs'
+
+interface UiFilters {
+  searchID?: string
+  fromDate?: string
+  toDate?: string
+}
+
+export function readUiFilters({
+  query,
+  session,
+  url,
+}: {
+  query: ParsedQs
+  session: Session & Partial<SessionData>
+  url: string
+}): UiFilters {
+  const uiFilters = {
+    searchID: typeof query.searchID === 'string' ? query.searchID.trim() : undefined,
+    fromDate: typeof query.fromDate === 'string' ? query.fromDate : undefined,
+    toDate: typeof query.toDate === 'string' ? query.toDate : undefined,
+  }
+
+  // If no filters are supplied from query, check for filters in session
+  if (url === '/' && session.dashboardFilters) {
+    const sessionFilters = session.dashboardFilters
+    uiFilters.searchID = sessionFilters?.searchID
+    uiFilters.fromDate = sessionFilters?.fromDate
+    uiFilters.toDate = sessionFilters?.toDate
+  }
+
+  return uiFilters
+}

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -17,6 +17,7 @@ import { parseDateInput } from '../../utils/parseDateTime'
 import format from '../../utils/format'
 import { type Order } from '../../data/offenderSearchApi'
 import { hasInvalidValues } from '../../utils/utils'
+import { type ApiUserAction } from '../../middleware/permissions'
 
 export type IncidentStatuses = Status | WorkList
 
@@ -28,6 +29,8 @@ interface UiFilters {
   toDate?: string
   typeFamily?: TypeFamily
   incidentStatuses?: IncidentStatuses[]
+  // TODO: Why was dashboard adding 'REQUEST_REMOVAL'??
+  latestUserActions?: ApiUserAction[]
   sort: string
   order: Order
   page?: string
@@ -60,6 +63,13 @@ export function readUiFilters({
     incidentStatuses = query.incidentStatuses
   }
 
+  let latestUserActions
+  if (typeof query.latestUserActions === 'string') {
+    latestUserActions = [query.latestUserActions]
+  } else if (Array.isArray(query.latestUserActions)) {
+    latestUserActions = query.latestUserActions
+  }
+
   const uiFilters: UiFilters = {
     clearFilters: typeof query.clearFilters === 'string' ? query.clearFilters : undefined,
     searchID: typeof query.searchID === 'string' ? query.searchID.trim() : undefined,
@@ -69,6 +79,8 @@ export function readUiFilters({
     typeFamily: query.typeFamily as TypeFamily | undefined,
     // @ts-expect-error - provided incidentStatuses could be invalid
     incidentStatuses,
+    // @ts-expect-error - provided latestUserActions could be invalid
+    latestUserActions,
     sort: typeof query.sort === 'string' ? query.sort : '',
     // @ts-expect-error - order is updated with default if invalid
     order: typeof query.order === 'string' ? query.order : '',
@@ -84,6 +96,7 @@ export function readUiFilters({
     uiFilters.toDate = sessionFilters?.toDate
     uiFilters.typeFamily = sessionFilters?.typeFamily
     uiFilters.incidentStatuses = sessionFilters?.incidentStatuses
+    uiFilters.latestUserActions = sessionFilters?.latestUserActions
     uiFilters.sort = sessionFilters?.sort ?? ''
     // @ts-expect-error - order is updated with default if invalid
     uiFilters.order = sessionFilters?.order ?? ''

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -7,8 +7,6 @@ import {
   type TypeFamily,
   type Status,
   type WorkList,
-  types,
-  typeFamilies,
   workListCodes,
   statuses,
   workListMapping,
@@ -19,6 +17,7 @@ import { type Order } from '../../data/offenderSearchApi'
 import { hasInvalidValues } from '../../utils/utils'
 import { type ApiUserAction, type Permissions, type UserAction, apiUserActions } from '../../middleware/permissions'
 import { pecsRegions } from '../../data/pecsRegions'
+import { typesForFamily } from '../../reportConfiguration/constants/familyToTypesMapping'
 
 /** Location search filter which is replaced by all PECS regions when performing search */
 export const ALL_PECS_REGIONS_FLAG = '.PECS' as const
@@ -159,7 +158,7 @@ export function validateUiFilters({
   validateIncidentStatuses(uiFilters, errors, useWorkLists)
   validateLatestUserActions(uiFilters, errors)
 
-  if (uiFilters.typeFamily && !(uiFilters.typeFamily in familyToType)) {
+  if (uiFilters.typeFamily && !validTypeFamily(uiFilters.typeFamily)) {
     errors.push({ href: '#typeFamily', text: 'Select a valid incident type' })
   }
 
@@ -195,7 +194,7 @@ export function filtersFromUiFilters({
     location: processLocation(uiFilters.location, permissions, userCaseloadIds),
     incidentDateFrom: validDateOrder ? incidentDateFrom : undefined,
     incidentDateUntil: validDateOrder ? incidentDateUntil : undefined,
-    type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
+    type: uiFilters.typeFamily && typesForFamily(uiFilters.typeFamily),
     status: processStatus(uiFilters.incidentStatuses, useWorkLists),
     userAction: processUserAction(uiFilters.latestUserActions, permissions),
     sort: [`${uiFilters.sort},${uiFilters.order}`],
@@ -399,6 +398,10 @@ function validateSearchId(uiFilters: UiFilters, errors: GovukErrorSummaryItem[])
   }
 }
 
+export function validTypeFamily(typeFamily: string): typeFamily is TypeFamily {
+  return typesForFamily(typeFamily) !== undefined
+}
+
 function isPrisonerNumber(searchID: string): boolean {
   return searchID.match(/^[a-zA-Z][0-9]{4}[a-zA-Z]{2}$/) !== null
 }
@@ -436,13 +439,3 @@ function parseDate(date: string | undefined): Date | undefined {
 
   return undefined
 }
-
-/** Given a family code, list type codes belonging to the family */
-const familyToType = Object.fromEntries(
-  Object.values(typeFamilies).map(({ code: familyCode }) => [
-    familyCode,
-    Object.values(types)
-      .filter(({ familyCode: someFamilyCode }) => someFamilyCode === familyCode)
-      .map(({ code }) => code),
-  ]),
-)

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -3,6 +3,8 @@ import { type ParsedQs } from 'qs'
 
 import { type GovukErrorSummaryItem } from '../../utils/govukFrontend'
 import { typeFamilies, TypeFamily, types } from '../../reportConfiguration/constants'
+import { parseDateInput } from '../../utils/parseDateTime'
+import format from '../../utils/format'
 
 interface UiFilters {
   searchID?: string
@@ -14,6 +16,8 @@ interface UiFilters {
 }
 
 interface Filters {
+  fromDate?: Date
+  toDate?: Date
   page: number
 }
 
@@ -51,6 +55,8 @@ export function readUiFilters({
 export function validateUiFilters(uiFilters: UiFilters): GovukErrorSummaryItem[] {
   const errors: GovukErrorSummaryItem[] = []
 
+  validateDateRanges(uiFilters, errors)
+
   if (uiFilters.typeFamily && !(uiFilters.typeFamily in familyToType)) {
     errors.push({ href: '#typeFamily', text: 'Select a valid incident type' })
   }
@@ -64,7 +70,14 @@ export function filtersFromUiFilters(uiFilters: UiFilters): Filters {
     page = 1
   }
 
+  const fromDate = parseDate(uiFilters.fromDate)
+  const toDate = parseDate(uiFilters.toDate)
+  const validDates = fromDate !== undefined && toDate !== undefined
+  const validDateOrder = validDates && toDate >= fromDate
+
   const filters = {
+    fromDate: validDateOrder ? fromDate : undefined,
+    toDate: validDateOrder ? toDate : undefined,
     page,
   }
 
@@ -80,3 +93,33 @@ export const familyToType = Object.fromEntries(
       .map(({ code }) => code),
   ]),
 )
+
+function validateDateRanges(uiFilters: UiFilters, errors: GovukErrorSummaryItem[]): void {
+  const todayAsShortDate = format.shortDate(new Date())
+
+  const fromDate = parseDate(uiFilters.fromDate)
+  const toDate = parseDate(uiFilters.toDate)
+
+  if (uiFilters.fromDate && !fromDate) {
+    errors.push({ href: '#fromDate', text: `Enter a valid from date, for example ${todayAsShortDate}` })
+  }
+  if (uiFilters.toDate && !toDate) {
+    errors.push({ href: '#toDate', text: `Enter a valid to date, for example ${todayAsShortDate}` })
+  }
+
+  if (fromDate && toDate && toDate < fromDate) {
+    errors.push({ href: '#toDate', text: 'Enter a date after from date' })
+  }
+}
+
+function parseDate(date: string | undefined): Date | undefined {
+  if (date) {
+    try {
+      return parseDateInput(date)
+    } catch {
+      //
+    }
+  }
+
+  return undefined
+}

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -44,11 +44,11 @@ export interface UiFilters {
 }
 
 interface Filters {
-  prisonerNumber?: string
-  referenceNumber?: string
+  involvingPrisonerNumber?: string
+  reference?: string
   location: string[]
-  fromDate?: Date
-  toDate?: Date
+  incidentDateFrom?: Date
+  incidentDateUntil?: Date
   type?: Type[]
   status?: Status[]
   userAction?: ApiUserAction[]
@@ -178,17 +178,17 @@ export function filtersFromUiFilters({
 
   const { prisonerNumber, referenceNumber } = processSearchId(uiFilters.searchID)
 
-  const fromDate = parseDate(uiFilters.fromDate)
-  const toDate = parseDate(uiFilters.toDate)
-  const validDates = fromDate !== undefined && toDate !== undefined
-  const validDateOrder = validDates && toDate >= fromDate
+  const incidentDateFrom = parseDate(uiFilters.fromDate)
+  const incidentDateUntil = parseDate(uiFilters.toDate)
+  const validDates = incidentDateFrom !== undefined && incidentDateUntil !== undefined
+  const validDateOrder = validDates && incidentDateUntil >= incidentDateFrom
 
   const filters = {
-    prisonerNumber,
-    referenceNumber,
+    involvingPrisonerNumber: prisonerNumber,
+    reference: referenceNumber,
     location: processLocation(uiFilters.location, permissions, userCaseloadIds),
-    fromDate: validDateOrder ? fromDate : undefined,
-    toDate: validDateOrder ? toDate : undefined,
+    incidentDateFrom: validDateOrder ? incidentDateFrom : undefined,
+    incidentDateUntil: validDateOrder ? incidentDateUntil : undefined,
     type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
     status: processStatus(uiFilters.incidentStatuses, useWorkLists),
     userAction: processUserAction(uiFilters.latestUserActions, permissions),

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -19,7 +19,11 @@ import { type Order } from '../../data/offenderSearchApi'
 import { hasInvalidValues } from '../../utils/utils'
 import { type ApiUserAction, apiUserActions } from '../../middleware/permissions'
 
-export type IncidentStatuses = Status | WorkList
+// `latestUserActions` can include 'REQUEST_REMOVAL' (not a valid `ApiUserAction`)
+// which maps/is replaced with 'REQUEST_NOT_REPORTABLE' and 'REQUEST_DUPLICATE'
+export type LatestUserActions = ApiUserAction | 'REQUEST_REMOVAL'
+
+type IncidentStatuses = Status | WorkList
 
 interface UiFilters {
   clearFilters?: string
@@ -29,8 +33,7 @@ interface UiFilters {
   toDate?: string
   typeFamily?: TypeFamily
   incidentStatuses?: IncidentStatuses[]
-  // TODO: Why was dashboard adding 'REQUEST_REMOVAL'??
-  latestUserActions?: ApiUserAction[]
+  latestUserActions?: LatestUserActions[]
   sort: string
   order: Order
   page?: string

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -99,15 +99,7 @@ export function filtersFromUiFilters(uiFilters: UiFilters): Filters {
     page = 1
   }
 
-  let prisonerNumber
-  let referenceNumber
-  if (uiFilters.searchID) {
-    if (isPrisonerNumber(uiFilters.searchID)) {
-      prisonerNumber = uiFilters.searchID
-    } else if (isReferenceNumber(uiFilters.searchID)) {
-      referenceNumber = uiFilters.searchID
-    }
-  }
+  const { prisonerNumber, referenceNumber } = processSearchId(uiFilters.searchID)
 
   const fromDate = parseDate(uiFilters.fromDate)
   const toDate = parseDate(uiFilters.toDate)
@@ -125,6 +117,24 @@ export function filtersFromUiFilters(uiFilters: UiFilters): Filters {
   }
 
   return filters
+}
+
+function processSearchId(searchID: string | undefined): { prisonerNumber?: string; referenceNumber?: string } {
+  let prisonerNumber
+  let referenceNumber
+
+  if (searchID) {
+    if (isPrisonerNumber(searchID)) {
+      prisonerNumber = searchID
+    } else if (isReferenceNumber(searchID)) {
+      referenceNumber = searchID
+    }
+  }
+
+  return {
+    prisonerNumber,
+    referenceNumber,
+  }
 }
 
 function validateSearchId(uiFilters: UiFilters, errors: GovukErrorSummaryItem[]): void {

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -20,7 +20,7 @@ import {
   areTypeFamiliesInactive,
 } from '../../reportConfiguration/constants'
 import type { PaginatedBasicReports } from '../../data/incidentReportingApi'
-import { type Order, orderOptions } from '../../data/offenderSearchApi'
+import { type Order } from '../../data/offenderSearchApi'
 import { pecsRegions } from '../../data/pecsRegions'
 import { ApiUserAction, apiUserActions } from '../../middleware/permissions'
 import type { HeaderCell } from '../../utils/sortableTable'
@@ -30,11 +30,9 @@ import { hasInvalidValues } from '../../utils/utils'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
-import { filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
+import { fillInDefaults, filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
 
 export type IncidentStatuses = Status | WorkList
-
-const sortOptions = ['incidentDateAndTime', 'reportReference', 'location', 'type', 'status', 'reportedBy']
 
 interface ListFormData {
   clearFilters?: string
@@ -66,29 +64,21 @@ export default function dashboard(): Router {
     const pecsRegionCodes = pecsRegions.map(pecsRegion => pecsRegion.code)
 
     const uiFilters = readUiFilters(req)
+    fillInDefaults(uiFilters)
     const errors = validateUiFilters(uiFilters)
     const filters = filtersFromUiFilters(uiFilters)
 
     const { clearFilters }: ListFormData = req.query
-    let { incidentStatuses, latestUserActions, sort, order }: ListFormData = req.query
+    let { incidentStatuses, latestUserActions }: ListFormData = req.query
 
     if (clearFilters && ['All', 'ToDo'].includes(clearFilters)) {
       req.session.dashboardFilters = {}
-    }
-
-    if (!sort || !sortOptions.includes(sort)) {
-      sort = 'incidentDateAndTime'
-    }
-    if (!order || !orderOptions.includes(order)) {
-      order = 'DESC'
     }
 
     // If no filters are supplied from query and no errors generated, check for filters in session
     if (req.url === '/' && req.session.dashboardFilters) {
       incidentStatuses = req.session.dashboardFilters?.incidentStatuses
       latestUserActions = req.session.dashboardFilters?.latestUserActions
-      sort = req.session.dashboardFilters?.sort ?? 'incidentDateAndTime'
-      order = req.session.dashboardFilters?.order ?? 'DESC'
     }
 
     // RO: Default work list to 'To do' for an RO when no other filters are applied and when the user arrives on page
@@ -166,7 +156,7 @@ export default function dashboard(): Router {
         involvingPrisonerNumber: filters.prisonerNumber,
         userAction: userActionFilter,
         page: filters.page - 1,
-        sort: [`${sort},${order}`],
+        sort: filters.sort,
       })
     } catch (e) {
       logger.error(e, 'Search failed: %j', e)
@@ -181,8 +171,8 @@ export default function dashboard(): Router {
       typeFamily: uiFilters.typeFamily,
       incidentStatuses,
       latestUserActions,
-      sort,
-      order,
+      sort: uiFilters.sort,
+      order: uiFilters.order,
       page: uiFilters.page,
     }
 
@@ -217,11 +207,11 @@ export default function dashboard(): Router {
       }
     }
     const tableHeadUrlPrefix = `/reports?${queryString}&`
-    if (sort) {
-      queryString.append('sort', sort)
+    if (uiFilters.sort) {
+      queryString.append('sort', uiFilters.sort)
     }
-    if (order) {
-      queryString.append('order', order)
+    if (uiFilters.order) {
+      queryString.append('order', uiFilters.order)
     }
 
     const urlPrefix = `/reports?${queryString}&`
@@ -280,8 +270,8 @@ export default function dashboard(): Router {
     const columns = showLocationFilter ? multiCaseloadColumns : singleCaseloadColumns
     const tableHead: HeaderCell[] = sortableTableHead({
       columns,
-      sortColumn: sort,
-      order,
+      sortColumn: uiFilters.sort,
+      order: uiFilters.order,
       urlPrefix: tableHeadUrlPrefix,
       destinationFocusId: 'results-table',
     })
@@ -310,8 +300,8 @@ export default function dashboard(): Router {
         typeFamily: uiFilters.typeFamily,
         incidentStatuses,
         latestUserActions,
-        sort,
-        order,
+        sort: uiFilters.sort,
+        order: uiFilters.order,
       }
     }
 

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -31,6 +31,7 @@ import { hasInvalidValues } from '../../utils/utils'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
+import { readUiFilters } from './filters'
 
 export type IncidentStatuses = Status | WorkList
 
@@ -65,26 +66,15 @@ export default function dashboard(): Router {
     const userCaseloadIds = userCaseloads.map(caseload => caseload.caseLoadId)
     const pecsRegionCodes = pecsRegions.map(pecsRegion => pecsRegion.code)
 
+    const uiFilters = readUiFilters(req)
+
     const { page, clearFilters }: ListFormData = req.query
-    let {
-      fromDate: fromDateInput,
-      toDate: toDateInput,
-      location,
-      searchID,
-      typeFamily,
-      incidentStatuses,
-      latestUserActions,
-      sort,
-      order,
-    }: ListFormData = req.query
+    let { location, typeFamily, incidentStatuses, latestUserActions, sort, order }: ListFormData = req.query
 
     if (clearFilters && ['All', 'ToDo'].includes(clearFilters)) {
       req.session.dashboardFilters = {}
     }
 
-    if (searchID) {
-      searchID = searchID.trim()
-    }
     if (!sort || !sortOptions.includes(sort)) {
       sort = 'incidentDateAndTime'
     }
@@ -96,11 +86,8 @@ export default function dashboard(): Router {
     const errors: GovukErrorSummaryItem[] = []
 
     // If no filters are supplied from query and no errors generated, check for filters in session
-    if (errors.length === 0 && req.url === '/' && req.session.dashboardFilters) {
+    if (req.url === '/' && req.session.dashboardFilters) {
       location = req.session.dashboardFilters?.location
-      fromDateInput = req.session.dashboardFilters?.fromDateInput
-      toDateInput = req.session.dashboardFilters?.toDateInput
-      searchID = req.session.dashboardFilters?.searchID
       typeFamily = req.session.dashboardFilters?.typeFamily
       incidentStatuses = req.session.dashboardFilters?.incidentStatuses
       latestUserActions = req.session.dashboardFilters?.latestUserActions
@@ -113,16 +100,16 @@ export default function dashboard(): Router {
     let fromDate: Date | undefined
     let toDate: Date | undefined
     try {
-      if (fromDateInput) {
-        fromDate = parseDateInput(fromDateInput)
+      if (uiFilters.fromDate) {
+        fromDate = parseDateInput(uiFilters.fromDate)
       }
     } catch {
       fromDate = undefined
       errors.push({ href: '#fromDate', text: `Enter a valid from date, for example ${todayAsShortDate}` })
     }
     try {
-      if (toDateInput) {
-        toDate = parseDateInput(toDateInput)
+      if (uiFilters.toDate) {
+        toDate = parseDateInput(uiFilters.toDate)
       }
     } catch {
       toDate = undefined
@@ -140,7 +127,13 @@ export default function dashboard(): Router {
 
     // Check for supplied filters from session
     let noFiltersSupplied = Boolean(
-      !searchID && !location && !fromDate && !toDate && !typeFamily && !incidentStatuses && !latestUserActions,
+      !uiFilters.searchID &&
+      !location &&
+      !fromDate &&
+      !toDate &&
+      !typeFamily &&
+      !incidentStatuses &&
+      !latestUserActions,
     )
 
     // RO: Default work list to 'To do' for an RO when no other filters are applied and when the user arrives on page
@@ -187,14 +180,14 @@ export default function dashboard(): Router {
 
     let prisonerId: string | undefined
     let referenceNumber: string | undefined
-    if (searchID) {
+    if (uiFilters.searchID) {
       // Test if search is for a prisoner ID and use if so
-      if (searchID.match(/^[a-zA-Z][0-9]{4}[a-zA-Z]{2}$/)) {
-        prisonerId = searchID
+      if (uiFilters.searchID.match(/^[a-zA-Z][0-9]{4}[a-zA-Z]{2}$/)) {
+        prisonerId = uiFilters.searchID
       }
       // Test if search is for an incident reference number and use if so
-      else if (searchID.match(/^[0-9]+$/)) {
-        referenceNumber = searchID
+      else if (uiFilters.searchID.match(/^[0-9]+$/)) {
+        referenceNumber = uiFilters.searchID
       } else {
         errors.push({
           href: '#searchID',
@@ -251,10 +244,10 @@ export default function dashboard(): Router {
     }
 
     const formValues: ListFormData = {
-      searchID,
+      searchID: uiFilters.searchID,
       location,
-      fromDate: fromDateInput,
-      toDate: toDateInput,
+      fromDate: uiFilters.fromDate,
+      toDate: uiFilters.toDate,
       typeFamily,
       incidentStatuses,
       latestUserActions,
@@ -264,17 +257,17 @@ export default function dashboard(): Router {
     }
 
     const queryString = new URLSearchParams()
-    if (searchID) {
-      queryString.append('searchID', searchID)
+    if (uiFilters.searchID) {
+      queryString.append('searchID', uiFilters.searchID)
     }
     if (location) {
       queryString.append('location', location)
     }
-    if (fromDateInput) {
-      queryString.append('fromDate', fromDateInput)
+    if (uiFilters.fromDate) {
+      queryString.append('fromDate', uiFilters.fromDate)
     }
-    if (toDateInput) {
-      queryString.append('toDate', toDateInput)
+    if (uiFilters.toDate) {
+      queryString.append('toDate', uiFilters.toDate)
     }
     if (typeFamily) {
       queryString.append('typeFamily', typeFamily)
@@ -376,13 +369,14 @@ export default function dashboard(): Router {
     // Gather notification banner entries if they exist
     const banners = req.flash()
 
+    // TODO: Move logic into helper once all filters are in uiFilters
     // Set dashboard filters stored in the session if no errors present
     if (errors.length === 0) {
       req.session.dashboardFilters = {
-        searchID,
+        searchID: uiFilters.searchID,
         location,
-        fromDateInput,
-        toDateInput,
+        fromDate: uiFilters.fromDate,
+        toDate: uiFilters.toDate,
         typeFamily,
         incidentStatuses,
         latestUserActions,

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -67,8 +67,7 @@ export default function dashboard(): Router {
         status: filters.status,
         involvingPrisonerNumber: filters.involvingPrisonerNumber,
         userAction: filters.userAction,
-        // API page starts at 0
-        page: filters.page - 1,
+        page: filters.page,
         sort: filters.sort,
       })
     } catch (e) {
@@ -97,7 +96,7 @@ export default function dashboard(): Router {
     const paginationParams = reportsResponse
       ? pagination(
           // UI page starts at 1
-          filters.page,
+          filters.page + 1,
           reportsResponse.totalPages,
           paginationUrlPrefix,
           'moj',

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -83,6 +83,7 @@ export default function dashboard(): Router {
         status: filters.status,
         involvingPrisonerNumber: filters.prisonerNumber,
         userAction: filters.userAction,
+        // API page starts at 0
         page: filters.page - 1,
         sort: filters.sort,
       })
@@ -111,6 +112,7 @@ export default function dashboard(): Router {
     })
     const paginationParams = reportsResponse
       ? pagination(
+          // UI page starts at 1
           filters.page,
           reportsResponse.totalPages,
           paginationUrlPrefix,

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -44,12 +44,12 @@ export default function dashboard(): Router {
     const userCaseloadIds = userCaseloads.map(caseload => caseload.caseLoadId)
     const pecsRegionCodes = pecsRegions.map(pecsRegion => pecsRegion.code)
 
-    const useWorklists = permissions.isReportingOfficer
+    const useWorkLists = permissions.isReportingOfficer
 
     const uiFilters = readUiFilters(req)
-    fillInDefaults(uiFilters, useWorklists)
-    const errors = validateUiFilters({ uiFilters, useWorklists, permissions, userCaseloadIds, pecsRegionCodes })
-    const filters = filtersFromUiFilters({ uiFilters, useWorklists, permissions })
+    fillInDefaults(uiFilters, useWorkLists)
+    const errors = validateUiFilters({ uiFilters, useWorkLists, permissions, userCaseloadIds, pecsRegionCodes })
+    const filters = filtersFromUiFilters({ uiFilters, useWorkLists, permissions })
 
     if (uiFilters.clearFilters && ['All', 'ToDo'].includes(uiFilters.clearFilters)) {
       req.session.dashboardFilters = {}

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -23,6 +23,7 @@ import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
 import { type UiFilters, fillInDefaults, filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
+import { type CaseLoad } from '../../data/frontendComponentsClient'
 
 /** Location search filter which is replaced by all PECS regions when performing search */
 const allPecsRegionsFlag = '.PECS' as const
@@ -97,30 +98,7 @@ export default function dashboard(): Router {
     const usersLookup = await userService.getUsers(res.locals.systemToken, usernames)
 
     /** location choices for auto-complete */
-    const allLocations: GovukSelectItem[] = userCaseloads.map(caseload => ({
-      value: caseload.caseLoadId,
-      text: caseload.description,
-    }))
-    /** location map for code-to-description display */
-    const locationLookup = Object.fromEntries(
-      userCaseloads.map(caseload => [caseload.caseLoadId, caseload.description]),
-    )
-    if (permissions.hasPecsAccess) {
-      allLocations.unshift({
-        value: allPecsRegionsFlag,
-        text: 'All PECS regions',
-      })
-      allLocations.push(
-        ...pecsRegions.map(pecsRegion => ({
-          value: pecsRegion.code,
-          text: pecsRegion.description,
-        })),
-      )
-      pecsRegions.forEach(pecsRegion => {
-        locationLookup[pecsRegion.code] = pecsRegion.description
-      })
-    }
-
+    const allLocations = allLocationsItems(userCaseloads, permissions.hasPecsAccess)
     const showLocationFilter = allLocations.length > 1
 
     const { paginationUrlPrefix, tableHeadUrlPrefix } = urlPrefixes(uiFilters)
@@ -154,7 +132,7 @@ export default function dashboard(): Router {
       reports,
       showLocationFilter,
       allLocations,
-      locationLookup,
+      locationLookup: locationLookupFromCaseloads(userCaseloads, permissions.hasPecsAccess),
       usersLookup,
       typeFamilyItems: typeFamilyItems(),
       workLists,
@@ -172,6 +150,40 @@ export default function dashboard(): Router {
   })
 
   return router
+}
+
+function locationLookupFromCaseloads(userCaseloads: CaseLoad[], hasPecsAccess: boolean): Record<string, string> {
+  const locationLookup = Object.fromEntries(userCaseloads.map(caseload => [caseload.caseLoadId, caseload.description]))
+
+  if (hasPecsAccess) {
+    pecsRegions.forEach(pecsRegion => {
+      locationLookup[pecsRegion.code] = pecsRegion.description
+    })
+  }
+
+  return locationLookup
+}
+
+function allLocationsItems(userCaseloads: CaseLoad[], hasPecsAccess: boolean): GovukSelectItem[] {
+  const allLocations: GovukSelectItem[] = userCaseloads.map(caseload => ({
+    value: caseload.caseLoadId,
+    text: caseload.description,
+  }))
+
+  if (hasPecsAccess) {
+    allLocations.unshift({
+      value: allPecsRegionsFlag,
+      text: 'All PECS regions',
+    })
+    allLocations.push(
+      ...pecsRegions.map(pecsRegion => ({
+        value: pecsRegion.code,
+        text: pecsRegion.description,
+      })),
+    )
+  }
+
+  return allLocations
 }
 
 /**

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -25,7 +25,7 @@ import { pecsRegions } from '../../data/pecsRegions'
 import { ApiUserAction, apiUserActions } from '../../middleware/permissions'
 import type { HeaderCell } from '../../utils/sortableTable'
 import format from '../../utils/format'
-import type { GovukErrorSummaryItem, GovukSelectItem } from '../../utils/govukFrontend'
+import type { GovukSelectItem } from '../../utils/govukFrontend'
 import { hasInvalidValues } from '../../utils/utils'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
@@ -66,6 +66,8 @@ export default function dashboard(): Router {
     const pecsRegionCodes = pecsRegions.map(pecsRegion => pecsRegion.code)
 
     const uiFilters = readUiFilters(req)
+    const errors = validateUiFilters(uiFilters)
+    const filters = filtersFromUiFilters(uiFilters)
 
     const { clearFilters }: ListFormData = req.query
     let { incidentStatuses, latestUserActions, sort, order }: ListFormData = req.query
@@ -81,9 +83,6 @@ export default function dashboard(): Router {
       order = 'DESC'
     }
 
-    // Collect errors
-    const errors: GovukErrorSummaryItem[] = validateUiFilters(uiFilters)
-
     // If no filters are supplied from query and no errors generated, check for filters in session
     if (req.url === '/' && req.session.dashboardFilters) {
       incidentStatuses = req.session.dashboardFilters?.incidentStatuses
@@ -92,23 +91,9 @@ export default function dashboard(): Router {
       order = req.session.dashboardFilters?.order ?? 'DESC'
     }
 
-    const filters = filtersFromUiFilters(uiFilters)
-
-    // Check for supplied filters from session
-    let noFiltersSupplied = Boolean(
-      !uiFilters.searchID &&
-      !uiFilters.location &&
-      !filters.fromDate &&
-      !filters.toDate &&
-      !uiFilters.typeFamily &&
-      !incidentStatuses &&
-      !latestUserActions,
-    )
-
     // RO: Default work list to 'To do' for an RO when no other filters are applied and when the user arrives on page
     if (permissions.isReportingOfficer && clearFilters === 'ToDo') {
       incidentStatuses = ['toDo']
-      noFiltersSupplied = false
     }
 
     // Ensure incidentStatuses is an array when provided
@@ -350,7 +335,6 @@ export default function dashboard(): Router {
       formValues,
       errors,
       todayAsShortDate,
-      noFiltersSupplied,
       tableHead,
       paginationParams,
     })

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -25,7 +25,6 @@ import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
 import {
   type UiFilters,
   ALL_PECS_REGIONS_FLAG,
-  fillInDefaults,
   filtersFromUiFilters,
   readUiFilters,
   validateUiFilters,
@@ -45,8 +44,7 @@ export default function dashboard(): Router {
 
     const useWorkLists = permissions.isReportingOfficer
 
-    const uiFilters = readUiFilters(req)
-    fillInDefaults(uiFilters, useWorkLists)
+    const uiFilters = readUiFilters({ query: req.query, session: req.session, url: req.url, useWorkLists })
     const errors = validateUiFilters({ uiFilters, useWorkLists, permissions, userCaseloadIds })
     const filters = filtersFromUiFilters({ uiFilters, useWorkLists, permissions, userCaseloadIds })
 

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -96,23 +96,6 @@ export default function dashboard(): Router {
     const usernames = reports.map(report => report.reportedBy)
     const usersLookup = await userService.getUsers(res.locals.systemToken, usernames)
 
-    const familyInactiveStatus = areTypeFamiliesInactive(types)
-    const activeTypeFamilyItems: GovukSelectItem[] = typeFamilies
-      .filter(({ code: someFamilyCode }) => !familyInactiveStatus[someFamilyCode])
-      .map(family => ({
-        value: family.code,
-        text: family.description,
-      }))
-
-    const expiredTypeFamilyItems: GovukSelectItem[] = typeFamilies
-      .filter(({ code: someFamilyCode }) => familyInactiveStatus[someFamilyCode])
-      .map(family => ({
-        value: family.code,
-        text: `${family.description} (inactive since ${familyExpiryDates[family.code]})`,
-      }))
-
-    const typeFamilyItems: GovukSelectItem[] = [...activeTypeFamilyItems, ...expiredTypeFamilyItems]
-
     /** location choices for auto-complete */
     const allLocations: GovukSelectItem[] = userCaseloads.map(caseload => ({
       value: caseload.caseLoadId,
@@ -173,7 +156,7 @@ export default function dashboard(): Router {
       allLocations,
       locationLookup,
       usersLookup,
-      typeFamilyItems,
+      typeFamilyItems: typeFamilyItems(),
       workLists,
       workListMapping,
       showWorkListFilters: permissions.isReportingOfficer,
@@ -189,6 +172,28 @@ export default function dashboard(): Router {
   })
 
   return router
+}
+
+/**
+ * List of type families. Sorted alphabeticaly. Inactive ones at the end and display inactive date
+ */
+function typeFamilyItems(): GovukSelectItem[] {
+  const familyInactiveStatus = areTypeFamiliesInactive(types)
+  const activeTypeFamilyItems: GovukSelectItem[] = typeFamilies
+    .filter(({ code: someFamilyCode }) => !familyInactiveStatus[someFamilyCode])
+    .map(family => ({
+      value: family.code,
+      text: family.description,
+    }))
+
+  const expiredTypeFamilyItems: GovukSelectItem[] = typeFamilies
+    .filter(({ code: someFamilyCode }) => familyInactiveStatus[someFamilyCode])
+    .map(family => ({
+      value: family.code,
+      text: `${family.description} (inactive since ${familyExpiryDates[family.code]})`,
+    }))
+
+  return [...activeTypeFamilyItems, ...expiredTypeFamilyItems]
 }
 
 function urlPrefixes(uiFilters: UiFilters): { paginationUrlPrefix: string; tableHeadUrlPrefix: string } {

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -58,18 +58,7 @@ export default function dashboard(): Router {
     let reportsResponse: PaginatedBasicReports | undefined
     // TODO: should probably not search if there are errors, because what’ll show will not match apparent filters
     try {
-      reportsResponse = await incidentReportingApi.getReports({
-        reference: filters.reference,
-        location: filters.location,
-        incidentDateFrom: filters.incidentDateFrom,
-        incidentDateUntil: filters.incidentDateUntil,
-        type: filters.type,
-        status: filters.status,
-        involvingPrisonerNumber: filters.involvingPrisonerNumber,
-        userAction: filters.userAction,
-        page: filters.page,
-        sort: filters.sort,
-      })
+      reportsResponse = await incidentReportingApi.getReports(filters)
     } catch (e) {
       logger.error(e, 'Search failed: %j', e)
       errors.push({ href: '#searchID', text: 'Sorry, there was a problem with your request' })

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -113,8 +113,6 @@ export default function dashboard(): Router {
 
     const typeFamilyItems: GovukSelectItem[] = [...activeTypeFamilyItems, ...expiredTypeFamilyItems]
 
-    const showWorkListFilters = permissions.isReportingOfficer
-
     /** location choices for auto-complete */
     const allLocations: GovukSelectItem[] = userCaseloads.map(caseload => ({
       value: caseload.caseLoadId,
@@ -162,19 +160,14 @@ export default function dashboard(): Router {
         )
       : undefined
 
-    // Gather notification banner entries if they exist
-    const banners = req.flash()
-
     // Set dashboard filters stored in the session if no errors present
     if (errors.length === 0) {
       req.session.dashboardFilters = uiFilters
     }
 
-    const todayAsShortDate = format.shortDate(new Date())
-
     res.render('pages/dashboard/index', {
       activeCaseLoad,
-      banners,
+      banners: req.flash,
       reports,
       showLocationFilter,
       allLocations,
@@ -183,13 +176,13 @@ export default function dashboard(): Router {
       typeFamilyItems,
       workLists,
       workListMapping,
-      showWorkListFilters,
+      showWorkListFilters: permissions.isReportingOfficer,
       statusesDescriptions,
       statusHints,
       typesDescriptions,
       formValues: uiFilters,
       errors,
-      todayAsShortDate,
+      todayAsShortDate: format.shortDate(new Date()),
       tableHead,
       paginationParams,
     })

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -22,7 +22,7 @@ import type { GovukSelectItem } from '../../utils/govukFrontend'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
-import { fillInDefaults, filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
+import { type UiFilters, fillInDefaults, filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
 
 /** Location search filter which is replaced by all PECS regions when performing search */
 const allPecsRegionsFlag = '.PECS' as const
@@ -91,35 +91,6 @@ export default function dashboard(): Router {
       errors.push({ href: '#searchID', text: 'Sorry, there was a problem with your request' })
     }
 
-    const queryString = new URLSearchParams()
-    if (uiFilters.searchID) {
-      queryString.append('searchID', uiFilters.searchID)
-    }
-    if (uiFilters.location) {
-      queryString.append('location', uiFilters.location)
-    }
-    if (uiFilters.fromDate) {
-      queryString.append('fromDate', uiFilters.fromDate)
-    }
-    if (uiFilters.toDate) {
-      queryString.append('toDate', uiFilters.toDate)
-    }
-    if (uiFilters.typeFamily) {
-      queryString.append('typeFamily', uiFilters.typeFamily)
-    }
-    uiFilters.incidentStatuses?.forEach(status => queryString.append('incidentStatuses', status))
-    uiFilters.latestUserActions?.forEach(userAction => queryString.append('latestUserActions', userAction))
-
-    const tableHeadUrlPrefix = `/reports?${queryString}&`
-    if (uiFilters.sort) {
-      queryString.append('sort', uiFilters.sort)
-    }
-    if (uiFilters.order) {
-      queryString.append('order', uiFilters.order)
-    }
-
-    const urlPrefix = `/reports?${queryString}&`
-
     const reports = reportsResponse?.content ?? []
 
     const usernames = reports.map(report => report.reportedBy)
@@ -171,6 +142,7 @@ export default function dashboard(): Router {
 
     const showLocationFilter = allLocations.length > 1
 
+    const { paginationUrlPrefix, tableHeadUrlPrefix } = urlPrefixes(uiFilters)
     const columns = showLocationFilter ? multiCaseloadColumns : singleCaseloadColumns
     const tableHead: HeaderCell[] = sortableTableHead({
       columns,
@@ -183,7 +155,7 @@ export default function dashboard(): Router {
       ? pagination(
           filters.page,
           reportsResponse.totalPages,
-          urlPrefix,
+          paginationUrlPrefix,
           'moj',
           reportsResponse.totalElements,
           reportsResponse.size,
@@ -224,4 +196,41 @@ export default function dashboard(): Router {
   })
 
   return router
+}
+
+function urlPrefixes(uiFilters: UiFilters): { paginationUrlPrefix: string; tableHeadUrlPrefix: string } {
+  const queryString = new URLSearchParams()
+
+  if (uiFilters.searchID) {
+    queryString.append('searchID', uiFilters.searchID)
+  }
+  if (uiFilters.location) {
+    queryString.append('location', uiFilters.location)
+  }
+  if (uiFilters.fromDate) {
+    queryString.append('fromDate', uiFilters.fromDate)
+  }
+  if (uiFilters.toDate) {
+    queryString.append('toDate', uiFilters.toDate)
+  }
+  if (uiFilters.typeFamily) {
+    queryString.append('typeFamily', uiFilters.typeFamily)
+  }
+  uiFilters.incidentStatuses?.forEach(status => queryString.append('incidentStatuses', status))
+  uiFilters.latestUserActions?.forEach(userAction => queryString.append('latestUserActions', userAction))
+
+  // sort/order *not* in query string, they're added by `sortableTableHead()`
+  const tableHeadUrlPrefix = `/reports?${queryString}&`
+
+  if (uiFilters.sort) {
+    queryString.append('sort', uiFilters.sort)
+  }
+  if (uiFilters.order) {
+    queryString.append('order', uiFilters.order)
+  }
+
+  // `paginationUrlPrefix` also include sort/order query params
+  const paginationUrlPrefix = `/reports?${queryString}&`
+
+  return { tableHeadUrlPrefix, paginationUrlPrefix }
 }

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -99,7 +99,7 @@ export default function dashboard(): Router {
 
     res.render('pages/dashboard/index', {
       activeCaseLoad,
-      banners: req.flash,
+      banners: req.flash(),
       reports,
       showLocationFilter,
       allLocations,

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -16,7 +16,6 @@ import {
 } from '../../reportConfiguration/constants'
 import type { PaginatedBasicReports } from '../../data/incidentReportingApi'
 import { pecsRegions } from '../../data/pecsRegions'
-import { type ApiUserAction } from '../../middleware/permissions'
 import type { HeaderCell } from '../../utils/sortableTable'
 import format from '../../utils/format'
 import type { GovukSelectItem } from '../../utils/govukFrontend'
@@ -45,20 +44,10 @@ export default function dashboard(): Router {
     const uiFilters = readUiFilters(req)
     fillInDefaults(uiFilters, useWorklists)
     const errors = validateUiFilters(uiFilters, useWorklists)
-    const filters = filtersFromUiFilters(uiFilters, useWorklists)
+    const filters = filtersFromUiFilters(uiFilters, useWorklists, permissions)
 
     if (uiFilters.clearFilters && ['All', 'ToDo'].includes(uiFilters.clearFilters)) {
       req.session.dashboardFilters = {}
-    }
-
-    // Validate and process user action filter
-    let userActionFilter: ApiUserAction[] | undefined
-    if (uiFilters.latestUserActions) {
-      userActionFilter = processUserAction(uiFilters.latestUserActions)
-    }
-    // If an RO opens a link containing filter, remove filter
-    if (permissions.isReportingOfficer) {
-      userActionFilter = undefined
     }
 
     // Set locations to user’s caseloads by default and PECS regions if allowed
@@ -93,7 +82,7 @@ export default function dashboard(): Router {
         type: filters.type,
         status: filters.status,
         involvingPrisonerNumber: filters.prisonerNumber,
-        userAction: userActionFilter,
+        userAction: filters.userAction,
         page: filters.page - 1,
         sort: filters.sort,
       })
@@ -235,16 +224,4 @@ export default function dashboard(): Router {
   })
 
   return router
-}
-
-function processUserAction(userActions: string[]): ApiUserAction[] {
-  if (userActions.includes('REQUEST_REMOVAL')) {
-    return [
-      ...userActions.filter(action => action !== 'REQUEST_REMOVAL'),
-      'REQUEST_NOT_REPORTABLE',
-      'REQUEST_DUPLICATE',
-    ] as ApiUserAction[]
-  }
-
-  return userActions as ApiUserAction[]
 }

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -4,7 +4,6 @@ import { Router } from 'express'
 
 import logger from '../../../logger'
 import {
-  type TypeFamily,
   workLists,
   workListMapping,
   statusesDescriptions,
@@ -16,7 +15,6 @@ import {
   areTypeFamiliesInactive,
 } from '../../reportConfiguration/constants'
 import type { PaginatedBasicReports } from '../../data/incidentReportingApi'
-import { type Order } from '../../data/offenderSearchApi'
 import { pecsRegions } from '../../data/pecsRegions'
 import { ApiUserAction, apiUserActions } from '../../middleware/permissions'
 import type { HeaderCell } from '../../utils/sortableTable'
@@ -26,27 +24,7 @@ import { hasInvalidValues } from '../../utils/utils'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
-import {
-  type IncidentStatuses,
-  fillInDefaults,
-  filtersFromUiFilters,
-  readUiFilters,
-  validateUiFilters,
-} from './filters'
-
-interface ListFormData {
-  clearFilters?: string
-  searchID?: string
-  location?: string
-  fromDate?: string
-  toDate?: string
-  typeFamily?: TypeFamily
-  incidentStatuses?: IncidentStatuses[]
-  latestUserActions?: ApiUserAction | ApiUserAction[] | 'REQUEST_REMOVAL'
-  sort?: string
-  order?: Order
-  page?: string
-}
+import { fillInDefaults, filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
 
 /** Location search filter which is replaced by all PECS regions when performing search */
 const allPecsRegionsFlag = '.PECS' as const
@@ -70,28 +48,16 @@ export default function dashboard(): Router {
     const errors = validateUiFilters(uiFilters, useWorklists)
     const filters = filtersFromUiFilters(uiFilters, useWorklists)
 
-    let { latestUserActions }: ListFormData = req.query
-
     if (uiFilters.clearFilters && ['All', 'ToDo'].includes(uiFilters.clearFilters)) {
       req.session.dashboardFilters = {}
     }
 
-    // If no filters are supplied from query and no errors generated, check for filters in session
-    if (req.url === '/' && req.session.dashboardFilters) {
-      latestUserActions = req.session.dashboardFilters?.latestUserActions
-    }
-
-    // Ensure latestUserActions is an array when provided
-    if (latestUserActions && !Array.isArray(latestUserActions)) {
-      latestUserActions = [latestUserActions]
-    }
     // Validate and process user action filter
     let userActionFilter: ApiUserAction[] | undefined
-    if (latestUserActions) {
+    if (uiFilters.latestUserActions) {
       try {
-        userActionFilter = processUserAction(latestUserActions as string[])
+        userActionFilter = processUserAction(uiFilters.latestUserActions)
       } catch (err) {
-        latestUserActions = undefined
         userActionFilter = undefined
         const errorMessage = err instanceof Error ? err.message : err!.toString()
         errors.push({ href: '#latestUserActions-item', text: errorMessage })
@@ -143,19 +109,6 @@ export default function dashboard(): Router {
       errors.push({ href: '#searchID', text: 'Sorry, there was a problem with your request' })
     }
 
-    const formValues: ListFormData = {
-      searchID: uiFilters.searchID,
-      location: uiFilters.location,
-      fromDate: uiFilters.fromDate,
-      toDate: uiFilters.toDate,
-      typeFamily: uiFilters.typeFamily,
-      incidentStatuses: uiFilters.incidentStatuses,
-      latestUserActions,
-      sort: uiFilters.sort,
-      order: uiFilters.order,
-      page: uiFilters.page,
-    }
-
     const queryString = new URLSearchParams()
     if (uiFilters.searchID) {
       queryString.append('searchID', uiFilters.searchID)
@@ -172,16 +125,9 @@ export default function dashboard(): Router {
     if (uiFilters.typeFamily) {
       queryString.append('typeFamily', uiFilters.typeFamily)
     }
-    if (uiFilters.incidentStatuses) {
-      uiFilters.incidentStatuses.forEach(status => queryString.append('incidentStatuses', status))
-    }
-    if (latestUserActions) {
-      if (Array.isArray(latestUserActions)) {
-        latestUserActions.forEach(userAction => queryString.append('latestUserActions', userAction))
-      } else {
-        queryString.append('latestUserActions', latestUserActions)
-      }
-    }
+    uiFilters.incidentStatuses?.forEach(status => queryString.append('incidentStatuses', status))
+    uiFilters.latestUserActions?.forEach(userAction => queryString.append('latestUserActions', userAction))
+
     const tableHeadUrlPrefix = `/reports?${queryString}&`
     if (uiFilters.sort) {
       queryString.append('sort', uiFilters.sort)
@@ -265,20 +211,9 @@ export default function dashboard(): Router {
     // Gather notification banner entries if they exist
     const banners = req.flash()
 
-    // TODO: Move logic into helper once all filters are in uiFilters
     // Set dashboard filters stored in the session if no errors present
     if (errors.length === 0) {
-      req.session.dashboardFilters = {
-        searchID: uiFilters.searchID,
-        location: uiFilters.location,
-        fromDate: uiFilters.fromDate,
-        toDate: uiFilters.toDate,
-        typeFamily: uiFilters.typeFamily,
-        incidentStatuses: uiFilters.incidentStatuses,
-        latestUserActions,
-        sort: uiFilters.sort,
-        order: uiFilters.order,
-      }
+      req.session.dashboardFilters = uiFilters
     }
 
     const todayAsShortDate = format.shortDate(new Date())
@@ -298,7 +233,7 @@ export default function dashboard(): Router {
       statusesDescriptions,
       statusHints,
       typesDescriptions,
-      formValues,
+      formValues: uiFilters,
       errors,
       todayAsShortDate,
       tableHead,

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -42,32 +42,16 @@ export default function dashboard(): Router {
     const { activeCaseLoad, caseLoads } = res.locals.user
     const userCaseloads = caseLoads ?? []
     const userCaseloadIds = userCaseloads.map(caseload => caseload.caseLoadId)
-    const pecsRegionCodes = pecsRegions.map(pecsRegion => pecsRegion.code)
 
     const useWorkLists = permissions.isReportingOfficer
 
     const uiFilters = readUiFilters(req)
     fillInDefaults(uiFilters, useWorkLists)
-    const errors = validateUiFilters({ uiFilters, useWorkLists, permissions, userCaseloadIds, pecsRegionCodes })
-    const filters = filtersFromUiFilters({ uiFilters, useWorkLists, permissions })
+    const errors = validateUiFilters({ uiFilters, useWorkLists, permissions, userCaseloadIds })
+    const filters = filtersFromUiFilters({ uiFilters, useWorkLists, permissions, userCaseloadIds })
 
     if (uiFilters.clearFilters && ['All', 'ToDo'].includes(uiFilters.clearFilters)) {
       req.session.dashboardFilters = {}
-    }
-
-    // Set locations to user’s caseloads by default and PECS regions if allowed
-    let searchLocations: string[] = userCaseloadIds
-    if (permissions.hasPecsAccess) {
-      searchLocations.push(...pecsRegionCodes)
-    }
-    if (uiFilters.location) {
-      if (userCaseloadIds.includes(uiFilters.location)) {
-        searchLocations = [uiFilters.location]
-      } else if (permissions.hasPecsAccess && pecsRegionCodes.includes(uiFilters.location)) {
-        searchLocations = [uiFilters.location]
-      } else if (permissions.hasPecsAccess && uiFilters.location === ALL_PECS_REGIONS_FLAG) {
-        searchLocations = pecsRegionCodes
-      }
     }
 
     // Get reports from API
@@ -76,7 +60,7 @@ export default function dashboard(): Router {
     try {
       reportsResponse = await incidentReportingApi.getReports({
         reference: filters.referenceNumber,
-        location: searchLocations,
+        location: filters.location,
         incidentDateFrom: filters.fromDate,
         incidentDateUntil: filters.toDate,
         type: filters.type,

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -4,13 +4,9 @@ import { Router } from 'express'
 
 import logger from '../../../logger'
 import {
-  type Status,
   type TypeFamily,
-  type WorkList,
   workLists,
-  workListCodes,
   workListMapping,
-  statuses,
   statusesDescriptions,
   statusHints,
   types,
@@ -30,9 +26,13 @@ import { hasInvalidValues } from '../../utils/utils'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
-import { fillInDefaults, filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
-
-export type IncidentStatuses = Status | WorkList
+import {
+  type IncidentStatuses,
+  fillInDefaults,
+  filtersFromUiFilters,
+  readUiFilters,
+  validateUiFilters,
+} from './filters'
 
 interface ListFormData {
   clearFilters?: string
@@ -41,7 +41,7 @@ interface ListFormData {
   fromDate?: string
   toDate?: string
   typeFamily?: TypeFamily
-  incidentStatuses?: IncidentStatuses | IncidentStatuses[]
+  incidentStatuses?: IncidentStatuses[]
   latestUserActions?: ApiUserAction | ApiUserAction[] | 'REQUEST_REMOVAL'
   sort?: string
   order?: Order
@@ -63,35 +63,25 @@ export default function dashboard(): Router {
     const userCaseloadIds = userCaseloads.map(caseload => caseload.caseLoadId)
     const pecsRegionCodes = pecsRegions.map(pecsRegion => pecsRegion.code)
 
+    const useWorklists = permissions.isReportingOfficer
+
     const uiFilters = readUiFilters(req)
-    fillInDefaults(uiFilters)
-    const errors = validateUiFilters(uiFilters)
-    const filters = filtersFromUiFilters(uiFilters)
+    fillInDefaults(uiFilters, useWorklists)
+    const errors = validateUiFilters(uiFilters, useWorklists)
+    const filters = filtersFromUiFilters(uiFilters, useWorklists)
 
-    const { clearFilters }: ListFormData = req.query
-    let { incidentStatuses, latestUserActions }: ListFormData = req.query
+    let { latestUserActions }: ListFormData = req.query
 
-    if (clearFilters && ['All', 'ToDo'].includes(clearFilters)) {
+    if (uiFilters.clearFilters && ['All', 'ToDo'].includes(uiFilters.clearFilters)) {
       req.session.dashboardFilters = {}
     }
 
     // If no filters are supplied from query and no errors generated, check for filters in session
     if (req.url === '/' && req.session.dashboardFilters) {
-      incidentStatuses = req.session.dashboardFilters?.incidentStatuses
       latestUserActions = req.session.dashboardFilters?.latestUserActions
     }
 
-    // RO: Default work list to 'To do' for an RO when no other filters are applied and when the user arrives on page
-    if (permissions.isReportingOfficer && clearFilters === 'ToDo') {
-      incidentStatuses = ['toDo']
-    }
-
-    // Ensure incidentStatuses is an array when provided
-    if (incidentStatuses && !Array.isArray(incidentStatuses)) {
-      incidentStatuses = [incidentStatuses]
-    }
-
-    // Ensure incidentStatuses is an array when provided
+    // Ensure latestUserActions is an array when provided
     if (latestUserActions && !Array.isArray(latestUserActions)) {
       latestUserActions = [latestUserActions]
     }
@@ -110,16 +100,6 @@ export default function dashboard(): Router {
     // If an RO opens a link containing filter, remove filter
     if (permissions.isReportingOfficer) {
       userActionFilter = undefined
-    }
-
-    let searchStatuses: Status[] | undefined
-    try {
-      const useWorklists = permissions.isReportingOfficer
-      searchStatuses = statusesFromParam(incidentStatuses as IncidentStatuses[], useWorklists)
-    } catch (err) {
-      incidentStatuses = undefined
-      const errorMessage = err instanceof Error ? err.message : err!.toString()
-      errors.push({ href: '#incidentStatuses-item', text: errorMessage })
     }
 
     // Set locations to user’s caseloads by default and PECS regions if allowed
@@ -152,7 +132,7 @@ export default function dashboard(): Router {
         incidentDateFrom: filters.fromDate,
         incidentDateUntil: filters.toDate,
         type: filters.type,
-        status: searchStatuses,
+        status: filters.status,
         involvingPrisonerNumber: filters.prisonerNumber,
         userAction: userActionFilter,
         page: filters.page - 1,
@@ -169,7 +149,7 @@ export default function dashboard(): Router {
       fromDate: uiFilters.fromDate,
       toDate: uiFilters.toDate,
       typeFamily: uiFilters.typeFamily,
-      incidentStatuses,
+      incidentStatuses: uiFilters.incidentStatuses,
       latestUserActions,
       sort: uiFilters.sort,
       order: uiFilters.order,
@@ -192,12 +172,8 @@ export default function dashboard(): Router {
     if (uiFilters.typeFamily) {
       queryString.append('typeFamily', uiFilters.typeFamily)
     }
-    if (incidentStatuses) {
-      if (Array.isArray(incidentStatuses)) {
-        incidentStatuses.forEach(status => queryString.append('incidentStatuses', status))
-      } else {
-        queryString.append('incidentStatuses', incidentStatuses)
-      }
+    if (uiFilters.incidentStatuses) {
+      uiFilters.incidentStatuses.forEach(status => queryString.append('incidentStatuses', status))
     }
     if (latestUserActions) {
       if (Array.isArray(latestUserActions)) {
@@ -298,7 +274,7 @@ export default function dashboard(): Router {
         fromDate: uiFilters.fromDate,
         toDate: uiFilters.toDate,
         typeFamily: uiFilters.typeFamily,
-        incidentStatuses,
+        incidentStatuses: uiFilters.incidentStatuses,
         latestUserActions,
         sort: uiFilters.sort,
         order: uiFilters.order,
@@ -331,36 +307,6 @@ export default function dashboard(): Router {
   })
 
   return router
-}
-
-/** Converts the `incidentStatuses` query param into a list of statuses */
-function statusesFromParam(statusesParam: IncidentStatuses[] | undefined, useWorklists: boolean): Status[] | undefined {
-  if (!statusesParam) {
-    return undefined
-  }
-
-  // TODO: consider converting between work lists and statuses so that links with filters can be shared between user types
-
-  // Reporting Officer
-  if (useWorklists) {
-    const hasInvalidWorklist = hasInvalidValues(statusesParam, workListCodes)
-    if (hasInvalidWorklist) {
-      throw new Error('Select a valid work list')
-    }
-
-    const worklists = statusesParam as WorkList[]
-    // Map RO worklists to list of statuses
-    return worklists.map(worklist => workListMapping[worklist]).flat(1)
-  }
-
-  // Data Warden
-  const statusCodes = statuses.map(status => status.code)
-  const hasInvalidStatus = hasInvalidValues(statusesParam, statusCodes)
-  if (hasInvalidStatus) {
-    throw new Error('Select a valid status')
-  }
-
-  return statusesParam as Status[]
 }
 
 function processUserAction(userActions: string[]): ApiUserAction[] {

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -31,7 +31,7 @@ import { hasInvalidValues } from '../../utils/utils'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
-import { readUiFilters } from './filters'
+import { familyToType, readUiFilters, validateUiFilters } from './filters'
 
 export type IncidentStatuses = Status | WorkList
 
@@ -69,7 +69,7 @@ export default function dashboard(): Router {
     const uiFilters = readUiFilters(req)
 
     const { page, clearFilters }: ListFormData = req.query
-    let { location, typeFamily, incidentStatuses, latestUserActions, sort, order }: ListFormData = req.query
+    let { incidentStatuses, latestUserActions, sort, order }: ListFormData = req.query
 
     if (clearFilters && ['All', 'ToDo'].includes(clearFilters)) {
       req.session.dashboardFilters = {}
@@ -83,12 +83,10 @@ export default function dashboard(): Router {
     }
 
     // Collect errors
-    const errors: GovukErrorSummaryItem[] = []
+    const errors: GovukErrorSummaryItem[] = validateUiFilters(uiFilters)
 
     // If no filters are supplied from query and no errors generated, check for filters in session
     if (req.url === '/' && req.session.dashboardFilters) {
-      location = req.session.dashboardFilters?.location
-      typeFamily = req.session.dashboardFilters?.typeFamily
       incidentStatuses = req.session.dashboardFilters?.incidentStatuses
       latestUserActions = req.session.dashboardFilters?.latestUserActions
       sort = req.session.dashboardFilters?.sort ?? 'incidentDateAndTime'
@@ -120,18 +118,14 @@ export default function dashboard(): Router {
       toDate = undefined
       errors.push({ href: '#toDate', text: 'Enter a date after from date' })
     }
-    if (typeFamily && !(typeFamily in familyToType)) {
-      typeFamily = undefined
-      errors.push({ href: '#typeFamily', text: 'Select a valid incident type' })
-    }
 
     // Check for supplied filters from session
     let noFiltersSupplied = Boolean(
       !uiFilters.searchID &&
-      !location &&
+      !uiFilters.location &&
       !fromDate &&
       !toDate &&
-      !typeFamily &&
+      !uiFilters.typeFamily &&
       !incidentStatuses &&
       !latestUserActions,
     )
@@ -207,12 +201,12 @@ export default function dashboard(): Router {
     if (permissions.hasPecsAccess) {
       searchLocations.push(...pecsRegionCodes)
     }
-    if (location) {
-      if (userCaseloadIds.includes(location)) {
-        searchLocations = [location]
-      } else if (permissions.hasPecsAccess && pecsRegionCodes.includes(location)) {
-        searchLocations = [location]
-      } else if (permissions.hasPecsAccess && location === allPecsRegionsFlag) {
+    if (uiFilters.location) {
+      if (userCaseloadIds.includes(uiFilters.location)) {
+        searchLocations = [uiFilters.location]
+      } else if (permissions.hasPecsAccess && pecsRegionCodes.includes(uiFilters.location)) {
+        searchLocations = [uiFilters.location]
+      } else if (permissions.hasPecsAccess && uiFilters.location === allPecsRegionsFlag) {
         searchLocations = pecsRegionCodes
       } else {
         errors.push({
@@ -231,7 +225,7 @@ export default function dashboard(): Router {
         location: searchLocations,
         incidentDateFrom: fromDate,
         incidentDateUntil: toDate,
-        type: typeFamily && familyToType[typeFamily],
+        type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
         status: searchStatuses,
         involvingPrisonerNumber: prisonerId,
         userAction: userActionFilter,
@@ -245,10 +239,10 @@ export default function dashboard(): Router {
 
     const formValues: ListFormData = {
       searchID: uiFilters.searchID,
-      location,
+      location: uiFilters.location,
       fromDate: uiFilters.fromDate,
       toDate: uiFilters.toDate,
-      typeFamily,
+      typeFamily: uiFilters.typeFamily,
       incidentStatuses,
       latestUserActions,
       sort,
@@ -260,8 +254,8 @@ export default function dashboard(): Router {
     if (uiFilters.searchID) {
       queryString.append('searchID', uiFilters.searchID)
     }
-    if (location) {
-      queryString.append('location', location)
+    if (uiFilters.location) {
+      queryString.append('location', uiFilters.location)
     }
     if (uiFilters.fromDate) {
       queryString.append('fromDate', uiFilters.fromDate)
@@ -269,8 +263,8 @@ export default function dashboard(): Router {
     if (uiFilters.toDate) {
       queryString.append('toDate', uiFilters.toDate)
     }
-    if (typeFamily) {
-      queryString.append('typeFamily', typeFamily)
+    if (uiFilters.typeFamily) {
+      queryString.append('typeFamily', uiFilters.typeFamily)
     }
     if (incidentStatuses) {
       if (Array.isArray(incidentStatuses)) {
@@ -374,10 +368,10 @@ export default function dashboard(): Router {
     if (errors.length === 0) {
       req.session.dashboardFilters = {
         searchID: uiFilters.searchID,
-        location,
+        location: uiFilters.location,
         fromDate: uiFilters.fromDate,
         toDate: uiFilters.toDate,
-        typeFamily,
+        typeFamily: uiFilters.typeFamily,
         incidentStatuses,
         latestUserActions,
         sort,
@@ -411,16 +405,6 @@ export default function dashboard(): Router {
 
   return router
 }
-
-/** Given a family code, list type codes belonging to the family */
-const familyToType = Object.fromEntries(
-  Object.values(typeFamilies).map(({ code: familyCode }) => [
-    familyCode,
-    Object.values(types)
-      .filter(({ familyCode: someFamilyCode }) => someFamilyCode === familyCode)
-      .map(({ code }) => code),
-  ]),
-)
 
 /** Converts the `incidentStatuses` query param into a list of statuses */
 function statusesFromParam(statusesParam: IncidentStatuses[] | undefined, useWorklists: boolean): Status[] | undefined {

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -44,8 +44,8 @@ export default function dashboard(): Router {
 
     const uiFilters = readUiFilters(req)
     fillInDefaults(uiFilters, useWorklists)
-    const errors = validateUiFilters(uiFilters, useWorklists)
-    const filters = filtersFromUiFilters(uiFilters, useWorklists, permissions)
+    const errors = validateUiFilters({ uiFilters, useWorklists })
+    const filters = filtersFromUiFilters({ uiFilters, useWorklists, permissions })
 
     if (uiFilters.clearFilters && ['All', 'ToDo'].includes(uiFilters.clearFilters)) {
       req.session.dashboardFilters = {}

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -16,11 +16,10 @@ import {
 } from '../../reportConfiguration/constants'
 import type { PaginatedBasicReports } from '../../data/incidentReportingApi'
 import { pecsRegions } from '../../data/pecsRegions'
-import { ApiUserAction, apiUserActions } from '../../middleware/permissions'
+import { type ApiUserAction } from '../../middleware/permissions'
 import type { HeaderCell } from '../../utils/sortableTable'
 import format from '../../utils/format'
 import type { GovukSelectItem } from '../../utils/govukFrontend'
-import { hasInvalidValues } from '../../utils/utils'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
@@ -55,13 +54,7 @@ export default function dashboard(): Router {
     // Validate and process user action filter
     let userActionFilter: ApiUserAction[] | undefined
     if (uiFilters.latestUserActions) {
-      try {
-        userActionFilter = processUserAction(uiFilters.latestUserActions)
-      } catch (err) {
-        userActionFilter = undefined
-        const errorMessage = err instanceof Error ? err.message : err!.toString()
-        errors.push({ href: '#latestUserActions-item', text: errorMessage })
-      }
+      userActionFilter = processUserAction(uiFilters.latestUserActions)
     }
     // If an RO opens a link containing filter, remove filter
     if (permissions.isReportingOfficer) {
@@ -245,15 +238,13 @@ export default function dashboard(): Router {
 }
 
 function processUserAction(userActions: string[]): ApiUserAction[] {
-  if (hasInvalidValues(userActions, [...apiUserActions, 'REQUEST_REMOVAL'])) {
-    throw new Error('Enter a valid user action')
-  } else if (userActions.includes('REQUEST_REMOVAL')) {
+  if (userActions.includes('REQUEST_REMOVAL')) {
     return [
       ...userActions.filter(action => action !== 'REQUEST_REMOVAL'),
       'REQUEST_NOT_REPORTABLE',
       'REQUEST_DUPLICATE',
     ] as ApiUserAction[]
-  } else {
-    return userActions as ApiUserAction[]
   }
+
+  return userActions as ApiUserAction[]
 }

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -30,7 +30,7 @@ import { hasInvalidValues } from '../../utils/utils'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
-import { familyToType, filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
+import { filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
 
 export type IncidentStatuses = Status | WorkList
 
@@ -176,7 +176,7 @@ export default function dashboard(): Router {
         location: searchLocations,
         incidentDateFrom: filters.fromDate,
         incidentDateUntil: filters.toDate,
-        type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
+        type: filters.type,
         status: searchStatuses,
         involvingPrisonerNumber: filters.prisonerNumber,
         userAction: userActionFilter,

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -22,11 +22,15 @@ import type { GovukSelectItem } from '../../utils/govukFrontend'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
-import { type UiFilters, fillInDefaults, filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
+import {
+  type UiFilters,
+  ALL_PECS_REGIONS_FLAG,
+  fillInDefaults,
+  filtersFromUiFilters,
+  readUiFilters,
+  validateUiFilters,
+} from './filters'
 import { type CaseLoad } from '../../data/frontendComponentsClient'
-
-/** Location search filter which is replaced by all PECS regions when performing search */
-const allPecsRegionsFlag = '.PECS' as const
 
 export default function dashboard(): Router {
   const router = Router({ mergeParams: true })
@@ -44,7 +48,7 @@ export default function dashboard(): Router {
 
     const uiFilters = readUiFilters(req)
     fillInDefaults(uiFilters, useWorklists)
-    const errors = validateUiFilters({ uiFilters, useWorklists })
+    const errors = validateUiFilters({ uiFilters, useWorklists, permissions, userCaseloadIds, pecsRegionCodes })
     const filters = filtersFromUiFilters({ uiFilters, useWorklists, permissions })
 
     if (uiFilters.clearFilters && ['All', 'ToDo'].includes(uiFilters.clearFilters)) {
@@ -61,13 +65,8 @@ export default function dashboard(): Router {
         searchLocations = [uiFilters.location]
       } else if (permissions.hasPecsAccess && pecsRegionCodes.includes(uiFilters.location)) {
         searchLocations = [uiFilters.location]
-      } else if (permissions.hasPecsAccess && uiFilters.location === allPecsRegionsFlag) {
+      } else if (permissions.hasPecsAccess && uiFilters.location === ALL_PECS_REGIONS_FLAG) {
         searchLocations = pecsRegionCodes
-      } else {
-        errors.push({
-          href: '#location',
-          text: 'Select a location to search',
-        })
       }
     }
 
@@ -172,7 +171,7 @@ function allLocationsItems(userCaseloads: CaseLoad[], hasPecsAccess: boolean): G
 
   if (hasPecsAccess) {
     allLocations.unshift({
-      value: allPecsRegionsFlag,
+      value: ALL_PECS_REGIONS_FLAG,
       text: 'All PECS regions',
     })
     allLocations.push(

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -31,7 +31,7 @@ import { hasInvalidValues } from '../../utils/utils'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
 import { multiCaseloadColumns, singleCaseloadColumns } from './tableColumns'
-import { familyToType, readUiFilters, validateUiFilters } from './filters'
+import { familyToType, filtersFromUiFilters, readUiFilters, validateUiFilters } from './filters'
 
 export type IncidentStatuses = Status | WorkList
 
@@ -68,7 +68,7 @@ export default function dashboard(): Router {
 
     const uiFilters = readUiFilters(req)
 
-    const { page, clearFilters }: ListFormData = req.query
+    const { clearFilters }: ListFormData = req.query
     let { incidentStatuses, latestUserActions, sort, order }: ListFormData = req.query
 
     if (clearFilters && ['All', 'ToDo'].includes(clearFilters)) {
@@ -190,12 +190,6 @@ export default function dashboard(): Router {
       }
     }
 
-    // Parse page number
-    let pageNumber = (page && typeof page === 'string' && parseInt(page, 10)) || 1
-    if (pageNumber < 1) {
-      pageNumber = 1
-    }
-
     // Set locations to user’s caseloads by default and PECS regions if allowed
     let searchLocations: string[] = userCaseloadIds
     if (permissions.hasPecsAccess) {
@@ -216,6 +210,8 @@ export default function dashboard(): Router {
       }
     }
 
+    const filters = filtersFromUiFilters(uiFilters)
+
     // Get reports from API
     let reportsResponse: PaginatedBasicReports | undefined
     // TODO: should probably not search if there are errors, because what’ll show will not match apparent filters
@@ -229,7 +225,7 @@ export default function dashboard(): Router {
         status: searchStatuses,
         involvingPrisonerNumber: prisonerId,
         userAction: userActionFilter,
-        page: pageNumber - 1,
+        page: filters.page - 1,
         sort: [`${sort},${order}`],
       })
     } catch (e) {
@@ -247,7 +243,7 @@ export default function dashboard(): Router {
       latestUserActions,
       sort,
       order,
-      page,
+      page: uiFilters.page,
     }
 
     const queryString = new URLSearchParams()
@@ -351,7 +347,7 @@ export default function dashboard(): Router {
     })
     const paginationParams = reportsResponse
       ? pagination(
-          pageNumber,
+          filters.page,
           reportsResponse.totalPages,
           urlPrefix,
           'moj',

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -26,7 +26,6 @@ import { ApiUserAction, apiUserActions } from '../../middleware/permissions'
 import type { HeaderCell } from '../../utils/sortableTable'
 import format from '../../utils/format'
 import type { GovukErrorSummaryItem, GovukSelectItem } from '../../utils/govukFrontend'
-import { parseDateInput } from '../../utils/parseDateTime'
 import { hasInvalidValues } from '../../utils/utils'
 import { sortableTableHead } from '../../utils/sortableTable'
 import { pagination } from '../../utils/pagination'
@@ -93,38 +92,14 @@ export default function dashboard(): Router {
       order = req.session.dashboardFilters?.order ?? 'DESC'
     }
 
-    // Parse params
-    const todayAsShortDate = format.shortDate(new Date())
-    let fromDate: Date | undefined
-    let toDate: Date | undefined
-    try {
-      if (uiFilters.fromDate) {
-        fromDate = parseDateInput(uiFilters.fromDate)
-      }
-    } catch {
-      fromDate = undefined
-      errors.push({ href: '#fromDate', text: `Enter a valid from date, for example ${todayAsShortDate}` })
-    }
-    try {
-      if (uiFilters.toDate) {
-        toDate = parseDateInput(uiFilters.toDate)
-      }
-    } catch {
-      toDate = undefined
-      errors.push({ href: '#toDate', text: `Enter a valid to date, for example ${todayAsShortDate}` })
-    }
-    if (fromDate && toDate && toDate < fromDate) {
-      fromDate = undefined
-      toDate = undefined
-      errors.push({ href: '#toDate', text: 'Enter a date after from date' })
-    }
+    const filters = filtersFromUiFilters(uiFilters)
 
     // Check for supplied filters from session
     let noFiltersSupplied = Boolean(
       !uiFilters.searchID &&
       !uiFilters.location &&
-      !fromDate &&
-      !toDate &&
+      !filters.fromDate &&
+      !filters.toDate &&
       !uiFilters.typeFamily &&
       !incidentStatuses &&
       !latestUserActions,
@@ -210,8 +185,6 @@ export default function dashboard(): Router {
       }
     }
 
-    const filters = filtersFromUiFilters(uiFilters)
-
     // Get reports from API
     let reportsResponse: PaginatedBasicReports | undefined
     // TODO: should probably not search if there are errors, because what’ll show will not match apparent filters
@@ -219,8 +192,8 @@ export default function dashboard(): Router {
       reportsResponse = await incidentReportingApi.getReports({
         reference: referenceNumber,
         location: searchLocations,
-        incidentDateFrom: fromDate,
-        incidentDateUntil: toDate,
+        incidentDateFrom: filters.fromDate,
+        incidentDateUntil: filters.toDate,
         type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
         status: searchStatuses,
         involvingPrisonerNumber: prisonerId,
@@ -374,6 +347,8 @@ export default function dashboard(): Router {
         order,
       }
     }
+
+    const todayAsShortDate = format.shortDate(new Date())
 
     res.render('pages/dashboard/index', {
       activeCaseLoad,

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -147,24 +147,6 @@ export default function dashboard(): Router {
       errors.push({ href: '#incidentStatuses-item', text: errorMessage })
     }
 
-    let prisonerId: string | undefined
-    let referenceNumber: string | undefined
-    if (uiFilters.searchID) {
-      // Test if search is for a prisoner ID and use if so
-      if (uiFilters.searchID.match(/^[a-zA-Z][0-9]{4}[a-zA-Z]{2}$/)) {
-        prisonerId = uiFilters.searchID
-      }
-      // Test if search is for an incident reference number and use if so
-      else if (uiFilters.searchID.match(/^[0-9]+$/)) {
-        referenceNumber = uiFilters.searchID
-      } else {
-        errors.push({
-          href: '#searchID',
-          text: `Enter a valid incident number or offender ID. For example, 12345678 or A0011BB`,
-        })
-      }
-    }
-
     // Set locations to user’s caseloads by default and PECS regions if allowed
     let searchLocations: string[] = userCaseloadIds
     if (permissions.hasPecsAccess) {
@@ -190,13 +172,13 @@ export default function dashboard(): Router {
     // TODO: should probably not search if there are errors, because what’ll show will not match apparent filters
     try {
       reportsResponse = await incidentReportingApi.getReports({
-        reference: referenceNumber,
+        reference: filters.referenceNumber,
         location: searchLocations,
         incidentDateFrom: filters.fromDate,
         incidentDateUntil: filters.toDate,
         type: uiFilters.typeFamily && familyToType[uiFilters.typeFamily],
         status: searchStatuses,
-        involvingPrisonerNumber: prisonerId,
+        involvingPrisonerNumber: filters.prisonerNumber,
         userAction: userActionFilter,
         page: filters.page - 1,
         sort: [`${sort},${order}`],

--- a/server/routes/dashboard/index.ts
+++ b/server/routes/dashboard/index.ts
@@ -59,13 +59,13 @@ export default function dashboard(): Router {
     // TODO: should probably not search if there are errors, because what’ll show will not match apparent filters
     try {
       reportsResponse = await incidentReportingApi.getReports({
-        reference: filters.referenceNumber,
+        reference: filters.reference,
         location: filters.location,
-        incidentDateFrom: filters.fromDate,
-        incidentDateUntil: filters.toDate,
+        incidentDateFrom: filters.incidentDateFrom,
+        incidentDateUntil: filters.incidentDateUntil,
         type: filters.type,
         status: filters.status,
-        involvingPrisonerNumber: filters.prisonerNumber,
+        involvingPrisonerNumber: filters.involvingPrisonerNumber,
         userAction: filters.userAction,
         // API page starts at 0
         page: filters.page - 1,


### PR DESCRIPTION
The dashboard request handler was very long (250+ lines), difficult to read/update.
A lot of the logic to read values from query params/session was mixed with logic to validate or convert these values into an higher level format.

This refactoring moved most of the logic out of the request handler.

Key concepts:
- `UiFilters` is what you get from the UI (e.g. the mostly raw strings)
- `Filters` is the high level - processed and cleaned - filters, mainly passed to `getReports()` to get the actual reports
- reading of UI filters from query/session happens in `readUiFilters()` (which also apply defaults for `sort`/`order`/`incidentStatuses`)
- validation is also moved out of the request handler into `validateUiFilters()`
- and transformation into the high-level filters happens in `filtersFromUiFilters()`
- I've also simplified some of the types by turning `Thing | Thing[]` into just `Thing[]` (normalised early on. by `readUiFilters()` so that subsequent code doesn't have to check if it's an array or not at every step

Structure:
- `validateUiFilters()` relies on a bunch of helper functions like `validateSearchId()`, `validateLatestUserActions()`, etc...
  - there are also smaller utility functions to check validity of individual fields, e.g. `validPrisonerNumber()`, `validTypeFamily()`, etc...
- `filtersFromUiFilters()` also relies on a bunch of helper functions that convert lower level-values into higher-level filter values, e.g. `processLocation()`, `processStatus()`, etc...
- the idea is that these concepts are behind nice names that makes higher-level logic easier to read and follow and more intent-revealing

Other changes:
- Introduced/tweak some of the type names
- `Filters` fields were renamed so that they match the filters properties used to get the list of reports
- About the `page` property
  - in `UiFilters` is a optional string and start from 1 as this is the value coming from the UI where pagination starts at 1
  - in `Filters` the page is a mandatory number and starts from 0 as this is the value used to get filtered reports from the API

Ultimately the goal is not perfection but rather a simplification of the request handler and moving the filters handling in its own module. There are probably more improvements that can be made.

Also note that the aim was not remove code but rather give it structure and improve readability and make it less brittle. Most of the logic is still there, just in different places. In fact potentially there are _more_ line of code now because of how some of the logic is extracted into smaller, well-named, self-contained functions.