### PR TITLE
IR-1812: Date filters bug on dashboard

### DIFF
--- a/integration_tests/e2e/changeType.cy.ts
+++ b/integration_tests/e2e/changeType.cy.ts
@@ -128,7 +128,7 @@ context('Change incident type', () => {
         },
         {
           label: 'Key or lock compromise',
-          value: 'KEY_OR_LOCK_2',
+          value: 'KEY_OR_LOCK_3',
           checked: false,
         },
         {
@@ -148,7 +148,7 @@ context('Change incident type', () => {
         },
         {
           label: 'Tool or equipment loss',
-          value: 'TOOL_LOSS_1',
+          value: 'TOOL_LOSS_2',
           checked: false,
         },
         {

--- a/server/routes/dashboard/filters.ts
+++ b/server/routes/dashboard/filters.ts
@@ -201,12 +201,14 @@ export function filtersFromUiFilters({
 function processDateRange(uiFilters: UiFilters): { incidentDateFrom?: Date; incidentDateUntil?: Date } {
   const incidentDateFrom = parseDate(uiFilters.fromDate)
   const incidentDateUntil = parseDate(uiFilters.toDate)
-  const validDates = incidentDateFrom !== undefined && incidentDateUntil !== undefined
-  const validDateOrder = validDates && incidentDateUntil >= incidentDateFrom
+  const validDateFrom = incidentDateFrom !== undefined
+  const validDateUntil = incidentDateUntil !== undefined
+  const bothValidDates = validDateFrom && validDateUntil
+  const validDateOrder = bothValidDates && incidentDateUntil >= incidentDateFrom
 
   return {
-    incidentDateFrom: validDateOrder ? incidentDateFrom : undefined,
-    incidentDateUntil: validDateOrder ? incidentDateUntil : undefined,
+    incidentDateFrom: validDateFrom && (validDateOrder || !validDateUntil) ? incidentDateFrom : undefined,
+    incidentDateUntil: validDateUntil && (validDateOrder || !validDateFrom) ? incidentDateUntil : undefined,
   }
 }
 


### PR DESCRIPTION
There was an issue with the logic in the `processDateRange` function that meant no dates were parsed into the API call if only one of "date from" or "date to" had a value submitted in them. This led to no date filtering instead of setting a limit at one end. 

This PR updates the logic in the `processDateRange` so that when parsing the date filters without a valid value being set for the other date, it will still be be parsed and used in API call correctly.